### PR TITLE
Add CI for pre-releases

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,7 +14,7 @@ indent_style = space
 indent_style = tab
 indent_size = 8
 
-[*{.yaml, yml}]
+[*.{yaml,yml}]
 indent_size = 2
 indent_style = space
 

--- a/.github/workflows/pre-release-tests.yml
+++ b/.github/workflows/pre-release-tests.yml
@@ -1,0 +1,45 @@
+# Testing the code base against the MeiliSearch pre-releases
+name: Pre-Release Tests
+
+# Will only run for PRs and pushes to bump-meilisearch-v*
+on:
+  push:
+    branches: bump-meilisearch-v*
+  pull_request:
+    branches: bump-meilisearch-v*
+
+jobs:
+
+  integration_tests:
+    runs-on: ubuntu-latest
+    strategy:
+        matrix:
+          # Current go.mod version and latest stable go version
+          go: [1.12, 1.15]
+          include:
+            - go: 1.12
+              tag: current
+            - go: 1.15
+              tag: latest
+
+    name: integration-tests-against-rc (go ${{ matrix.tag }} version)
+    steps:
+    - name: Set up Go ${{ matrix.go }}
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go }}
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+    - name: Get dependencies
+      run: |
+        go get -v -t -d ./...
+        if [ -f Gopkg.toml ]; then
+          curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+          dep ensure
+        fi
+    - name: Get the latest MeiliSearch RC
+      run: echo "MEILISEARCH_VERSION=$(curl https://raw.githubusercontent.com/meilisearch/integration-guides/master/scripts/get-latest-meilisearch-rc.sh | bash)" >> $GITHUB_ENV
+    - name: MeiliSearch (${{ env.MEILISEARCH_VERSION }}) setup with Docker
+      run: docker run -d -p 7700:7700 getmeili/meilisearch:{{ env. MEILISEARCH_VERSION }} ./meilisearch --master-key=masterKey --no-analytics=true
+    - name: Run integration tests
+      run: go test -v ./...

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,9 @@ jobs:
 
   integration_tests:
     runs-on: ubuntu-latest
+    # Will not run if the event is a PR to bump-meilisearch-v* (so a pre-release PR)
+    # Will still run for each push to bump-meilisearch-v*
+    if: github.event_name != 'pull_request' || startsWith(github.base_ref, 'bump-meilisearch-v') != true
     strategy:
         matrix:
           # Current go.mod version and latest stable go version
@@ -41,7 +44,7 @@ jobs:
             - go: 1.15
               tag: latest
 
-    name: integration-tests with go ${{ matrix.tag }} version
+    name: integration-tests (go ${{ matrix.tag }} version)
     steps:
     - name: Set up Go ${{ matrix.go }}
       uses: actions/setup-go@v2

--- a/bors.toml
+++ b/bors.toml
@@ -1,3 +1,3 @@
-status = ['integration-tests with go current version', 'integration-tests with go latest version', 'linter']
+status = ['integration-tests (go current version)', 'integration-tests (go latest version)', 'linter']
 # 1 hour timeout
 timeout-sec = 3600


### PR DESCRIPTION
Add CI for the pre-release PRs = PRs to `bump-meilisearch-v*`. This CI will run the tests against the MeilliSearch RC instead of the MeiliSearch `latest`.

For each PR to `bump-meilisearch-v*`:
- the `linter` job will run
- the `integration-tests-against-rc` job will run
- the `integration-tests` job will be skipped
- the required jobs (for merging) in the settings will be: `linter` and `integration-tests-against-rc`

For each **push** to `bump-meilisearch-v*`:
- the `linter` job will run
- the `integration-tests-against-rc` job will run
- the `integration-tests` job will run
- the required jobs (for merging) in the settings will be: `linter` and `integration-tests`

For any other event (PRs and pushes):
- the `linter` job will run
- the `integration-tests-against-rc` job will NOT run
- the `integration-tests` job will run
- the required jobs (for merging) in the settings will be: `linter` and `integration-tests`

⚠️ Bors will not work when trying to merge a PR into `bump-meilisearch-v*` since we can not apply conditional jobs for merging with Bors. 