### PR TITLE
Improvement: Method AwaitAsyncUpdateID

### DIFF
--- a/client.go
+++ b/client.go
@@ -239,20 +239,20 @@ func contains(slice []int, val int) bool {
 	return false
 }
 
-// AwaitAsyncUpdateID check each 50ms the status of a AsyncUpdateID.
-// This method should be avoided.
-func (c Client) AwaitAsyncUpdateIDSimplified(indexUID string, updateID *AsyncUpdateID) (UpdateStatus, error) {
+// defaultWaitForPendingUpdate check each 50ms the status of a AsyncUpdateID.
+// This method is used for test purpose
+func (c Client) defaultWaitForPendingUpdate(indexUID string, updateID *AsyncUpdateID) (UpdateStatus, error) {
 	ctx, cancelFunc := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancelFunc()
 
-	return c.AwaitAsyncUpdateID(ctx, time.Millisecond*50, indexUID, updateID)
+	return c.WaitForPendingUpdate(ctx, time.Millisecond*50, indexUID, updateID)
 }
 
-// AwaitAsyncUpdateID wait for the end of an update.
+// WaitForPendingUpdate wait for the end of an update.
 // The function will check by regular interval provided in parameter interval
 // the UpdateStatus. If it is not UpdateStatusEnqueued or the ctx cancelled
 // we return the UpdateStatus.
-func (c Client) AwaitAsyncUpdateID(
+func (c Client) WaitForPendingUpdate(
 	ctx context.Context,
 	interval time.Duration,
 	indexID string,

--- a/client.go
+++ b/client.go
@@ -239,7 +239,7 @@ func (c Client) defaultWaitForPendingUpdate(indexUID string, updateID *AsyncUpda
 	return c.WaitForPendingUpdate(ctx, time.Millisecond*50, indexUID, updateID)
 }
 
-// WaitForPendingUpdate wait for the end of an update.
+// WaitForPendingUpdate waits for the end of an update.
 // The function will check by regular interval provided in parameter interval
 // the UpdateStatus. If it is not UpdateStatusEnqueued or the ctx cancelled
 // we return the UpdateStatus.

--- a/client.go
+++ b/client.go
@@ -230,15 +230,6 @@ func (c Client) handleResponse(req *internalRequest, response *http.Response, in
 	return nil
 }
 
-func contains(slice []int, val int) bool {
-	for _, item := range slice {
-		if item == val {
-			return true
-		}
-	}
-	return false
-}
-
 // defaultWaitForPendingUpdate check each 50ms the status of a AsyncUpdateID.
 // This method is used for test purpose
 func (c Client) defaultWaitForPendingUpdate(indexUID string, updateID *AsyncUpdateID) (UpdateStatus, error) {

--- a/client.go
+++ b/client.go
@@ -230,7 +230,7 @@ func (c Client) handleResponse(req *internalRequest, response *http.Response, in
 	return nil
 }
 
-// defaultWaitForPendingUpdate check each 50ms the status of a AsyncUpdateID.
+// defaultWaitForPendingUpdate checks each 50ms the status of a WaitForPendingUpdate.
 // This method is used for test purpose
 func (c Client) defaultWaitForPendingUpdate(indexUID string, updateID *AsyncUpdateID) (UpdateStatus, error) {
 	ctx, cancelFunc := context.WithTimeout(context.Background(), time.Second*5)

--- a/client_documents_test.go
+++ b/client_documents_test.go
@@ -34,7 +34,7 @@ func TestClientDocuments_Get(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateID(indexUID, updateIDRes)
+	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
 
 	var doc docTest
 	if err = client.
@@ -74,7 +74,7 @@ func TestClientDocuments_Delete(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateID(indexUID, updateIDRes)
+	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
 
 	updateIDRes, err = client.Documents(indexUID).Delete("123")
 
@@ -82,7 +82,7 @@ func TestClientDocuments_Delete(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateID(indexUID, updateIDRes)
+	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
 
 	var doc docTest
 	err = client.Documents(indexUID).Get("123", &doc)
@@ -118,7 +118,7 @@ func TestClientDocuments_Deletes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateID(indexUID, updateIDRes)
+	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
 
 	updateIDRes, err = client.Documents(indexUID).Deletes([]string{"123", "456"})
 
@@ -126,7 +126,7 @@ func TestClientDocuments_Deletes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateID(indexUID, updateIDRes)
+	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
 
 	var doc docTest
 	err = client.Documents(indexUID).Get("123", &doc)
@@ -162,7 +162,7 @@ func TestClientDocuments_List(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateID(indexUID, updateIDRes)
+	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
 
 	var list []docTest
 	err = client.Documents(indexUID).List(ListDocumentsRequest{
@@ -206,7 +206,7 @@ func TestClientDocuments_AddOrReplace(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateID(indexUID, updateIDRes)
+	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
 
 	var list []docTest
 	err = client.Documents(indexUID).List(ListDocumentsRequest{
@@ -250,7 +250,7 @@ func TestClientDocuments_AddOrUpdate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateID(indexUID, updateIDRes)
+	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
 
 	var list []docTest
 	err = client.Documents(indexUID).List(ListDocumentsRequest{
@@ -294,7 +294,7 @@ func TestClientDocuments_DeleteAllDocuments(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateID(indexUID, updateIDRes)
+	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
 
 	_, err = client.Documents(indexUID).DeleteAllDocuments()
 

--- a/client_documents_test.go
+++ b/client_documents_test.go
@@ -34,7 +34,7 @@ func TestClientDocuments_Get(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
+	client.defaultWaitForPendingUpdate(indexUID, updateIDRes)
 
 	var doc docTest
 	if err = client.
@@ -74,7 +74,7 @@ func TestClientDocuments_Delete(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
+	client.defaultWaitForPendingUpdate(indexUID, updateIDRes)
 
 	updateIDRes, err = client.Documents(indexUID).Delete("123")
 
@@ -82,7 +82,7 @@ func TestClientDocuments_Delete(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
+	client.defaultWaitForPendingUpdate(indexUID, updateIDRes)
 
 	var doc docTest
 	err = client.Documents(indexUID).Get("123", &doc)
@@ -118,7 +118,7 @@ func TestClientDocuments_Deletes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
+	client.defaultWaitForPendingUpdate(indexUID, updateIDRes)
 
 	updateIDRes, err = client.Documents(indexUID).Deletes([]string{"123", "456"})
 
@@ -126,7 +126,7 @@ func TestClientDocuments_Deletes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
+	client.defaultWaitForPendingUpdate(indexUID, updateIDRes)
 
 	var doc docTest
 	err = client.Documents(indexUID).Get("123", &doc)
@@ -162,7 +162,7 @@ func TestClientDocuments_List(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
+	client.defaultWaitForPendingUpdate(indexUID, updateIDRes)
 
 	var list []docTest
 	err = client.Documents(indexUID).List(ListDocumentsRequest{
@@ -206,7 +206,7 @@ func TestClientDocuments_AddOrReplace(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
+	client.defaultWaitForPendingUpdate(indexUID, updateIDRes)
 
 	var list []docTest
 	err = client.Documents(indexUID).List(ListDocumentsRequest{
@@ -250,7 +250,7 @@ func TestClientDocuments_AddOrUpdate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
+	client.defaultWaitForPendingUpdate(indexUID, updateIDRes)
 
 	var list []docTest
 	err = client.Documents(indexUID).List(ListDocumentsRequest{
@@ -294,7 +294,7 @@ func TestClientDocuments_DeleteAllDocuments(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
+	client.defaultWaitForPendingUpdate(indexUID, updateIDRes)
 
 	_, err = client.Documents(indexUID).DeleteAllDocuments()
 

--- a/client_search_test.go
+++ b/client_search_test.go
@@ -31,7 +31,7 @@ func TestClientSearch_Search(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
+	client.defaultWaitForPendingUpdate(indexUID, updateIDRes)
 
 	resp, err := client.Search(indexUID).Search(SearchRequest{
 		Query: "citrons",

--- a/client_search_test.go
+++ b/client_search_test.go
@@ -31,7 +31,7 @@ func TestClientSearch_Search(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateID(indexUID, updateIDRes)
+	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
 
 	resp, err := client.Search(indexUID).Search(SearchRequest{
 		Query: "citrons",

--- a/client_settings_test.go
+++ b/client_settings_test.go
@@ -73,7 +73,7 @@ func TestClientSettings_UpdateAll(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
+	client.defaultWaitForPendingUpdate(indexUID, updateIDRes)
 }
 
 func TestClientSettings_ResetAll(t *testing.T) {
@@ -97,7 +97,7 @@ func TestClientSettings_ResetAll(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
+	client.defaultWaitForPendingUpdate(indexUID, updateIDRes)
 
 }
 
@@ -152,7 +152,7 @@ func TestClientSettings_UpdateRankingRules(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
+	client.defaultWaitForPendingUpdate(indexUID, updateIDRes)
 }
 
 func TestClientSettings_ResetRankingRules(t *testing.T) {
@@ -176,7 +176,7 @@ func TestClientSettings_ResetRankingRules(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
+	client.defaultWaitForPendingUpdate(indexUID, updateIDRes)
 }
 
 func TestClientSettings_GetDistinctAttribute(t *testing.T) {
@@ -226,7 +226,7 @@ func TestClientSettings_UpdateDistinctAttribute(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
+	client.defaultWaitForPendingUpdate(indexUID, updateIDRes)
 
 }
 
@@ -251,7 +251,7 @@ func TestClientSettings_ResetDistinctAttribute(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
+	client.defaultWaitForPendingUpdate(indexUID, updateIDRes)
 
 }
 
@@ -304,7 +304,7 @@ func TestClientSettings_UpdateSearchableAttributes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
+	client.defaultWaitForPendingUpdate(indexUID, updateIDRes)
 }
 
 func TestClientSettings_ResetSearchableAttributes(t *testing.T) {
@@ -328,7 +328,7 @@ func TestClientSettings_ResetSearchableAttributes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
+	client.defaultWaitForPendingUpdate(indexUID, updateIDRes)
 }
 
 func TestClientSettings_GetDisplayedAttributes(t *testing.T) {
@@ -380,7 +380,7 @@ func TestClientSettings_UpdateDisplayedAttributes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
+	client.defaultWaitForPendingUpdate(indexUID, updateIDRes)
 }
 
 func TestClientSettings_ResetDisplayedAttributes(t *testing.T) {
@@ -404,7 +404,7 @@ func TestClientSettings_ResetDisplayedAttributes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
+	client.defaultWaitForPendingUpdate(indexUID, updateIDRes)
 }
 
 func TestClientSettings_GetStopWords(t *testing.T) {
@@ -457,7 +457,7 @@ func TestClientSettings_UpdateStopWords(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
+	client.defaultWaitForPendingUpdate(indexUID, updateIDRes)
 
 }
 
@@ -482,7 +482,7 @@ func TestClientSettings_ResetStopWords(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
+	client.defaultWaitForPendingUpdate(indexUID, updateIDRes)
 
 }
 
@@ -538,7 +538,7 @@ func TestClientSettings_UpdateSynonyms(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
+	client.defaultWaitForPendingUpdate(indexUID, updateIDRes)
 }
 
 func TestClientSettings_ResetSynonyms(t *testing.T) {
@@ -562,7 +562,7 @@ func TestClientSettings_ResetSynonyms(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
+	client.defaultWaitForPendingUpdate(indexUID, updateIDRes)
 
 }
 
@@ -613,6 +613,6 @@ func TestClientSettings_UpdateAcceptNewFields(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
+	client.defaultWaitForPendingUpdate(indexUID, updateIDRes)
 
 }

--- a/client_settings_test.go
+++ b/client_settings_test.go
@@ -73,7 +73,7 @@ func TestClientSettings_UpdateAll(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateID(indexUID, updateIDRes)
+	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
 }
 
 func TestClientSettings_ResetAll(t *testing.T) {
@@ -97,7 +97,7 @@ func TestClientSettings_ResetAll(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateID(indexUID, updateIDRes)
+	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
 
 }
 
@@ -152,7 +152,7 @@ func TestClientSettings_UpdateRankingRules(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateID(indexUID, updateIDRes)
+	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
 }
 
 func TestClientSettings_ResetRankingRules(t *testing.T) {
@@ -176,7 +176,7 @@ func TestClientSettings_ResetRankingRules(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateID(indexUID, updateIDRes)
+	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
 }
 
 func TestClientSettings_GetDistinctAttribute(t *testing.T) {
@@ -226,7 +226,7 @@ func TestClientSettings_UpdateDistinctAttribute(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateID(indexUID, updateIDRes)
+	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
 
 }
 
@@ -251,7 +251,7 @@ func TestClientSettings_ResetDistinctAttribute(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateID(indexUID, updateIDRes)
+	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
 
 }
 
@@ -304,7 +304,7 @@ func TestClientSettings_UpdateSearchableAttributes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateID(indexUID, updateIDRes)
+	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
 }
 
 func TestClientSettings_ResetSearchableAttributes(t *testing.T) {
@@ -328,7 +328,7 @@ func TestClientSettings_ResetSearchableAttributes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateID(indexUID, updateIDRes)
+	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
 }
 
 func TestClientSettings_GetDisplayedAttributes(t *testing.T) {
@@ -380,7 +380,7 @@ func TestClientSettings_UpdateDisplayedAttributes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateID(indexUID, updateIDRes)
+	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
 }
 
 func TestClientSettings_ResetDisplayedAttributes(t *testing.T) {
@@ -404,7 +404,7 @@ func TestClientSettings_ResetDisplayedAttributes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateID(indexUID, updateIDRes)
+	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
 }
 
 func TestClientSettings_GetStopWords(t *testing.T) {
@@ -457,7 +457,7 @@ func TestClientSettings_UpdateStopWords(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateID(indexUID, updateIDRes)
+	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
 
 }
 
@@ -482,7 +482,7 @@ func TestClientSettings_ResetStopWords(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateID(indexUID, updateIDRes)
+	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
 
 }
 
@@ -538,7 +538,7 @@ func TestClientSettings_UpdateSynonyms(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateID(indexUID, updateIDRes)
+	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
 }
 
 func TestClientSettings_ResetSynonyms(t *testing.T) {
@@ -562,7 +562,7 @@ func TestClientSettings_ResetSynonyms(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateID(indexUID, updateIDRes)
+	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
 
 }
 
@@ -613,6 +613,6 @@ func TestClientSettings_UpdateAcceptNewFields(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	client.AwaitAsyncUpdateID(indexUID, updateIDRes)
+	client.AwaitAsyncUpdateIDSimplified(indexUID, updateIDRes)
 
 }


### PR DESCRIPTION
The method has been changed to add two things:
- A context to manipulate from the outside when the function should stop polling the status of an update id.
- A interval duration to configure the time between each poll. 

A simplified method called `AwaitAsyncUpdateIDSimplified` set default to `AwaitAsyncUpdateID` with a timeout of `5 seconds` and a interval of `50ms`. 

Resolve issue #10 