### PR TITLE
Convert the dump status to an enum

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -230,13 +230,13 @@ func TestClient_GetDumpStatus(t *testing.T) {
 	tests := []struct {
 		name     string
 		client   *Client
-		wantResp []string
+		wantResp []DumpStatus
 		wantErr  bool
 	}{
 		{
 			name:     "TestGetDumpStatus",
 			client:   defaultClient,
-			wantResp: []string{"in_progress", "failed", "done"},
+			wantResp: []DumpStatus{DumpStatusInProgress, DumpStatusFailed, DumpStatusDone},
 			wantErr:  false,
 		},
 	}

--- a/types.go
+++ b/types.go
@@ -99,14 +99,26 @@ type Keys struct {
 	Private string `json:"private,omitempty"`
 }
 
+// DumpStatus is the status of a dump.
+type DumpStatus string
+
+const (
+	// DumpStatusInProgress means the server is processing the dump
+	DumpStatusInProgress DumpStatus = "in_progress"
+	// DumpStatusFailed means the server failed to create a dump
+	DumpStatusFailed DumpStatus = "failed"
+	// DumpStatusDone means the server completed the dump
+	DumpStatusDone DumpStatus = "done"
+)
+
 // Dump indicate information about an dump
 //
 // Documentation: https://docs.meilisearch.com/reference/api/dump.html
 type Dump struct {
-	UID        string    `json:"uid"`
-	Status     string    `json:"status"`
-	StartedAt  time.Time `json:"startedAt"`
-	FinishedAt time.Time `json:"finishedAt"`
+	UID        string     `json:"uid"`
+	Status     DumpStatus `json:"status"`
+	StartedAt  time.Time  `json:"startedAt"`
+	FinishedAt time.Time  `json:"finishedAt"`
 }
 
 //

--- a/types_easyjson.go
+++ b/types_easyjson.go
@@ -1691,7 +1691,7 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo11(in *jlexer.Lexer,
 		case "uid":
 			out.UID = string(in.String())
 		case "status":
-			out.Status = string(in.String())
+			out.Status = DumpStatus(in.String())
 		case "startedAt":
 			if data := in.Raw(); in.Ok() {
 				in.AddError((out.StartedAt).UnmarshalJSON(data))


### PR DESCRIPTION
This change helps to make the status field more consistent between "Update" and "Dump" and fixes #242.

The UpdateStatus field is an enum, but the DumpStatus field is a string. 
In the docs, these fields have a set number of possibilities and that's why it'd be proper to make DumpStatus an enum, rather than a string.

