### PR TITLE
hotfix: empty params in Documents().List()

### DIFF
--- a/client.go
+++ b/client.go
@@ -170,9 +170,14 @@ func (c Client) sendRequest(req *internalRequest, internalError *Error) (*http.R
 		if req.method == "GET" {
 			r, ok := req.withRequest.(*ListDocumentsRequest)
 			if ok {
-				URL = fmt.Sprintf("%s?limit=%d&offset=%d&attributesToRetrieve=%s",
-					URL, r.Limit, r.Offset, strings.Join(r.AttributesToRetrieve, ","),
+				URL = fmt.Sprintf("%s?limit=%d&offset=%d",
+					URL, r.Limit, r.Offset,
 				)
+				if len(r.AttributesToRetrieve) > 0 {
+					URL = fmt.Sprintf("%s&attributesToRetrieve=%s",
+						URL, strings.Join(r.AttributesToRetrieve, ","),
+					)
+				}
 			}
 		}
 


### PR DESCRIPTION
The new server in MeiliSearch doesn't handle empty parameters. Each parameter should be sent only if it has a value to avoid having a wrong response.

In this case, `attributesToRetrieve` was being sent even if the list of attributes was empty. This PR is a hotfix to not send this parameter unless it has some content.