### PR TITLE
Fix codesample for Get Started Add documents section

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -346,7 +346,7 @@ getting_started_add_documents_md: |-
   )
 
   func main() {
-  	client = meilisearch.NewClient(meilisearch.ClientConfig{
+    client := meilisearch.NewClient(meilisearch.ClientConfig{
       Host: "http://127.0.0.1:7700",
     })
 


### PR DESCRIPTION
In this page: https://docs.meilisearch.com/learn/getting_started/quick_start.html#add-documents

Screenshot:
<img width="735" alt="image" src="https://user-images.githubusercontent.com/553444/125691006-ac786474-7d1a-49d3-83af-cecb7dd77aff.png">

The highlighted line is not indented correctly (mixed spaces and tabs) while also `client` is not defined at this point, which is why I switched to `:=`