### PR TITLE
Add 'application/json' as content media type

### DIFF
--- a/client.go
+++ b/client.go
@@ -185,7 +185,8 @@ func (c Client) sendRequest(req *internalRequest, internalError *Error) (*http.R
 		return nil, internalError.WithErrCode(ErrCodeRequestCreation, err)
 	}
 
-	// adding apikey to the request
+	// adding request headers
+	request.Header.Set("Content-Type", "application/json")
 	if c.config.APIKey != "" {
 		request.Header.Set("X-Meili-API-Key", c.config.APIKey)
 	}


### PR DESCRIPTION
With the changes introduced by the v0.11 of MeiliSearch, requests will receive an error from API: `Unsupported media type`

This PR fixes this by adding a header "Content-Type" with value "application/json" which is backward compatible with other versions (tested v0.9 and v0.10)