### PR TITLE
Add NbHits as int64 to SearchResponse

### DIFF
--- a/client_search_test.go
+++ b/client_search_test.go
@@ -59,6 +59,10 @@ func TestClientSearch_Search(t *testing.T) {
 		fmt.Println(resp)
 		t.Fatalf("Basic search: should have found %s\n", booksTest[1].Title)
 	}
+	if resp.NbHits != 3 {
+		fmt.Println(resp)
+		t.Fatalf("Basic search: wrong number of hits, should have 3, got %d\n", resp.NbHits)
+	}
 
 	// Test basic search with limit
 

--- a/types.go
+++ b/types.go
@@ -166,6 +166,7 @@ type SearchRequest struct {
 // SearchResponse is the response body for search method
 type SearchResponse struct {
 	Hits                  []interface{} `json:"hits"`
+	NbHits                int64         `json:"nbHits"`
 	Offset                int64         `json:"offset"`
 	Limit                 int64         `json:"limit"`
 	ProcessingTimeMs      int64         `json:"processingTimeMs"`


### PR DESCRIPTION
- [x] Add `nbHits` element from MeiliSearch response to SearchResponse struct
- [x] Add a simple test to check NbHits in SearchResponse

Closes #53 