### PR TITLE
Fix error in code samples

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -10,6 +10,7 @@ list_all_indexes_1: |-
 create_an_index_1: |-
   client.Indexes().Create(meilisearch.CreateIndexRequest{
     UID: "movies",
+    PrimaryKey: "movie_id",
   })
 update_an_index_1: |-
   response, error := client.Indexes().Get("movies")


### PR DESCRIPTION
Code sample for creating an index doesn't exactly match other SDK code samples, as it this one is not using the primary key as a parameter.