### PR TITLE
Tests error compare fix

### DIFF
--- a/client_index_test.go
+++ b/client_index_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/valyala/fasthttp"
 )
 
 func TestClient_CreateIndex(t *testing.T) {
@@ -83,24 +82,11 @@ func TestClient_CreateIndex(t *testing.T) {
 				},
 			},
 			wantErr: true,
-			expectedError: Error(Error{
-				Endpoint:         "/indexes",
-				Method:           "POST",
-				Function:         "CreateIndex",
-				RequestToString:  "{\"uid\":\"TestCreateIndexInvalidUid*\"}",
-				ResponseToString: "{\"message\":\"Index must have a valid uid; Index uid can be of type integer or string only composed of alphanumeric characters, hyphens (-) and underscores (_).\",\"errorCode\":\"invalid_index_uid\",\"errorType\":\"invalid_request_error\",\"errorLink\":\"https://docs.meilisearch.com/errors#invalid_index_uid\"}",
+			expectedError: Error{
 				MeilisearchApiMessage: meilisearchApiMessage{
-					Message:   "Index must have a valid uid; Index uid can be of type integer or string only composed of alphanumeric characters, hyphens (-) and underscores (_).",
 					ErrorCode: "invalid_index_uid",
-					ErrorType: "invalid_request_error",
-					ErrorLink: "https://docs.meilisearch.com/errors#invalid_index_uid",
 				},
-				StatusCode:         400,
-				StatusCodeExpected: []int{201},
-				rawMessage:         "unaccepted status code found: ${statusCode} expected: ${statusCodeExpected}, MeilisearchApiError Message: ${message}, ErrorCode: ${errorCode}, ErrorType: ${errorType}, ErrorLink: ${errorLink} (path \"${method} ${endpoint}\" with method \"${function}\")",
-				OriginError:        error(nil),
-				ErrCode:            4,
-			}),
+			},
 		},
 		{
 			name:   "TestCreateIndexAlreadyExist",
@@ -111,24 +97,11 @@ func TestClient_CreateIndex(t *testing.T) {
 				},
 			},
 			wantErr: true,
-			expectedError: Error(Error{
-				Endpoint:         "/indexes",
-				Method:           "POST",
-				Function:         "CreateIndex",
-				RequestToString:  "{\"uid\":\"indexUID\"}",
-				ResponseToString: "{\"message\":\"Index already exists.\",\"errorCode\":\"index_already_exists\",\"errorType\":\"invalid_request_error\",\"errorLink\":\"https://docs.meilisearch.com/errors#index_already_exists\"}",
+			expectedError: Error{
 				MeilisearchApiMessage: meilisearchApiMessage{
-					Message:   "Index already exists.",
 					ErrorCode: "index_already_exists",
-					ErrorType: "invalid_request_error",
-					ErrorLink: "https://docs.meilisearch.com/errors#index_already_exists",
 				},
-				StatusCode:         400,
-				StatusCodeExpected: []int{201},
-				rawMessage:         "unaccepted status code found: ${statusCode} expected: ${statusCodeExpected}, MeilisearchApiError Message: ${message}, ErrorCode: ${errorCode}, ErrorType: ${errorType}, ErrorLink: ${errorLink} (path \"${method} ${endpoint}\" with method \"${function}\")",
-				OriginError:        error(nil),
-				ErrCode:            4,
-			}),
+			},
 		},
 		{
 			name:   "TestCreateIndexTimeout",
@@ -139,24 +112,9 @@ func TestClient_CreateIndex(t *testing.T) {
 				},
 			},
 			wantErr: true,
-			expectedError: Error(Error{
-				Endpoint:         "/indexes",
-				Method:           "POST",
-				Function:         "CreateIndex",
-				RequestToString:  "{\"uid\":\"indexUID\"}",
-				ResponseToString: "empty response",
-				MeilisearchApiMessage: meilisearchApiMessage{
-					Message:   "empty meilisearch message",
-					ErrorCode: "",
-					ErrorType: "",
-					ErrorLink: "",
-				},
-				StatusCode:         0,
-				StatusCodeExpected: []int{201},
-				rawMessage:         "MeilisearchTimeoutError (path \"${method} ${endpoint}\" with method \"${function}\")",
-				OriginError:        fasthttp.ErrTimeout,
-				ErrCode:            6,
-			}),
+			expectedError: Error{
+				MeilisearchApiMessage: meilisearchApiMessage{},
+			},
 		},
 	}
 	for _, tt := range tests {
@@ -168,7 +126,8 @@ func TestClient_CreateIndex(t *testing.T) {
 			gotResp, err := c.CreateIndex(&tt.args.config)
 			if tt.wantErr {
 				require.Error(t, err)
-				require.Equal(t, &tt.expectedError, err)
+				require.Equal(t, tt.expectedError.MeilisearchApiMessage.ErrorCode,
+					err.(*Error).MeilisearchApiMessage.ErrorCode)
 			} else {
 				require.NoError(t, err)
 				if assert.NotNil(t, gotResp) {
@@ -227,24 +186,11 @@ func TestClient_DeleteIndex(t *testing.T) {
 			},
 			wantErr: true,
 			expectedError: []Error{
-				Error(Error{
-					Endpoint:         "/indexes/1",
-					Method:           "DELETE",
-					Function:         "DeleteIndex",
-					RequestToString:  "empty request",
-					ResponseToString: "{\"message\":\"Index \\\"1\\\" not found.\",\"errorCode\":\"index_not_found\",\"errorType\":\"invalid_request_error\",\"errorLink\":\"https://docs.meilisearch.com/errors#index_not_found\"}",
+				{
 					MeilisearchApiMessage: meilisearchApiMessage{
-						Message:   "Index \"1\" not found.",
 						ErrorCode: "index_not_found",
-						ErrorType: "invalid_request_error",
-						ErrorLink: "https://docs.meilisearch.com/errors#index_not_found",
 					},
-					StatusCode:         404,
-					StatusCodeExpected: []int{204},
-					rawMessage:         "unaccepted status code found: ${statusCode} expected: ${statusCodeExpected}, MeilisearchApiError Message: ${message}, ErrorCode: ${errorCode}, ErrorType: ${errorType}, ErrorLink: ${errorLink} (path \"${method} ${endpoint}\" with method \"${function}\")",
-					OriginError:        error(nil),
-					ErrCode:            4,
-				}),
+				},
 			},
 		},
 		{
@@ -255,76 +201,26 @@ func TestClient_DeleteIndex(t *testing.T) {
 			},
 			wantErr: true,
 			expectedError: []Error{
-				Error(Error{
-					Endpoint:         "/indexes/2",
-					Method:           "DELETE",
-					Function:         "DeleteIndex",
-					RequestToString:  "empty request",
-					ResponseToString: "{\"message\":\"Index \\\"2\\\" not found.\",\"errorCode\":\"index_not_found\",\"errorType\":\"invalid_request_error\",\"errorLink\":\"https://docs.meilisearch.com/errors#index_not_found\"}",
+				{
 					MeilisearchApiMessage: meilisearchApiMessage{
-						Message:   "Index \"2\" not found.",
 						ErrorCode: "index_not_found",
-						ErrorType: "invalid_request_error",
-						ErrorLink: "https://docs.meilisearch.com/errors#index_not_found",
 					},
-					StatusCode:         404,
-					StatusCodeExpected: []int{204},
-					rawMessage:         "unaccepted status code found: ${statusCode} expected: ${statusCodeExpected}, MeilisearchApiError Message: ${message}, ErrorCode: ${errorCode}, ErrorType: ${errorType}, ErrorLink: ${errorLink} (path \"${method} ${endpoint}\" with method \"${function}\")",
-					OriginError:        error(nil),
-					ErrCode:            4,
-				}),
-				Error(Error{
-					Endpoint:         "/indexes/3",
-					Method:           "DELETE",
-					Function:         "DeleteIndex",
-					RequestToString:  "empty request",
-					ResponseToString: "{\"message\":\"Index \\\"3\\\" not found.\",\"errorCode\":\"index_not_found\",\"errorType\":\"invalid_request_error\",\"errorLink\":\"https://docs.meilisearch.com/errors#index_not_found\"}",
+				},
+				{
 					MeilisearchApiMessage: meilisearchApiMessage{
-						Message:   "Index \"3\" not found.",
 						ErrorCode: "index_not_found",
-						ErrorType: "invalid_request_error",
-						ErrorLink: "https://docs.meilisearch.com/errors#index_not_found",
 					},
-					StatusCode:         404,
-					StatusCodeExpected: []int{204},
-					rawMessage:         "unaccepted status code found: ${statusCode} expected: ${statusCodeExpected}, MeilisearchApiError Message: ${message}, ErrorCode: ${errorCode}, ErrorType: ${errorType}, ErrorLink: ${errorLink} (path \"${method} ${endpoint}\" with method \"${function}\")", OriginError: error(nil), ErrCode: 4,
-				}),
-				Error(Error{
-					Endpoint:         "/indexes/4",
-					Method:           "DELETE",
-					Function:         "DeleteIndex",
-					RequestToString:  "empty request",
-					ResponseToString: "{\"message\":\"Index \\\"4\\\" not found.\",\"errorCode\":\"index_not_found\",\"errorType\":\"invalid_request_error\",\"errorLink\":\"https://docs.meilisearch.com/errors#index_not_found\"}",
+				},
+				{
 					MeilisearchApiMessage: meilisearchApiMessage{
-						Message:   "Index \"4\" not found.",
 						ErrorCode: "index_not_found",
-						ErrorType: "invalid_request_error",
-						ErrorLink: "https://docs.meilisearch.com/errors#index_not_found",
 					},
-					StatusCode:         404,
-					StatusCodeExpected: []int{204},
-					rawMessage:         "unaccepted status code found: ${statusCode} expected: ${statusCodeExpected}, MeilisearchApiError Message: ${message}, ErrorCode: ${errorCode}, ErrorType: ${errorType}, ErrorLink: ${errorLink} (path \"${method} ${endpoint}\" with method \"${function}\")",
-					OriginError:        error(nil),
-					ErrCode:            4,
-				}),
-				Error(Error{
-					Endpoint:         "/indexes/5",
-					Method:           "DELETE",
-					Function:         "DeleteIndex",
-					RequestToString:  "empty request",
-					ResponseToString: "{\"message\":\"Index \\\"5\\\" not found.\",\"errorCode\":\"index_not_found\",\"errorType\":\"invalid_request_error\",\"errorLink\":\"https://docs.meilisearch.com/errors#index_not_found\"}",
+				},
+				{
 					MeilisearchApiMessage: meilisearchApiMessage{
-						Message:   "Index \"5\" not found.",
 						ErrorCode: "index_not_found",
-						ErrorType: "invalid_request_error",
-						ErrorLink: "https://docs.meilisearch.com/errors#index_not_found",
 					},
-					StatusCode:         404,
-					StatusCodeExpected: []int{204},
-					rawMessage:         "unaccepted status code found: ${statusCode} expected: ${statusCodeExpected}, MeilisearchApiError Message: ${message}, ErrorCode: ${errorCode}, ErrorType: ${errorType}, ErrorLink: ${errorLink} (path \"${method} ${endpoint}\" with method \"${function}\")",
-					OriginError:        error(nil),
-					ErrCode:            4,
-				}),
+				},
 			},
 		},
 		{
@@ -335,24 +231,9 @@ func TestClient_DeleteIndex(t *testing.T) {
 			},
 			wantErr: true,
 			expectedError: []Error{
-				Error(Error{
-					Endpoint:         "/indexes/1",
-					Method:           "DELETE",
-					Function:         "DeleteIndex",
-					RequestToString:  "empty request",
-					ResponseToString: "empty response",
-					MeilisearchApiMessage: meilisearchApiMessage{
-						Message:   "empty meilisearch message",
-						ErrorCode: "",
-						ErrorType: "",
-						ErrorLink: "",
-					},
-					StatusCode:         0,
-					StatusCodeExpected: []int{204},
-					rawMessage:         "MeilisearchTimeoutError (path \"${method} ${endpoint}\" with method \"${function}\")",
-					OriginError:        fasthttp.ErrTimeout,
-					ErrCode:            6,
-				}),
+				{
+					MeilisearchApiMessage: meilisearchApiMessage{},
+				},
 			},
 		},
 	}
@@ -369,7 +250,8 @@ func TestClient_DeleteIndex(t *testing.T) {
 				gotOk, err := c.DeleteIndex(tt.args.deleteUid[k])
 				if tt.wantErr {
 					require.Error(t, err)
-					require.Equal(t, &tt.expectedError[k], err)
+					require.Equal(t, tt.expectedError[k].MeilisearchApiMessage.ErrorCode,
+						err.(*Error).MeilisearchApiMessage.ErrorCode)
 				} else {
 					require.NoError(t, err)
 					require.True(t, gotOk)

--- a/client_test.go
+++ b/client_test.go
@@ -40,24 +40,9 @@ func TestClient_TimeoutError(t *testing.T) {
 		{
 			name:   "TestTimeoutError",
 			client: timeoutClient,
-			expectedError: Error(Error{
-				Endpoint:         "/version",
-				Method:           "GET",
-				Function:         "Version",
-				RequestToString:  "empty request",
-				ResponseToString: "empty response",
-				MeilisearchApiMessage: meilisearchApiMessage{
-					Message:   "empty meilisearch message",
-					ErrorCode: "",
-					ErrorType: "",
-					ErrorLink: "",
-				},
-				StatusCode:         0,
-				StatusCodeExpected: []int{200},
-				rawMessage:         "MeilisearchTimeoutError (path \"${method} ${endpoint}\" with method \"${function}\")",
-				OriginError:        fasthttp.ErrTimeout,
-				ErrCode:            6,
-			}),
+			expectedError: Error{
+				MeilisearchApiMessage: meilisearchApiMessage{},
+			},
 		},
 	}
 	for _, tt := range tests {
@@ -65,7 +50,8 @@ func TestClient_TimeoutError(t *testing.T) {
 			gotResp, err := tt.client.GetVersion()
 			require.Error(t, err)
 			require.Nil(t, gotResp)
-			require.Equal(t, &tt.expectedError, err)
+			require.Equal(t, tt.expectedError.MeilisearchApiMessage.ErrorCode,
+				err.(*Error).MeilisearchApiMessage.ErrorCode)
 		})
 	}
 }

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,6 @@ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9sn
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9sn
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=

--- a/index_test.go
+++ b/index_test.go
@@ -56,24 +56,11 @@ func TestIndex_Delete(t *testing.T) {
 			},
 			wantErr: true,
 			expectedError: []Error{
-				Error(Error{
-					Endpoint:         "/indexes/1",
-					Method:           "DELETE",
-					Function:         "Delete",
-					RequestToString:  "empty request",
-					ResponseToString: "{\"message\":\"Index \\\"1\\\" not found.\",\"errorCode\":\"index_not_found\",\"errorType\":\"invalid_request_error\",\"errorLink\":\"https://docs.meilisearch.com/errors#index_not_found\"}",
+				{
 					MeilisearchApiMessage: meilisearchApiMessage{
-						Message:   "Index \"1\" not found.",
 						ErrorCode: "index_not_found",
-						ErrorType: "invalid_request_error",
-						ErrorLink: "https://docs.meilisearch.com/errors#index_not_found",
 					},
-					StatusCode:         404,
-					StatusCodeExpected: []int{204},
-					rawMessage:         "unaccepted status code found: ${statusCode} expected: ${statusCodeExpected}, MeilisearchApiError Message: ${message}, ErrorCode: ${errorCode}, ErrorType: ${errorType}, ErrorLink: ${errorLink} (path \"${method} ${endpoint}\" with method \"${function}\")",
-					OriginError:        error(nil),
-					ErrCode:            4,
-				}),
+				},
 			},
 		},
 		{
@@ -85,61 +72,21 @@ func TestIndex_Delete(t *testing.T) {
 			},
 			wantErr: true,
 			expectedError: []Error{
-				Error(Error{
-					Endpoint:         "/indexes/1",
-					Method:           "DELETE",
-					Function:         "Delete",
-					RequestToString:  "empty request",
-					ResponseToString: "{\"message\":\"Index \\\"1\\\" not found.\",\"errorCode\":\"index_not_found\",\"errorType\":\"invalid_request_error\",\"errorLink\":\"https://docs.meilisearch.com/errors#index_not_found\"}",
+				{
 					MeilisearchApiMessage: meilisearchApiMessage{
-						Message:   "Index \"1\" not found.",
 						ErrorCode: "index_not_found",
-						ErrorType: "invalid_request_error",
-						ErrorLink: "https://docs.meilisearch.com/errors#index_not_found",
 					},
-					StatusCode:         404,
-					StatusCodeExpected: []int{204},
-					rawMessage:         "unaccepted status code found: ${statusCode} expected: ${statusCodeExpected}, MeilisearchApiError Message: ${message}, ErrorCode: ${errorCode}, ErrorType: ${errorType}, ErrorLink: ${errorLink} (path \"${method} ${endpoint}\" with method \"${function}\")",
-					OriginError:        error(nil),
-					ErrCode:            4,
-				}),
-				Error(Error{
-					Endpoint:         "/indexes/2",
-					Method:           "DELETE",
-					Function:         "Delete",
-					RequestToString:  "empty request",
-					ResponseToString: "{\"message\":\"Index \\\"2\\\" not found.\",\"errorCode\":\"index_not_found\",\"errorType\":\"invalid_request_error\",\"errorLink\":\"https://docs.meilisearch.com/errors#index_not_found\"}",
-					MeilisearchApiMessage: meilisearchApiMessage{
-						Message:   "Index \"2\" not found.",
-						ErrorCode: "index_not_found",
-						ErrorType: "invalid_request_error",
-						ErrorLink: "https://docs.meilisearch.com/errors#index_not_found",
-					},
-					StatusCode:         404,
-					StatusCodeExpected: []int{204},
-					rawMessage:         "unaccepted status code found: ${statusCode} expected: ${statusCodeExpected}, MeilisearchApiError Message: ${message}, ErrorCode: ${errorCode}, ErrorType: ${errorType}, ErrorLink: ${errorLink} (path \"${method} ${endpoint}\" with method \"${function}\")",
-					OriginError:        error(nil),
-					ErrCode:            4,
-				}),
-				Error(Error{
-					Endpoint:         "/indexes/3",
-					Method:           "DELETE",
-					Function:         "Delete",
-					RequestToString:  "empty request",
-					ResponseToString: "{\"message\":\"Index \\\"3\\\" not found.\",\"errorCode\":\"index_not_found\",\"errorType\":\"invalid_request_error\",\"errorLink\":\"https://docs.meilisearch.com/errors#index_not_found\"}",
-					MeilisearchApiMessage: meilisearchApiMessage{
-						Message:   "Index \"3\" not found.",
-						ErrorCode: "index_not_found",
-						ErrorType: "invalid_request_error",
-						ErrorLink: "https://docs.meilisearch.com/errors#index_not_found",
-					},
-					StatusCode:         404,
-					StatusCodeExpected: []int{204},
-					rawMessage:         "unaccepted status code found: ${statusCode} expected: ${statusCodeExpected}, MeilisearchApiError Message: ${message}, ErrorCode: ${errorCode}, ErrorType: ${errorType}, ErrorLink: ${errorLink} (path \"${method} ${endpoint}\" with method \"${function}\")",
-					OriginError:        error(nil),
-					ErrCode:            4,
 				},
-				),
+				{
+					MeilisearchApiMessage: meilisearchApiMessage{
+						ErrorCode: "index_not_found",
+					},
+				},
+				{
+					MeilisearchApiMessage: meilisearchApiMessage{
+						ErrorCode: "index_not_found",
+					},
+				},
 			},
 		},
 	}
@@ -155,7 +102,8 @@ func TestIndex_Delete(t *testing.T) {
 				gotOk, err := i.Delete(tt.args.deleteUid[k])
 				if tt.wantErr {
 					require.Error(t, err)
-					require.Equal(t, &tt.expectedError[k], err)
+					require.Equal(t, tt.expectedError[k].MeilisearchApiMessage.ErrorCode,
+						err.(*Error).MeilisearchApiMessage.ErrorCode)
 				} else {
 					require.NoError(t, err)
 					require.True(t, gotOk)


### PR DESCRIPTION
This PR changes the way of comparing `Error` objects in tests. It compares only `MeilisearchApiMessage.ErrorCode`.
Also removes unused import and redundant type declarations.
Closes #198 