### PR TITLE
Make sure that `createdAt` and `updatedAt` are correctly update in `Index`

### DIFF
--- a/client_index_test.go
+++ b/client_index_test.go
@@ -133,6 +133,9 @@ func TestClient_CreateIndex(t *testing.T) {
 				if assert.NotNil(t, gotResp) {
 					require.Equal(t, tt.wantResp.UID, gotResp.UID)
 					require.Equal(t, tt.wantResp.PrimaryKey, gotResp.PrimaryKey)
+					// Make sure that timestamps are also retrieved
+					require.NotZero(t, gotResp.CreatedAt)
+					require.NotZero(t, gotResp.UpdatedAt)
 				}
 			}
 		})
@@ -658,6 +661,11 @@ func TestClient_GetIndex(t *testing.T) {
 				require.Equal(t, gotCreatedResp.UID, gotResp.UID)
 				require.Equal(t, tt.wantResp.PrimaryKey, gotResp.PrimaryKey)
 				require.Equal(t, gotCreatedResp.PrimaryKey, gotResp.PrimaryKey)
+				// Make sure that timestamps are also retrieved
+				require.NotZero(t, gotResp.CreatedAt)
+				require.Equal(t, gotCreatedResp.CreatedAt, gotResp.CreatedAt)
+				require.NotZero(t, gotResp.UpdatedAt)
+				require.Equal(t, gotCreatedResp.UpdatedAt, gotResp.UpdatedAt)
 			}
 		})
 	}
@@ -817,6 +825,9 @@ func TestClient_GetOrCreateIndex(t *testing.T) {
 			if assert.NotNil(t, gotResp) {
 				require.Equal(t, tt.wantResp.UID, gotResp.UID)
 				require.Equal(t, tt.wantResp.PrimaryKey, gotResp.PrimaryKey)
+				// Make sure that timestamps are also retrieved
+				require.NotZero(t, gotResp.CreatedAt)
+				require.NotZero(t, gotResp.UpdatedAt)
 			}
 		})
 	}
@@ -858,6 +869,9 @@ func TestClient_Index(t *testing.T) {
 			got := tt.client.Index(tt.args.uid)
 			require.NotNil(t, got)
 			require.Equal(t, tt.want.UID, got.UID)
+			// Timestamps should be empty unless fetched
+			require.Zero(t, got.CreatedAt)
+			require.Zero(t, got.UpdatedAt)
 		})
 	}
 }

--- a/index_test.go
+++ b/index_test.go
@@ -281,6 +281,9 @@ func Test_newIndex(t *testing.T) {
 			got := newIndex(c, tt.args.uid)
 			require.Equal(t, tt.want.UID, got.UID)
 			require.Equal(t, tt.want.client, got.client)
+			// Timestamps should be empty unless fetched
+			require.Zero(t, got.CreatedAt)
+			require.Zero(t, got.UpdatedAt)
 		})
 	}
 }
@@ -617,6 +620,9 @@ func TestIndex_FetchInfo(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tt.wantResp.UID, gotResp.UID)
 			require.Equal(t, tt.wantResp.PrimaryKey, gotResp.PrimaryKey)
+			// Make sure that timestamps are also fetched
+			require.NotZero(t, gotResp.CreatedAt)
+			require.NotZero(t, gotResp.UpdatedAt)
 		})
 	}
 }
@@ -710,12 +716,18 @@ func TestIndex_UpdateIndex(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tt.args.config.Uid, i.UID)
 			require.Equal(t, tt.args.config.PrimaryKey, i.PrimaryKey)
+			// Store original timestamps
+			createdAt := i.CreatedAt
+			updatedAt := i.UpdatedAt
 
 			gotResp, err := i.UpdateIndex(tt.args.primaryKey)
 
 			require.NoError(t, err)
 			require.Equal(t, tt.wantResp.UID, gotResp.UID)
 			require.Equal(t, tt.wantResp.PrimaryKey, gotResp.PrimaryKey)
+			// Make sure that timestamps were correctly updated as well
+			require.Equal(t, createdAt, gotResp.CreatedAt)
+			require.NotEqual(t, updatedAt, gotResp.UpdatedAt)
 		})
 	}
 }


### PR DESCRIPTION
Added checks in related test cases to make sure that `createdAt` and `updatedAt` fields in `Index` are always filled when expected. These checks are currently passing, so the `Index` values returned should be correct already. 

Fixes #209 