### PR TITLE
Run build and test on current go.mod version and latest stable go version

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Get dependencies
       run: |
         go get -v -t -d ./...
@@ -32,13 +32,17 @@ jobs:
   integration_tests:
     name: integration-tests
     runs-on: ubuntu-latest
+    strategy:
+        matrix:
+          # Current go.mod version and latest stable go version
+          go: [ '1.12', '1.15' ]
     steps:
-    - name: Set up Go
-      uses: actions/setup-go@v1
+    - name: Set up Go ${{ matrix.go }}
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.12
+        go-version: ${{ matrix.go }}
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Get dependencies
       run: |
         go get -v -t -d ./...

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -30,12 +30,18 @@ jobs:
       run: /home/runner/go/bin/golint
 
   integration_tests:
-    name: integration-tests
     runs-on: ubuntu-latest
     strategy:
         matrix:
           # Current go.mod version and latest stable go version
-          go: [ '1.12', '1.15' ]
+          go: [1.12, 1.15]
+          include:
+            - go: 1.12
+              tag: current
+            - go: 1.15
+              tag: latest
+
+    name: integration-tests with go ${{ matrix.tag }} version
     steps:
     - name: Set up Go ${{ matrix.go }}
       uses: actions/setup-go@v2

--- a/bors.toml
+++ b/bors.toml
@@ -1,3 +1,3 @@
-status = ['integration-tests', 'linter']
+status = ['integration-tests (1.12)', 'integration-tests (1.15)', 'linter']
 # 1 hour timeout
 timeout-sec = 3600

--- a/bors.toml
+++ b/bors.toml
@@ -1,3 +1,3 @@
-status = ['integration-tests (1.12)', 'integration-tests (1.15)', 'linter']
+status = ['integration-tests with go current version', 'integration-tests with go latest version', 'linter']
 # 1 hour timeout
 timeout-sec = 3600

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,6 @@ require (
 	github.com/mailru/easyjson v0.7.6
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.6.1
-	github.com/valyala/fasthttp v1.16.0
+	github.com/valyala/fasthttp v1.17.0
 	github.com/valyala/fastjson v1.6.1
-	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect
-	golang.org/x/tools v0.0.0-20201028215501-2b84a066b2fb // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6Kllzaw
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v1.16.0 h1:9zAqOYLl8Tuy3E5R6ckzGDJ1g8+pw15oQp2iL9Jl6gQ=
 github.com/valyala/fasthttp v1.16.0/go.mod h1:YOKImeEosDdBPnxc0gy7INqi3m1zK6A+xl6TwOBhHCA=
+github.com/valyala/fasthttp v1.17.0 h1:P8/koH4aSnJ4xbd0cUUFEGQs3jQqIxoDDyRQrUiAkqg=
+github.com/valyala/fasthttp v1.17.0/go.mod h1:jjraHZVbKOXftJfsOYoAjaeygpj5hr8ermTRJNroD7A=
 github.com/valyala/fastjson v1.6.1 h1:qJs/Kz/HebWzk8LmhOrSm7kdOyJBr1XB+zSkYtEEfQE=
 github.com/valyala/fastjson v1.6.1/go.mod h1:CLCAqky6SMuOcxStkYQvblddUtoRxhYMGLrsQns1aXY=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
@@ -34,6 +36,7 @@ golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200602114024-627f9648deb9/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
+golang.org/x/net v0.0.0-20201016165138-7b1cca2348c0/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -50,6 +53,8 @@ golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7 h1:EBZoQjiKKPaLbPrbpssUfuH
 golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20201028215501-2b84a066b2fb h1:7jySlx0Xbs/eWGdwZloH40E5fjPjckyPWgddcNhlE3w=
 golang.org/x/tools v0.0.0-20201028215501-2b84a066b2fb/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.0.0-20201105001634-bc3cf281b174 h1:0rx0F4EjJNbxTuzWe0KjKcIzs+3VEb/Mrs/d1ciNz1c=
+golang.org/x/tools v0.0.0-20201105001634-bc3cf281b174/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
This PR introduces a 2 jobs test in the CI:
- one with the current go version of meilisearch-go module (1.12, set in `go.mod`)
- a second one with the latest stable go version (1.15 as of today).

It uses `include` in the GitHub Actions to add a tag system that uses the word `current` instead of `1.12` and `latest` instead of `1.15` to make it easy to automate GitHub and Bors checks by using always stable names. 

This way, for example, a job isn't called 

```
Check / integration-tests with go 1.12 version
```

but 

```
Check / integration-tests with go current version
```

For example, by changing the tests version from `1.12` -> `1.13` we won't need to update the repo nor the bors settings to do all the CI + checks, a simple version number change will work out-of-the-box! 🎉 


NOTE: It also removes some unused dependencies! 

Closes #99 