### PR TITLE
Update tests for MeiliSearch v0.15.0

### DIFF
--- a/client_search_test.go
+++ b/client_search_test.go
@@ -70,7 +70,7 @@ func TestClientSearch_Search(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(resp.Hits) == 0 {
+	if len(resp.Hits) != len(booksTest) {
 		fmt.Println(resp)
 		t.Fatal("Basic placeholder search with an empty string: should return placeholder results")
 	}

--- a/client_search_test.go
+++ b/client_search_test.go
@@ -70,9 +70,9 @@ func TestClientSearch_Search(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(resp.Hits) != 0 {
+	if len(resp.Hits) == 0 {
 		fmt.Println(resp)
-		t.Fatal("Basic search: empty search should return 0 results")
+		t.Fatal("Basic placeholder search with an empty string: should return placeholder results")
 	}
 
 	// Test basic placeholder search
@@ -87,7 +87,7 @@ func TestClientSearch_Search(t *testing.T) {
 
 	if len(resp.Hits) != len(booksTest) {
 		fmt.Println(resp)
-		t.Fatal("Basic placeholder search: should return placeholder results")
+		t.Fatal("Basic placeholder search with no Query: should return placeholder results")
 	}
 
 	// Test basic search with limit


### PR DESCRIPTION
This PR:
- fails in this CI because the MeiliSearch's release v0.15.0 is not out
- should work locally with the [prerelease v0.15.0rc2](https://github.com/meilisearch/MeiliSearch/releases/tag/v0.15.0rc2)