### PR TITLE
Rename error response fields to support v0.24.0

### DIFF
--- a/error.go
+++ b/error.go
@@ -59,9 +59,9 @@ func (e ErrCode) rawMessage() string {
 
 type meilisearchApiMessage struct {
 	Message   string `json:"message"`
-	ErrorCode string `json:"errorCode"`
-	ErrorType string `json:"errorType"`
-	ErrorLink string `json:"errorLink"`
+	ErrorCode string `json:"code"`
+	ErrorType string `json:"type"`
+	ErrorLink string `json:"link"`
 }
 
 // Error is the internal error structure that all exposed method use.


### PR DESCRIPTION
This **breaking** change makes sure that this library is following the naming of error fields in the new version of MeiliSearch.

# Pull Request

## What does this PR do?
Fixes #240 

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?
