### PR TITLE
Add clean cache command in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ Each PR should pass the tests and the linter to be accepted.
 # Tests
 curl -L https://install.meilisearch.com | sh # download MeiliSearch
 ./meilisearch --master-key=masterKey --no-analytics=true # run MeiliSearch
-go test -v ./...
+go clean -cache ; go test -v ./...
 # Use golangci-lint
 docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:v1.42.0 golangci-lint run -v
 # Use gofmt


### PR DESCRIPTION
Before running the test, we should enforce this command. Indeed, because of the cache, running the same tests against two different versions of MeiliSearch will not behave as expected: the second run will give the exact same result as the second one.