### PR TITLE
Add PlaceholderSearch boolean to perform placehold search. Update tests

### DIFF
--- a/client_search.go
+++ b/client_search.go
@@ -27,7 +27,9 @@ func (c clientSearch) Search(request SearchRequest) (*SearchResponse, error) {
 		request.Limit = 20
 	}
 
-	values.Add("q", request.Query)
+	if !request.PlaceholderSearch {
+		values.Add("q", request.Query)
+	}
 	if request.Filters != "" {
 		values.Add("filters", request.Filters)
 	}

--- a/client_search_test.go
+++ b/client_search_test.go
@@ -60,6 +60,36 @@ func TestClientSearch_Search(t *testing.T) {
 		t.Fatalf("Basic search: wrong number of hits, should have 3, got %d\n", resp.NbHits)
 	}
 
+	// Test basic empty search
+
+	resp, err = client.Search(indexUID).Search(SearchRequest{
+		Query: "",
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(resp.Hits) != 0 {
+		fmt.Println(resp)
+		t.Fatal("Basic search: empty search should return 0 results")
+	}
+
+	// Test basic placeholder search
+
+	resp, err = client.Search(indexUID).Search(SearchRequest{
+		PlaceholderSearch: true,
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(resp.Hits) != len(booksTest) {
+		fmt.Println(resp)
+		t.Fatal("Basic placeholder search: should return placeholder results")
+	}
+
 	// Test basic search with limit
 
 	resp, err = client.Search(indexUID).Search(SearchRequest{
@@ -79,6 +109,22 @@ func TestClientSearch_Search(t *testing.T) {
 	if title != booksTest[1].Title {
 		fmt.Println(resp)
 		t.Fatalf("Basic search: should have found %s\n", booksTest[1].Title)
+	}
+
+	// Test basic placeholder search with limit
+
+	resp, err = client.Search(indexUID).Search(SearchRequest{
+		PlaceholderSearch: true,
+		Limit:             3,
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(resp.Hits) != 3 {
+		fmt.Println(resp)
+		t.Fatal("Basic placeholder search with limit: should return 3 results")
 	}
 
 	// Test basic search with offset

--- a/types.go
+++ b/types.go
@@ -127,6 +127,7 @@ type SearchRequest struct {
 	Matches               bool
 	FacetsDistribution    []string
 	FacetFilters          interface{}
+	PlaceholderSearch     bool
 }
 
 // SearchResponse is the response body for search method


### PR DESCRIPTION
About this PR: 

As defined in https://github.com/meilisearch/MeiliSearch/pull/771, MeiliSearch will implement placeholder search starting with v0.13.0

A search request containing no Query parameter (or a null value in that parameter) will send a response with a basic placeholder search showing ranked results, and will be as customizable as any other search request.

GO types and default initialization to zero value doesn't let us make a clear distinction between an uninitialized String (some `nil` value) and an empty String (some `""` value) when all we are handling is a string. We need to be able to provide those two options in order to implement placeholder search, which expects no `q` parameter (no query) or a null value.

An option to do this would be using a string pointer that can be uninitialized (nil), contain an empty string, or contain a valid string. The problem with this is that it would add some unnecessary complexity to the whole search experience, as the user would need to always use pointers towards a string to perform the search. So adding a new functionnality results in making search experience work.

The most practical solution to this from my POV is to add a boolean value to the SearchRequest struct where the user indicates if he wants to perform a placeholder search. This won't be breaking, completey optional, and really simple to use.It can work as in:

```go
resp, err = client.Search(indexUID).Search(SearchRequest{
	PlaceholderSearch: true,
})
```

Which would return the placeholder search results, and would be clearly different than 

```go
resp, err = client.Search(indexUID).Search(SearchRequest{
	Query: "",
})
```

if `PlaceholderSearch` is set to true, `Query` will be totally ignored for that request

Which would return no results

Closes #69 