### PR TITLE
Add methods for new document formats

### DIFF
--- a/client_request.go
+++ b/client_request.go
@@ -15,7 +15,7 @@ const (
 	contentTypeJSON string = "application/json"
 	// These two types are defined in advance of the resolution of this issue
 	// https://github.com/meilisearch/meilisearch-go/issues/215. Don't forget to remove the no lint comment when it's done.
-	contentTypeNDJSON string = "application/x-dnjson" //nolint
+	contentTypeNDJSON string = "application/x-ndjson" //nolint
 	contentTypeCSV    string = "text/csv"             //nolint
 )
 

--- a/client_request.go
+++ b/client_request.go
@@ -13,11 +13,9 @@ import (
 )
 
 const (
-	contentTypeJSON string = "application/json"
-	// These two types are defined in advance of the resolution of this issue
-	// https://github.com/meilisearch/meilisearch-go/issues/215. Don't forget to remove the no lint comment when it's done.
-	contentTypeNDJSON string = "application/x-ndjson" //nolint
-	contentTypeCSV    string = "text/csv"             //nolint
+	contentTypeJSON   string = "application/json"
+	contentTypeNDJSON string = "application/x-ndjson"
+	contentTypeCSV    string = "text/csv"
 )
 
 type internalRequest struct {

--- a/client_request.go
+++ b/client_request.go
@@ -110,6 +110,7 @@ func (c *Client) sendRequest(req *internalRequest, internalError *Error, respons
 			request.SetBody(bytes)
 		} else if reader, ok := rawRequest.(io.Reader); ok {
 			// If the request body is an io.Reader then stream it directly until io.EOF
+			// NOTE: Avoid using this, due to problems with streamed request bodies
 			request.SetBodyStream(reader, -1)
 		} else {
 			// Otherwise convert it to JSON

--- a/index.go
+++ b/index.go
@@ -29,10 +29,10 @@ type IndexInterface interface {
 
 	AddDocuments(documentsPtr interface{}, primaryKey ...string) (resp *AsyncUpdateID, err error)
 	AddDocumentsInBatches(documentsPtr interface{}, batchSize int, primaryKey ...string) (resp []AsyncUpdateID, err error)
-	AddDocumentsCsv(documents string, primaryKey ...string) (resp *AsyncUpdateID, err error)
-	AddDocumentsCsvInBatches(documents string, batchSize int, primaryKey ...string) (resp []AsyncUpdateID, err error)
-	AddDocumentsNdjson(documents string, primaryKey ...string) (resp *AsyncUpdateID, err error)
-	AddDocumentsNdjsonInBatches(documents string, batchSize int, primaryKey ...string) (resp []AsyncUpdateID, err error)
+	AddDocumentsCsv(documents []byte, primaryKey ...string) (resp *AsyncUpdateID, err error)
+	AddDocumentsCsvInBatches(documents []byte, batchSize int, primaryKey ...string) (resp []AsyncUpdateID, err error)
+	AddDocumentsNdjson(documents []byte, primaryKey ...string) (resp *AsyncUpdateID, err error)
+	AddDocumentsNdjsonInBatches(documents []byte, batchSize int, primaryKey ...string) (resp []AsyncUpdateID, err error)
 	UpdateDocuments(documentsPtr interface{}, primaryKey ...string) (resp *AsyncUpdateID, err error)
 	GetDocument(uid string, documentPtr interface{}) error
 	GetDocuments(request *DocumentsRequest, resp interface{}) error

--- a/index.go
+++ b/index.go
@@ -28,6 +28,11 @@ type IndexInterface interface {
 	GetStats() (resp *StatsIndex, err error)
 
 	AddDocuments(documentsPtr interface{}, primaryKey ...string) (resp *AsyncUpdateID, err error)
+	AddDocumentsInBatches(documentsPtr interface{}, batchSize int, primaryKey ...string) (resp []AsyncUpdateID, err error)
+	AddDocumentsCsv(documents string, primaryKey ...string) (resp *AsyncUpdateID, err error)
+	AddDocumentsCsvInBatches(documents string, batchSize int, primaryKey ...string) (resp []AsyncUpdateID, err error)
+	AddDocumentsNdjson(documents string, primaryKey ...string) (resp *AsyncUpdateID, err error)
+	AddDocumentsNdjsonInBatches(documents string, batchSize int, primaryKey ...string) (resp []AsyncUpdateID, err error)
 	UpdateDocuments(documentsPtr interface{}, primaryKey ...string) (resp *AsyncUpdateID, err error)
 	GetDocument(uid string, documentPtr interface{}) error
 	GetDocuments(request *DocumentsRequest, resp interface{}) error

--- a/index_documents.go
+++ b/index_documents.go
@@ -1,6 +1,11 @@
 package meilisearch
 
 import (
+	"bufio"
+	"bytes"
+	"encoding/csv"
+	"fmt"
+	"io"
 	"math"
 	"net/http"
 	"reflect"
@@ -48,7 +53,7 @@ func (i Index) GetDocuments(request *DocumentsRequest, resp interface{}) error {
 	return nil
 }
 
-func (i Index) AddDocuments(documentsPtr interface{}, primaryKey ...string) (resp *AsyncUpdateID, err error) {
+func (i Index) addDocuments(documentsPtr interface{}, contentType string, primaryKey ...string) (resp *AsyncUpdateID, err error) {
 	resp = &AsyncUpdateID{}
 	endpoint := ""
 	if primaryKey == nil {
@@ -60,7 +65,7 @@ func (i Index) AddDocuments(documentsPtr interface{}, primaryKey ...string) (res
 	req := internalRequest{
 		endpoint:            endpoint,
 		method:              http.MethodPost,
-		contentType:         contentTypeJSON,
+		contentType:         contentType,
 		withRequest:         documentsPtr,
 		withResponse:        resp,
 		acceptedStatusCodes: []int{http.StatusAccepted},
@@ -70,6 +75,10 @@ func (i Index) AddDocuments(documentsPtr interface{}, primaryKey ...string) (res
 		return nil, err
 	}
 	return resp, nil
+}
+
+func (i Index) AddDocuments(documentsPtr interface{}, primaryKey ...string) (resp *AsyncUpdateID, err error) {
+	return i.addDocuments(documentsPtr, contentTypeJSON, primaryKey...)
 }
 
 func (i Index) AddDocumentsInBatches(documentsPtr interface{}, batchSize int, primaryKey ...string) (resp []AsyncUpdateID, err error) {
@@ -104,6 +113,182 @@ func (i Index) AddDocumentsInBatches(documentsPtr interface{}, batchSize int, pr
 	}
 
 	return resp, nil
+}
+
+func (i Index) AddDocumentsCsv(documents string, primaryKey ...string) (resp *AsyncUpdateID, err error) {
+	// []byte avoids JSON conversion in Client.sendRequest()
+	return i.addDocuments([]byte(documents), contentTypeCSV, primaryKey...)
+}
+
+func (i Index) AddDocumentsCsvFromReader(documents io.Reader, primaryKey ...string) (resp *AsyncUpdateID, err error) {
+	// io.Reader avoids JSON conversion in Client.sendRequest()
+	return i.addDocuments(documents, contentTypeCSV, primaryKey...)
+}
+
+func (i Index) AddDocumentsCsvInBatches(documents string, batchSize int, primaryKey ...string) (resp []AsyncUpdateID, err error) {
+	// Reuse io.Reader implementation
+	return i.AddDocumentsCsvFromReaderInBatches(strings.NewReader(documents), batchSize, primaryKey...)
+}
+
+func (i Index) AddDocumentsCsvFromReaderInBatches(documents io.Reader, batchSize int, primaryKey ...string) (resp []AsyncUpdateID, err error) {
+	// Because of the possibility of multiline fields it's not safe to split
+	// into batches by lines, we'll have to parse the file and reassemble it
+	// into smaller parts. RFC 4180 compliant input with a header row is
+	// expected.
+	// Records are read and sent continuously to avoid reading all content
+	// into memory. However this means that only part of the documents might
+	// be added successfully.
+
+	var (
+		resps   []AsyncUpdateID
+		header  []string
+		records [][]string
+	)
+
+	sendCsvRecords := func(records [][]string) (*AsyncUpdateID, error) {
+		b := new(bytes.Buffer)
+		w := csv.NewWriter(b)
+		w.UseCRLF = true // Keep output RFC 4180 compliant
+		err := w.WriteAll(records)
+		if err != nil {
+			return nil, fmt.Errorf("could not write CSV records: %w", err)
+		}
+
+		resp, err := i.AddDocumentsCsvFromReader(b)
+		if err != nil {
+			return nil, err
+		}
+		return resp, nil
+	}
+
+	r := csv.NewReader(documents)
+	for {
+		// Read CSV record (empty lines and comments are already skipped by csv.Reader)
+		record, err := r.Read()
+		if err != io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("could not read CSV record: %w", err)
+		}
+
+		// Store first record as header
+		if header == nil {
+			header = record
+			continue
+		}
+
+		// Add header record to every batch
+		if len(records) == 0 {
+			records = append(records, header)
+		}
+
+		records = append(records, record)
+
+		// After reaching batchSize (not counting the header record) assemble a CSV file and send records
+		if len(records) == batchSize+1 {
+			resp, err := sendCsvRecords(records)
+			if err != nil {
+				return nil, err
+			}
+			resps = append(resps, *resp)
+			records = nil
+		}
+	}
+
+	// Send remaining records as the last batch if there is any
+	if len(records) > 0 {
+		resp, err := sendCsvRecords(records)
+		if err != nil {
+			return nil, err
+		}
+		resps = append(resps, *resp)
+	}
+
+	return resps, nil
+}
+
+func (i Index) AddDocumentsNdjson(documents string, primaryKey ...string) (resp *AsyncUpdateID, err error) {
+	// []byte avoids JSON conversion in Client.sendRequest()
+	return i.addDocuments([]byte(documents), contentTypeNDJSON, primaryKey...)
+}
+
+func (i Index) AddDocumentsNdjsonFromReader(documents io.Reader, primaryKey ...string) (resp *AsyncUpdateID, err error) {
+	// io.Reader avoids JSON conversion in Client.sendRequest()
+	return i.addDocuments(documents, contentTypeNDJSON, primaryKey...)
+}
+
+func (i Index) AddDocumentsNdjsonInBatches(documents string, batchSize int, primaryKey ...string) (resp []AsyncUpdateID, err error) {
+	// Reuse io.Reader implementation
+	return i.AddDocumentsNdjsonFromReaderInBatches(strings.NewReader(documents), batchSize, primaryKey...)
+}
+
+func (i Index) AddDocumentsNdjsonFromReaderInBatches(documents io.Reader, batchSize int, primaryKey ...string) (resp []AsyncUpdateID, err error) {
+	// NDJSON files supposed to contain a valid JSON document in each line, so
+	// it's safe to split by lines.
+	// Lines are read and sent continuously to avoid reading all content into
+	// memory. However this means that only part of the documents might be
+	// added successfully.
+
+	sendNdjsonLines := func(lines []string) (*AsyncUpdateID, error) {
+		b := new(bytes.Buffer)
+		for _, line := range lines {
+			_, err := b.WriteString(line)
+			if err != nil {
+				return nil, fmt.Errorf("could not write NDJSON line: %w", err)
+			}
+			err = b.WriteByte('\n')
+			if err != nil {
+				return nil, fmt.Errorf("could not write NDJSON line: %w", err)
+			}
+		}
+
+		resp, err := i.AddDocumentsNdjsonFromReader(b)
+		if err != nil {
+			return nil, err
+		}
+		return resp, nil
+	}
+
+	var (
+		resps []AsyncUpdateID
+		lines []string
+	)
+
+	scanner := bufio.NewScanner(documents)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+
+		// Skip empty lines (NDJSON might not allow this, but just to be sure)
+		if line == "" {
+			continue
+		}
+
+		lines = append(lines, line)
+		// After reaching batchSize send NDJSON lines
+		if len(lines) == batchSize {
+			resp, err := sendNdjsonLines(lines)
+			if err != nil {
+				return nil, err
+			}
+			resps = append(resps, *resp)
+			lines = nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("could not read NDJSON: %w", err)
+	}
+
+	// Send remaining records as the last batch if there is any
+	if len(lines) > 0 {
+		resp, err := sendNdjsonLines(lines)
+		if err != nil {
+			return nil, err
+		}
+		resps = append(resps, *resp)
+	}
+
+	return resps, nil
 }
 
 func (i Index) UpdateDocuments(documentsPtr interface{}, primaryKey ...string) (resp *AsyncUpdateID, err error) {

--- a/index_documents.go
+++ b/index_documents.go
@@ -117,9 +117,9 @@ func (i Index) AddDocumentsInBatches(documentsPtr interface{}, batchSize int, pr
 	return resp, nil
 }
 
-func (i Index) AddDocumentsCsv(documents string, primaryKey ...string) (resp *AsyncUpdateID, err error) {
+func (i Index) AddDocumentsCsv(documents []byte, primaryKey ...string) (resp *AsyncUpdateID, err error) {
 	// []byte avoids JSON conversion in Client.sendRequest()
-	return i.addDocuments([]byte(documents), contentTypeCSV, primaryKey...)
+	return i.addDocuments(documents, contentTypeCSV, primaryKey...)
 }
 
 func (i Index) AddDocumentsCsvFromReader(documents io.Reader, primaryKey ...string) (resp *AsyncUpdateID, err error) {
@@ -132,9 +132,9 @@ func (i Index) AddDocumentsCsvFromReader(documents io.Reader, primaryKey ...stri
 	return i.addDocuments(data, contentTypeCSV, primaryKey...)
 }
 
-func (i Index) AddDocumentsCsvInBatches(documents string, batchSize int, primaryKey ...string) (resp []AsyncUpdateID, err error) {
+func (i Index) AddDocumentsCsvInBatches(documents []byte, batchSize int, primaryKey ...string) (resp []AsyncUpdateID, err error) {
 	// Reuse io.Reader implementation
-	return i.AddDocumentsCsvFromReaderInBatches(strings.NewReader(documents), batchSize, primaryKey...)
+	return i.AddDocumentsCsvFromReaderInBatches(bytes.NewReader(documents), batchSize, primaryKey...)
 }
 
 func (i Index) AddDocumentsCsvFromReaderInBatches(documents io.Reader, batchSize int, primaryKey ...string) (resp []AsyncUpdateID, err error) {
@@ -161,7 +161,7 @@ func (i Index) AddDocumentsCsvFromReaderInBatches(documents io.Reader, batchSize
 			return nil, errors.Wrap(err, "could not write CSV records")
 		}
 
-		resp, err := i.AddDocumentsCsv(b.String(), primaryKey...)
+		resp, err := i.AddDocumentsCsv(b.Bytes(), primaryKey...)
 		if err != nil {
 			return nil, err
 		}
@@ -215,7 +215,7 @@ func (i Index) AddDocumentsCsvFromReaderInBatches(documents io.Reader, batchSize
 	return responses, nil
 }
 
-func (i Index) AddDocumentsNdjson(documents string, primaryKey ...string) (resp *AsyncUpdateID, err error) {
+func (i Index) AddDocumentsNdjson(documents []byte, primaryKey ...string) (resp *AsyncUpdateID, err error) {
 	// []byte avoids JSON conversion in Client.sendRequest()
 	return i.addDocuments([]byte(documents), contentTypeNDJSON, primaryKey...)
 }
@@ -230,9 +230,9 @@ func (i Index) AddDocumentsNdjsonFromReader(documents io.Reader, primaryKey ...s
 	return i.addDocuments(data, contentTypeNDJSON, primaryKey...)
 }
 
-func (i Index) AddDocumentsNdjsonInBatches(documents string, batchSize int, primaryKey ...string) (resp []AsyncUpdateID, err error) {
+func (i Index) AddDocumentsNdjsonInBatches(documents []byte, batchSize int, primaryKey ...string) (resp []AsyncUpdateID, err error) {
 	// Reuse io.Reader implementation
-	return i.AddDocumentsNdjsonFromReaderInBatches(strings.NewReader(documents), batchSize, primaryKey...)
+	return i.AddDocumentsNdjsonFromReaderInBatches(bytes.NewReader(documents), batchSize, primaryKey...)
 }
 
 func (i Index) AddDocumentsNdjsonFromReaderInBatches(documents io.Reader, batchSize int, primaryKey ...string) (resp []AsyncUpdateID, err error) {
@@ -255,7 +255,7 @@ func (i Index) AddDocumentsNdjsonFromReaderInBatches(documents io.Reader, batchS
 			}
 		}
 
-		resp, err := i.AddDocumentsNdjson(b.String(), primaryKey...)
+		resp, err := i.AddDocumentsNdjson(b.Bytes(), primaryKey...)
 		if err != nil {
 			return nil, err
 		}

--- a/index_documents_test.go
+++ b/index_documents_test.go
@@ -1,7 +1,12 @@
 package meilisearch
 
 import (
+	"bufio"
+	"encoding/csv"
+	"encoding/json"
+	"io"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -340,6 +345,375 @@ func TestIndex_AddDocumentsInBatches(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tt.args.documentsPtr, documents)
 		})
+	}
+}
+
+func testParseCsvDocuments(t *testing.T, documents io.Reader) []map[string]interface{} {
+	var (
+		docs   []map[string]interface{}
+		header []string
+	)
+	r := csv.NewReader(documents)
+	for {
+		record, err := r.Read()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		if header == nil {
+			header = record
+			continue
+		}
+		doc := make(map[string]interface{})
+		for i, key := range header {
+			doc[key] = record[i]
+		}
+		docs = append(docs, doc)
+	}
+	return docs
+}
+
+const testCsvDocuments = `
+id,name
+1,Alice In Wonderland
+2,Pride and Prejudice
+3,Le Petit Prince
+4,The Great Gatsby
+5,Don Quixote
+`
+
+func TestIndex_AddDocumentsCsv(t *testing.T) {
+	type args struct {
+		uid       string
+		client    *Client
+		documents string
+	}
+	type testData struct {
+		name     string
+		args     args
+		wantResp *AsyncUpdateID
+	}
+
+	tests := []testData{
+		{
+			name: "TestIndexBasic",
+			args: args{
+				uid:       "csv",
+				client:    defaultClient,
+				documents: testCsvDocuments,
+			},
+			wantResp: &AsyncUpdateID{UpdateID: 0},
+		},
+	}
+
+	testAddDocumentsCsv := func(t *testing.T, tt testData, testReader bool) {
+		name := tt.name + "AddDocumentsCsv"
+		if testReader {
+			name += "FromReader"
+		}
+
+		uid := tt.args.uid
+		if testReader {
+			uid += "-reader"
+		} else {
+			uid += "-string"
+		}
+
+		t.Run(name, func(t *testing.T) {
+			c := tt.args.client
+			i := c.Index(uid)
+			t.Cleanup(cleanup(c))
+
+			wantDocs := testParseCsvDocuments(t, strings.NewReader(tt.args.documents))
+
+			var (
+				gotResp *AsyncUpdateID
+				err     error
+			)
+
+			if testReader {
+				gotResp, err = i.AddDocumentsCsvFromReader(strings.NewReader(tt.args.documents))
+			} else {
+				gotResp, err = i.AddDocumentsCsv(tt.args.documents)
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, gotResp, tt.wantResp)
+
+			testWaitForPendingUpdate(t, i, gotResp)
+
+			var documents []map[string]interface{}
+			err = i.GetDocuments(&DocumentsRequest{}, &documents)
+			require.NoError(t, err)
+			require.Equal(t, wantDocs, documents)
+		})
+	}
+
+	for _, tt := range tests {
+		// Test both the string and io.Reader receiving versions
+		testAddDocumentsCsv(t, tt, false)
+		testAddDocumentsCsv(t, tt, true)
+	}
+}
+
+func TestIndex_AddDocumentsCsvInBatches(t *testing.T) {
+	type args struct {
+		uid       string
+		client    *Client
+		batchSize int
+		documents string
+	}
+	type testData struct {
+		name     string
+		args     args
+		wantResp []AsyncUpdateID
+	}
+
+	tests := []testData{
+		{
+			name: "TestIndexBasic",
+			args: args{
+				uid:       "csvbatch",
+				client:    defaultClient,
+				batchSize: 2,
+				documents: testCsvDocuments,
+			},
+			wantResp: []AsyncUpdateID{
+				{UpdateID: 0},
+				{UpdateID: 1},
+				{UpdateID: 2},
+			},
+		},
+	}
+
+	testAddDocumentsCsvInBatches := func(t *testing.T, tt testData, testReader bool) {
+		name := tt.name + "AddDocumentsCsv"
+		if testReader {
+			name += "FromReader"
+		}
+		name += "InBatches"
+
+		uid := tt.args.uid
+		if testReader {
+			uid += "-reader"
+		} else {
+			uid += "-string"
+		}
+
+		t.Run(name, func(t *testing.T) {
+			c := tt.args.client
+			i := c.Index(uid)
+			t.Cleanup(cleanup(c))
+
+			wantDocs := testParseCsvDocuments(t, strings.NewReader(tt.args.documents))
+
+			var (
+				gotResp []AsyncUpdateID
+				err     error
+			)
+
+			if testReader {
+				gotResp, err = i.AddDocumentsCsvFromReaderInBatches(strings.NewReader(tt.args.documents), tt.args.batchSize)
+			} else {
+				gotResp, err = i.AddDocumentsCsvInBatches(tt.args.documents, tt.args.batchSize)
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, gotResp, tt.wantResp)
+
+			testWaitForPendingBatchUpdate(t, i, gotResp)
+
+			var documents []map[string]interface{}
+			err = i.GetDocuments(&DocumentsRequest{}, &documents)
+			require.NoError(t, err)
+			require.Equal(t, wantDocs, documents)
+		})
+	}
+
+	for _, tt := range tests {
+		// Test both the string and io.Reader receiving versions
+		testAddDocumentsCsvInBatches(t, tt, false)
+		testAddDocumentsCsvInBatches(t, tt, true)
+	}
+}
+
+func testParseNdjsonDocuments(t *testing.T, documents io.Reader) []map[string]interface{} {
+	var docs []map[string]interface{}
+	scanner := bufio.NewScanner(documents)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		doc := make(map[string]interface{})
+		err := json.Unmarshal([]byte(line), &doc)
+		require.NoError(t, err)
+		docs = append(docs, doc)
+	}
+	require.NoError(t, scanner.Err())
+	return docs
+}
+
+const testNdjsonDocuments = `
+{"id": 1, "name": "Alice In Wonderland"}
+{"id": 2, "name": "Pride and Prejudice"}
+{"id": 3, "name": "Le Petit Prince"}
+{"id": 4, "name": "The Great Gatsby"}
+{"id": 5, "name": "Don Quixote"}
+`
+
+func TestIndex_AddDocumentsNdjson(t *testing.T) {
+	type args struct {
+		uid       string
+		client    *Client
+		documents string
+	}
+	type testData struct {
+		name     string
+		args     args
+		wantResp *AsyncUpdateID
+	}
+
+	tests := []testData{
+		{
+			name: "TestIndexBasic",
+			args: args{
+				uid:       "ndjson",
+				client:    defaultClient,
+				documents: testNdjsonDocuments,
+			},
+			wantResp: &AsyncUpdateID{UpdateID: 0},
+		},
+	}
+
+	testAddDocumentsNdjson := func(t *testing.T, tt testData, testReader bool) {
+		name := tt.name + "AddDocumentsNdjson"
+		if testReader {
+			name += "FromReader"
+		}
+
+		uid := tt.args.uid
+		if testReader {
+			uid += "-reader"
+		} else {
+			uid += "-string"
+		}
+
+		t.Run(name, func(t *testing.T) {
+			c := tt.args.client
+			i := c.Index(uid)
+			t.Cleanup(cleanup(c))
+
+			wantDocs := testParseNdjsonDocuments(t, strings.NewReader(tt.args.documents))
+
+			var (
+				gotResp *AsyncUpdateID
+				err     error
+			)
+
+			if testReader {
+				gotResp, err = i.AddDocumentsNdjsonFromReader(strings.NewReader(tt.args.documents))
+			} else {
+				gotResp, err = i.AddDocumentsNdjson(tt.args.documents)
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, gotResp, tt.wantResp)
+
+			testWaitForPendingUpdate(t, i, gotResp)
+
+			var documents []map[string]interface{}
+			err = i.GetDocuments(&DocumentsRequest{}, &documents)
+			require.NoError(t, err)
+			require.Equal(t, wantDocs, documents)
+		})
+	}
+
+	for _, tt := range tests {
+		// Test both the string and io.Reader receiving versions
+		testAddDocumentsNdjson(t, tt, false)
+		testAddDocumentsNdjson(t, tt, true)
+	}
+}
+
+func TestIndex_AddDocumentsNdjsonInBatches(t *testing.T) {
+	type args struct {
+		uid       string
+		client    *Client
+		batchSize int
+		documents string
+	}
+	type testData struct {
+		name     string
+		args     args
+		wantResp []AsyncUpdateID
+	}
+
+	tests := []testData{
+		{
+			name: "TestIndexBasic",
+			args: args{
+				uid:       "ndjsonbatch",
+				client:    defaultClient,
+				batchSize: 2,
+				documents: testNdjsonDocuments,
+			},
+			wantResp: []AsyncUpdateID{
+				{UpdateID: 0},
+				{UpdateID: 1},
+				{UpdateID: 2},
+			},
+		},
+	}
+
+	testAddDocumentsNdjsonInBatches := func(t *testing.T, tt testData, testReader bool) {
+		name := tt.name + "AddDocumentsNdjson"
+		if testReader {
+			name += "FromReader"
+		}
+		name += "InBatches"
+
+		uid := tt.args.uid
+		if testReader {
+			uid += "-reader"
+		} else {
+			uid += "-string"
+		}
+
+		t.Run(name, func(t *testing.T) {
+			c := tt.args.client
+			i := c.Index(uid)
+			t.Cleanup(cleanup(c))
+
+			wantDocs := testParseNdjsonDocuments(t, strings.NewReader(tt.args.documents))
+
+			var (
+				gotResp []AsyncUpdateID
+				err     error
+			)
+
+			if testReader {
+				gotResp, err = i.AddDocumentsNdjsonFromReaderInBatches(strings.NewReader(tt.args.documents), tt.args.batchSize)
+			} else {
+				gotResp, err = i.AddDocumentsNdjsonInBatches(tt.args.documents, tt.args.batchSize)
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, gotResp, tt.wantResp)
+
+			testWaitForPendingBatchUpdate(t, i, gotResp)
+
+			var documents []map[string]interface{}
+			err = i.GetDocuments(&DocumentsRequest{}, &documents)
+			require.NoError(t, err)
+			require.Equal(t, wantDocs, documents)
+		})
+	}
+
+	for _, tt := range tests {
+		// Test both the string and io.Reader receiving versions
+		testAddDocumentsNdjsonInBatches(t, tt, false)
+		testAddDocumentsNdjsonInBatches(t, tt, true)
 	}
 }
 

--- a/index_documents_test.go
+++ b/index_documents_test.go
@@ -2,6 +2,7 @@ package meilisearch
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/csv"
 	"encoding/json"
 	"io"
@@ -373,19 +374,19 @@ func testParseCsvDocuments(t *testing.T, documents io.Reader) []map[string]inter
 	return docs
 }
 
-const testCsvDocuments = `id,name
+var testCsvDocuments = []byte(`id,name
 1,Alice In Wonderland
 2,Pride and Prejudice
 3,Le Petit Prince
 4,The Great Gatsby
 5,Don Quixote
-`
+`)
 
 func TestIndex_AddDocumentsCsv(t *testing.T) {
 	type args struct {
 		uid       string
 		client    *Client
-		documents string
+		documents []byte
 	}
 	type testData struct {
 		name     string
@@ -423,7 +424,7 @@ func TestIndex_AddDocumentsCsv(t *testing.T) {
 			i := c.Index(uid)
 			t.Cleanup(cleanup(c))
 
-			wantDocs := testParseCsvDocuments(t, strings.NewReader(tt.args.documents))
+			wantDocs := testParseCsvDocuments(t, bytes.NewReader(tt.args.documents))
 
 			var (
 				gotResp *AsyncUpdateID
@@ -431,7 +432,7 @@ func TestIndex_AddDocumentsCsv(t *testing.T) {
 			)
 
 			if testReader {
-				gotResp, err = i.AddDocumentsCsvFromReader(strings.NewReader(tt.args.documents))
+				gotResp, err = i.AddDocumentsCsvFromReader(bytes.NewReader(tt.args.documents))
 			} else {
 				gotResp, err = i.AddDocumentsCsv(tt.args.documents)
 			}
@@ -460,7 +461,7 @@ func TestIndex_AddDocumentsCsvInBatches(t *testing.T) {
 		uid       string
 		client    *Client
 		batchSize int
-		documents string
+		documents []byte
 	}
 	type testData struct {
 		name     string
@@ -504,7 +505,7 @@ func TestIndex_AddDocumentsCsvInBatches(t *testing.T) {
 			i := c.Index(uid)
 			t.Cleanup(cleanup(c))
 
-			wantDocs := testParseCsvDocuments(t, strings.NewReader(tt.args.documents))
+			wantDocs := testParseCsvDocuments(t, bytes.NewReader(tt.args.documents))
 
 			var (
 				gotResp []AsyncUpdateID
@@ -512,7 +513,7 @@ func TestIndex_AddDocumentsCsvInBatches(t *testing.T) {
 			)
 
 			if testReader {
-				gotResp, err = i.AddDocumentsCsvFromReaderInBatches(strings.NewReader(tt.args.documents), tt.args.batchSize)
+				gotResp, err = i.AddDocumentsCsvFromReaderInBatches(bytes.NewReader(tt.args.documents), tt.args.batchSize)
 			} else {
 				gotResp, err = i.AddDocumentsCsvInBatches(tt.args.documents, tt.args.batchSize)
 			}
@@ -553,18 +554,18 @@ func testParseNdjsonDocuments(t *testing.T, documents io.Reader) []map[string]in
 	return docs
 }
 
-const testNdjsonDocuments = `{"id": 1, "name": "Alice In Wonderland"}
+var testNdjsonDocuments = []byte(`{"id": 1, "name": "Alice In Wonderland"}
 {"id": 2, "name": "Pride and Prejudice"}
 {"id": 3, "name": "Le Petit Prince"}
 {"id": 4, "name": "The Great Gatsby"}
 {"id": 5, "name": "Don Quixote"}
-`
+`)
 
 func TestIndex_AddDocumentsNdjson(t *testing.T) {
 	type args struct {
 		uid       string
 		client    *Client
-		documents string
+		documents []byte
 	}
 	type testData struct {
 		name     string
@@ -602,7 +603,7 @@ func TestIndex_AddDocumentsNdjson(t *testing.T) {
 			i := c.Index(uid)
 			t.Cleanup(cleanup(c))
 
-			wantDocs := testParseNdjsonDocuments(t, strings.NewReader(tt.args.documents))
+			wantDocs := testParseNdjsonDocuments(t, bytes.NewReader(tt.args.documents))
 
 			var (
 				gotResp *AsyncUpdateID
@@ -610,7 +611,7 @@ func TestIndex_AddDocumentsNdjson(t *testing.T) {
 			)
 
 			if testReader {
-				gotResp, err = i.AddDocumentsNdjsonFromReader(strings.NewReader(tt.args.documents))
+				gotResp, err = i.AddDocumentsNdjsonFromReader(bytes.NewReader(tt.args.documents))
 			} else {
 				gotResp, err = i.AddDocumentsNdjson(tt.args.documents)
 			}
@@ -639,7 +640,7 @@ func TestIndex_AddDocumentsNdjsonInBatches(t *testing.T) {
 		uid       string
 		client    *Client
 		batchSize int
-		documents string
+		documents []byte
 	}
 	type testData struct {
 		name     string
@@ -683,7 +684,7 @@ func TestIndex_AddDocumentsNdjsonInBatches(t *testing.T) {
 			i := c.Index(uid)
 			t.Cleanup(cleanup(c))
 
-			wantDocs := testParseNdjsonDocuments(t, strings.NewReader(tt.args.documents))
+			wantDocs := testParseNdjsonDocuments(t, bytes.NewReader(tt.args.documents))
 
 			var (
 				gotResp []AsyncUpdateID
@@ -691,7 +692,7 @@ func TestIndex_AddDocumentsNdjsonInBatches(t *testing.T) {
 			)
 
 			if testReader {
-				gotResp, err = i.AddDocumentsNdjsonFromReaderInBatches(strings.NewReader(tt.args.documents), tt.args.batchSize)
+				gotResp, err = i.AddDocumentsNdjsonFromReaderInBatches(bytes.NewReader(tt.args.documents), tt.args.batchSize)
 			} else {
 				gotResp, err = i.AddDocumentsNdjsonInBatches(tt.args.documents, tt.args.batchSize)
 			}

--- a/index_documents_test.go
+++ b/index_documents_test.go
@@ -373,8 +373,7 @@ func testParseCsvDocuments(t *testing.T, documents io.Reader) []map[string]inter
 	return docs
 }
 
-const testCsvDocuments = `
-id,name
+const testCsvDocuments = `id,name
 1,Alice In Wonderland
 2,Pride and Prejudice
 3,Le Petit Prince
@@ -554,8 +553,7 @@ func testParseNdjsonDocuments(t *testing.T, documents io.Reader) []map[string]in
 	return docs
 }
 
-const testNdjsonDocuments = `
-{"id": 1, "name": "Alice In Wonderland"}
+const testNdjsonDocuments = `{"id": 1, "name": "Alice In Wonderland"}
 {"id": 2, "name": "Pride and Prejudice"}
 {"id": 3, "name": "Le Petit Prince"}
 {"id": 4, "name": "The Great Gatsby"}


### PR DESCRIPTION
This completes the biggest part of #215 and adds the requested new methods for document insertion together with new test cases. Additionally some extra methods were added which receive `io.Reader` to provide a more idiomatic interface, especially for batch requests.

If this approach is approved, I can easily add the document update methods as well. 