### PR TITLE
Rename ApiKey by APIKey

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ import (
 func main() {
 	client := meilisearch.NewClient(meilisearch.ClientConfig{
                 Host: "http://127.0.0.1:7700",
-                ApiKey: "masterKey",
+                APIKey: "masterKey",
         })
 	// An index is where the documents are stored.
 	index := client.Index("indexUID")

--- a/client.go
+++ b/client.go
@@ -14,8 +14,8 @@ type ClientConfig struct {
 	// Example: 'http://localhost:7700'
 	Host string
 
-	// ApiKey is optional
-	ApiKey string
+	// APIKey is optional
+	APIKey string
 
 	// Timeout is optional
 	Timeout time.Duration

--- a/client_request.go
+++ b/client_request.go
@@ -104,8 +104,8 @@ func (c *Client) sendRequest(req *internalRequest, internalError *Error, respons
 
 	// adding request headers
 	request.Header.Set("Content-Type", "application/json")
-	if c.config.ApiKey != "" {
-		request.Header.Set("X-Meili-API-Key", c.config.ApiKey)
+	if c.config.APIKey != "" {
+		request.Header.Set("X-Meili-API-Key", c.config.APIKey)
 	}
 
 	// request is sent

--- a/client_test.go
+++ b/client_test.go
@@ -146,7 +146,7 @@ func TestClient_Health(t *testing.T) {
 			client: &Client{
 				config: ClientConfig{
 					Host:   "http://wrongurl:1234",
-					ApiKey: masterKey,
+					APIKey: masterKey,
 				},
 				httpClient: &fasthttp.Client{
 					Name: "meilsearch-client",
@@ -213,7 +213,7 @@ func TestClient_IsHealthy(t *testing.T) {
 			client: &Client{
 				config: ClientConfig{
 					Host:   "http://wrongurl:1234",
-					ApiKey: masterKey,
+					APIKey: masterKey,
 				},
 				httpClient: &fasthttp.Client{
 					Name: "meilsearch-client",

--- a/main_test.go
+++ b/main_test.go
@@ -36,7 +36,7 @@ func deleteAllIndexes(client ClientInterface) (ok bool, err error) {
 func SetUpBasicIndex() {
 	client := NewClient(ClientConfig{
 		Host:   "http://localhost:7700",
-		ApiKey: masterKey,
+		APIKey: masterKey,
 	})
 	index := client.Index("indexUID")
 
@@ -62,7 +62,7 @@ func SetUpBasicIndex() {
 func SetUpIndexForFaceting() {
 	client := NewClient(ClientConfig{
 		Host:   "http://localhost:7700",
-		ApiKey: masterKey,
+		APIKey: masterKey,
 	})
 	index := client.Index("indexUID")
 
@@ -103,12 +103,12 @@ var masterKey = "masterKey"
 var primaryKey = "primaryKey"
 var defaultClient = NewClient(ClientConfig{
 	Host:   "http://localhost:7700",
-	ApiKey: masterKey,
+	APIKey: masterKey,
 })
 
 var customClient = NewFastHTTPCustomClient(ClientConfig{
 	Host:   "http://localhost:7700",
-	ApiKey: masterKey,
+	APIKey: masterKey,
 },
 	&fasthttp.Client{
 		TLSConfig: &tls.Config{InsecureSkipVerify: true},
@@ -117,7 +117,7 @@ var customClient = NewFastHTTPCustomClient(ClientConfig{
 
 var timeoutClient = NewClient(ClientConfig{
 	Host:    "http://localhost:7700",
-	ApiKey:  masterKey,
+	APIKey:  masterKey,
 	Timeout: 1,
 })
 


### PR DESCRIPTION
Like it was!

Not breaking because a rollback in the same release