### PR TITLE
Make request body handling consistent

### DIFF
--- a/client_request.go
+++ b/client_request.go
@@ -1,6 +1,8 @@
 package meilisearch
 
 import (
+	"fmt"
+	"net/http"
 	"net/url"
 
 	"github.com/pkg/errors"
@@ -94,6 +96,12 @@ func (c *Client) sendRequest(req *internalRequest, internalError *Error, respons
 	request.Header.SetMethod(req.method)
 
 	if req.withRequest != nil {
+		if req.method == http.MethodGet || req.method == http.MethodHead {
+			return fmt.Errorf("sendRequest: request body is not expected for GET and HEAD requests")
+		}
+		if req.contentType == "" {
+			return fmt.Errorf("sendRequest: request body without Content-Type is not allowed")
+		}
 
 		// A json request is mandatory, so the request interface{} need to be passed as a raw json body.
 		rawJSONRequest := req.withRequest

--- a/index_documents.go
+++ b/index_documents.go
@@ -27,7 +27,7 @@ func (i Index) GetDocuments(request *DocumentsRequest, resp interface{}) error {
 	req := internalRequest{
 		endpoint:            "/indexes/" + i.UID + "/documents",
 		method:              http.MethodGet,
-		withRequest:         request,
+		withRequest:         nil,
 		withResponse:        resp,
 		withQueryParams:     map[string]string{},
 		acceptedStatusCodes: []int{http.StatusOK},


### PR DESCRIPTION
This adds verifications into `Client.sendRequest()` to make sure that request bodies are always set up as expected:
- GET and HEAD requests should not have a request body
- All requests with request bodies should have a Content-Type set

Running the tests with the new checks highlighted an issue in `Index.getDocuments()` which is fixed as well.