### PR TITLE
Redesign update API to task API

### DIFF
--- a/client.go
+++ b/client.go
@@ -43,7 +43,7 @@ type ClientInterface interface {
 	GetTask(taskID int64) (resp *Task, err error)
 	GetTasks() (resp *ResultTask, err error)
 	WaitForTask(ctx context.Context, interval time.Duration, task *Task) (*Task, error)
-	DefaultWaitForTask(taskID *Task) (*Task, error)
+	DefaultWaitForTask(task *Task) (*Task, error)
 }
 
 var _ ClientInterface = &Client{}

--- a/client.go
+++ b/client.go
@@ -42,7 +42,7 @@ type ClientInterface interface {
 	IsHealthy() bool
 	GetTask(taskID int64) (resp *Task, err error)
 	GetTasks() (resp *ResultTask, err error)
-	WaitForTask(ctx context.Context, interval time.Duration, taskID *Task) (*Task, error)
+	WaitForTask(ctx context.Context, interval time.Duration, task *Task) (*Task, error)
 	DefaultWaitForTask(taskID *Task) (*Task, error)
 }
 

--- a/client_index.go
+++ b/client_index.go
@@ -1,6 +1,8 @@
 package meilisearch
 
-import "net/http"
+import (
+	"net/http"
+)
 
 func (c *Client) Index(uid string) *Index {
 	return newIndex(c, uid)
@@ -26,19 +28,19 @@ func (c *Client) GetRawIndex(uid string) (resp map[string]interface{}, err error
 	return resp, nil
 }
 
-func (c *Client) CreateIndex(config *IndexConfig) (resp *Index, err error) {
+func (c *Client) CreateIndex(config *IndexConfig) (resp *Task, err error) {
 	request := &CreateIndexRequest{
 		UID:        config.Uid,
 		PrimaryKey: config.PrimaryKey,
 	}
-	resp = newIndex(c, config.Uid)
+	resp = &Task{}
 	req := internalRequest{
 		endpoint:            "/indexes",
 		method:              http.MethodPost,
 		contentType:         contentTypeJSON,
 		withRequest:         request,
 		withResponse:        resp,
-		acceptedStatusCodes: []int{http.StatusCreated},
+		acceptedStatusCodes: []int{http.StatusAccepted},
 		functionName:        "CreateIndex",
 	}
 	if err := c.executeRequest(req); err != nil {
@@ -79,18 +81,18 @@ func (c *Client) GetAllRawIndexes() (resp []map[string]interface{}, err error) {
 	return resp, nil
 }
 
-func (c *Client) DeleteIndex(uid string) (ok bool, err error) {
+func (c *Client) DeleteIndex(uid string) (resp *Task, err error) {
+	resp = &Task{}
 	req := internalRequest{
 		endpoint:            "/indexes/" + uid,
 		method:              http.MethodDelete,
 		withRequest:         nil,
-		withResponse:        nil,
-		acceptedStatusCodes: []int{http.StatusNoContent},
+		withResponse:        resp,
+		acceptedStatusCodes: []int{http.StatusAccepted},
 		functionName:        "DeleteIndex",
 	}
-	// err is not nil if status code is not 204 StatusNoContent
 	if err := c.executeRequest(req); err != nil {
-		return false, err
+		return nil, err
 	}
-	return true, nil
+	return resp, nil
 }

--- a/client_index_test.go
+++ b/client_index_test.go
@@ -107,7 +107,7 @@ func TestClient_CreateIndex(t *testing.T) {
 				// Make sure that timestamps are also retrieved
 				require.NotZero(t, gotResp.EnqueuedAt)
 
-				_, err := c.DefaultWaitForTask(gotResp)
+				_, err := c.WaitForTask(gotResp)
 				require.NoError(t, err)
 
 				index, err := c.GetIndex(tt.args.config.Uid)

--- a/client_request.go
+++ b/client_request.go
@@ -134,7 +134,7 @@ func (c *Client) sendRequest(req *internalRequest, internalError *Error, respons
 		request.Header.Set("Content-Type", req.contentType)
 	}
 	if c.config.APIKey != "" {
-		request.Header.Set("Authorization", "Bearer " + c.config.APIKey)
+		request.Header.Set("Authorization", "Bearer "+c.config.APIKey)
 	}
 
 	// request is sent

--- a/index.go
+++ b/index.go
@@ -22,54 +22,54 @@ type IndexConfig struct {
 type IndexInterface interface {
 	FetchInfo() (resp *Index, err error)
 	FetchPrimaryKey() (resp *string, err error)
-	UpdateIndex(primaryKey string) (resp *Index, err error)
+	UpdateIndex(primaryKey string) (resp *Task, err error)
 	Delete(uid string) (ok bool, err error)
 	GetStats() (resp *StatsIndex, err error)
 
-	AddDocuments(documentsPtr interface{}, primaryKey ...string) (resp *AsyncUpdateID, err error)
-	AddDocumentsInBatches(documentsPtr interface{}, batchSize int, primaryKey ...string) (resp []AsyncUpdateID, err error)
-	AddDocumentsCsv(documents []byte, primaryKey ...string) (resp *AsyncUpdateID, err error)
-	AddDocumentsCsvInBatches(documents []byte, batchSize int, primaryKey ...string) (resp []AsyncUpdateID, err error)
-	AddDocumentsNdjson(documents []byte, primaryKey ...string) (resp *AsyncUpdateID, err error)
-	AddDocumentsNdjsonInBatches(documents []byte, batchSize int, primaryKey ...string) (resp []AsyncUpdateID, err error)
-	UpdateDocuments(documentsPtr interface{}, primaryKey ...string) (resp *AsyncUpdateID, err error)
+	AddDocuments(documentsPtr interface{}, primaryKey ...string) (resp *Task, err error)
+	AddDocumentsInBatches(documentsPtr interface{}, batchSize int, primaryKey ...string) (resp []Task, err error)
+	AddDocumentsCsv(documents []byte, primaryKey ...string) (resp *Task, err error)
+	AddDocumentsCsvInBatches(documents []byte, batchSize int, primaryKey ...string) (resp []Task, err error)
+	AddDocumentsNdjson(documents []byte, primaryKey ...string) (resp *Task, err error)
+	AddDocumentsNdjsonInBatches(documents []byte, batchSize int, primaryKey ...string) (resp []Task, err error)
+	UpdateDocuments(documentsPtr interface{}, primaryKey ...string) (resp *Task, err error)
 	GetDocument(uid string, documentPtr interface{}) error
 	GetDocuments(request *DocumentsRequest, resp interface{}) error
-	DeleteDocument(uid string) (resp *AsyncUpdateID, err error)
-	DeleteDocuments(uid []string) (resp *AsyncUpdateID, err error)
-	DeleteAllDocuments() (resp *AsyncUpdateID, err error)
+	DeleteDocument(uid string) (resp *Task, err error)
+	DeleteDocuments(uid []string) (resp *Task, err error)
+	DeleteAllDocuments() (resp *Task, err error)
 	Search(query string, request *SearchRequest) (*SearchResponse, error)
 
-	GetUpdateStatus(updateID int64) (resp *Update, err error)
-	GetAllUpdateStatus() (resp *[]Update, err error)
+	GetTask(taskID int64) (resp *Task, err error)
+	GetTasks() (resp *ResultTask, err error)
 
 	GetSettings() (resp *Settings, err error)
-	UpdateSettings(request *Settings) (resp *AsyncUpdateID, err error)
-	ResetSettings() (resp *AsyncUpdateID, err error)
+	UpdateSettings(request *Settings) (resp *Task, err error)
+	ResetSettings() (resp *Task, err error)
 	GetRankingRules() (resp *[]string, err error)
-	UpdateRankingRules(request *[]string) (resp *AsyncUpdateID, err error)
-	ResetRankingRules() (resp *AsyncUpdateID, err error)
+	UpdateRankingRules(request *[]string) (resp *Task, err error)
+	ResetRankingRules() (resp *Task, err error)
 	GetDistinctAttribute() (resp *string, err error)
-	UpdateDistinctAttribute(request string) (resp *AsyncUpdateID, err error)
-	ResetDistinctAttribute() (resp *AsyncUpdateID, err error)
+	UpdateDistinctAttribute(request string) (resp *Task, err error)
+	ResetDistinctAttribute() (resp *Task, err error)
 	GetSearchableAttributes() (resp *[]string, err error)
-	UpdateSearchableAttributes(request *[]string) (resp *AsyncUpdateID, err error)
-	ResetSearchableAttributes() (resp *AsyncUpdateID, err error)
+	UpdateSearchableAttributes(request *[]string) (resp *Task, err error)
+	ResetSearchableAttributes() (resp *Task, err error)
 	GetDisplayedAttributes() (resp *[]string, err error)
-	UpdateDisplayedAttributes(request *[]string) (resp *AsyncUpdateID, err error)
-	ResetDisplayedAttributes() (resp *AsyncUpdateID, err error)
+	UpdateDisplayedAttributes(request *[]string) (resp *Task, err error)
+	ResetDisplayedAttributes() (resp *Task, err error)
 	GetStopWords() (resp *[]string, err error)
-	UpdateStopWords(request *[]string) (resp *AsyncUpdateID, err error)
-	ResetStopWords() (resp *AsyncUpdateID, err error)
+	UpdateStopWords(request *[]string) (resp *Task, err error)
+	ResetStopWords() (resp *Task, err error)
 	GetSynonyms() (resp *map[string][]string, err error)
-	UpdateSynonyms(request *map[string][]string) (resp *AsyncUpdateID, err error)
-	ResetSynonyms() (resp *AsyncUpdateID, err error)
+	UpdateSynonyms(request *map[string][]string) (resp *Task, err error)
+	ResetSynonyms() (resp *Task, err error)
 	GetFilterableAttributes() (resp *[]string, err error)
-	UpdateFilterableAttributes(request *[]string) (resp *AsyncUpdateID, err error)
-	ResetFilterableAttributes() (resp *AsyncUpdateID, err error)
+	UpdateFilterableAttributes(request *[]string) (resp *Task, err error)
+	ResetFilterableAttributes() (resp *Task, err error)
 
-	WaitForPendingUpdate(ctx context.Context, interval time.Duration, updateID *AsyncUpdateID) (UpdateStatus, error)
-	DefaultWaitForPendingUpdate(updateID *AsyncUpdateID) (UpdateStatus, error)
+	WaitForTask(ctx context.Context, interval time.Duration, taskID *Task) (*Task, error)
+	DefaultWaitForTask(taskID *Task) (*Task, error)
 }
 
 var _ IndexInterface = &Index{}
@@ -106,34 +106,36 @@ func (i Index) FetchPrimaryKey() (resp *string, err error) {
 	return &index.PrimaryKey, nil
 }
 
-func (i Index) UpdateIndex(primaryKey string) (resp *Index, err error) {
+func (i Index) UpdateIndex(primaryKey string) (resp *Task, err error) {
 	request := &UpdateIndexRequest{
 		PrimaryKey: primaryKey,
 	}
-	i.PrimaryKey = primaryKey
+	i.PrimaryKey = primaryKey //nolint:golint,staticcheck
+	resp = &Task{}
 
 	req := internalRequest{
 		endpoint:            "/indexes/" + i.UID,
 		method:              http.MethodPut,
 		contentType:         contentTypeJSON,
 		withRequest:         request,
-		withResponse:        &i,
-		acceptedStatusCodes: []int{http.StatusOK},
+		withResponse:        resp,
+		acceptedStatusCodes: []int{http.StatusAccepted},
 		functionName:        "UpdateIndex",
 	}
 	if err := i.client.executeRequest(req); err != nil {
 		return nil, err
 	}
-	return &i, nil
+	return resp, nil
 }
 
 func (i Index) Delete(uid string) (ok bool, err error) {
+	resp := &Task{}
 	req := internalRequest{
 		endpoint:            "/indexes/" + uid,
 		method:              http.MethodDelete,
 		withRequest:         nil,
-		withResponse:        nil,
-		acceptedStatusCodes: []int{http.StatusNoContent},
+		withResponse:        resp,
+		acceptedStatusCodes: []int{http.StatusAccepted},
 		functionName:        "Delete",
 	}
 	// err is not nil if status code is not 204 StatusNoContent
@@ -159,15 +161,15 @@ func (i Index) GetStats() (resp *StatsIndex, err error) {
 	return resp, nil
 }
 
-func (i Index) GetUpdateStatus(updateID int64) (resp *Update, err error) {
-	resp = &Update{}
+func (i Index) GetTask(taskID int64) (resp *Task, err error) {
+	resp = &Task{}
 	req := internalRequest{
-		endpoint:            "/indexes/" + i.UID + "/updates/" + strconv.FormatInt(updateID, 10),
+		endpoint:            "/indexes/" + i.UID + "/tasks/" + strconv.FormatInt(taskID, 10),
 		method:              http.MethodGet,
 		withRequest:         nil,
 		withResponse:        resp,
 		acceptedStatusCodes: []int{http.StatusOK},
-		functionName:        "GetUpdateStatus",
+		functionName:        "GetTask",
 	}
 	if err := i.client.executeRequest(req); err != nil {
 		return nil, err
@@ -175,15 +177,15 @@ func (i Index) GetUpdateStatus(updateID int64) (resp *Update, err error) {
 	return resp, nil
 }
 
-func (i Index) GetAllUpdateStatus() (resp *[]Update, err error) {
-	resp = &[]Update{}
+func (i Index) GetTasks() (resp *ResultTask, err error) {
+	resp = &ResultTask{}
 	req := internalRequest{
-		endpoint:            "/indexes/" + i.UID + "/updates",
+		endpoint:            "/indexes/" + i.UID + "/tasks",
 		method:              http.MethodGet,
 		withRequest:         nil,
 		withResponse:        &resp,
 		acceptedStatusCodes: []int{http.StatusOK},
-		functionName:        "GetAllUpdateStatus",
+		functionName:        "GetTasks",
 	}
 	if err := i.client.executeRequest(req); err != nil {
 		return nil, err
@@ -191,33 +193,21 @@ func (i Index) GetAllUpdateStatus() (resp *[]Update, err error) {
 	return resp, nil
 }
 
-// DefaultWaitForPendingUpdate checks each 50ms the status of a WaitForPendingUpdate.
-// This is a default implementation of WaitForPendingUpdate.
-func (i Index) DefaultWaitForPendingUpdate(updateID *AsyncUpdateID) (UpdateStatus, error) {
+// DefaultWaitForTask checks each 50ms the status of a WaitForTask.
+// This is a default implementation of WaitForTask.
+func (i Index) DefaultWaitForTask(taskID *Task) (*Task, error) {
 	ctx, cancelFunc := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancelFunc()
-	return i.WaitForPendingUpdate(ctx, time.Millisecond*50, updateID)
+	return i.WaitForTask(ctx, time.Millisecond*50, taskID)
 }
 
-// WaitForPendingUpdate waits for the end of an update.
+// WaitForTask waits for a task to be processed.
 // The function will check by regular interval provided in parameter interval
-// the UpdateStatus. If it is not UpdateStatusEnqueued or the ctx cancelled
-// we return the UpdateStatus.
-func (i Index) WaitForPendingUpdate(
+// the TaskStatus. If it is not TaskStatusEnqueued or the ctx cancelled
+// we return the TaskStatus.
+func (i Index) WaitForTask(
 	ctx context.Context,
 	interval time.Duration,
-	updateID *AsyncUpdateID) (UpdateStatus, error) {
-	for {
-		if err := ctx.Err(); err != nil {
-			return "", err
-		}
-		update, err := i.GetUpdateStatus(updateID.UpdateID)
-		if err != nil {
-			return UpdateStatusUnknown, nil
-		}
-		if update.Status != UpdateStatusEnqueued && update.Status != UpdateStatusProcessing {
-			return update.Status, nil
-		}
-		time.Sleep(interval)
-	}
+	taskID *Task) (*Task, error) {
+	return i.client.WaitForTask(ctx, interval, taskID)
 }

--- a/index.go
+++ b/index.go
@@ -68,8 +68,8 @@ type IndexInterface interface {
 	UpdateFilterableAttributes(request *[]string) (resp *Task, err error)
 	ResetFilterableAttributes() (resp *Task, err error)
 
-	WaitForTask(ctx context.Context, interval time.Duration, taskID *Task) (*Task, error)
-	DefaultWaitForTask(taskID *Task) (*Task, error)
+	WaitForTask(ctx context.Context, interval time.Duration, task *Task) (*Task, error)
+	DefaultWaitForTask(task *Task) (*Task, error)
 }
 
 var _ IndexInterface = &Index{}
@@ -208,6 +208,6 @@ func (i Index) DefaultWaitForTask(taskID *Task) (*Task, error) {
 func (i Index) WaitForTask(
 	ctx context.Context,
 	interval time.Duration,
-	taskID *Task) (*Task, error) {
-	return i.client.WaitForTask(ctx, interval, taskID)
+	task *Task) (*Task, error) {
+	return i.client.WaitForTask(ctx, interval, task)
 }

--- a/index_documents.go
+++ b/index_documents.go
@@ -55,8 +55,8 @@ func (i Index) GetDocuments(request *DocumentsRequest, resp interface{}) error {
 	return nil
 }
 
-func (i Index) addDocuments(documentsPtr interface{}, contentType string, primaryKey ...string) (resp *AsyncUpdateID, err error) {
-	resp = &AsyncUpdateID{}
+func (i Index) addDocuments(documentsPtr interface{}, contentType string, primaryKey ...string) (resp *Task, err error) {
+	resp = &Task{}
 	endpoint := ""
 	if primaryKey == nil {
 		endpoint = "/indexes/" + i.UID + "/documents"
@@ -79,15 +79,15 @@ func (i Index) addDocuments(documentsPtr interface{}, contentType string, primar
 	return resp, nil
 }
 
-func (i Index) AddDocuments(documentsPtr interface{}, primaryKey ...string) (resp *AsyncUpdateID, err error) {
+func (i Index) AddDocuments(documentsPtr interface{}, primaryKey ...string) (resp *Task, err error) {
 	return i.addDocuments(documentsPtr, contentTypeJSON, primaryKey...)
 }
 
-func (i Index) AddDocumentsInBatches(documentsPtr interface{}, batchSize int, primaryKey ...string) (resp []AsyncUpdateID, err error) {
+func (i Index) AddDocumentsInBatches(documentsPtr interface{}, batchSize int, primaryKey ...string) (resp []Task, err error) {
 	arr := reflect.ValueOf(documentsPtr)
 	lenDocs := arr.Len()
 	numBatches := int(math.Ceil(float64(lenDocs) / float64(batchSize)))
-	resp = make([]AsyncUpdateID, numBatches)
+	resp = make([]Task, numBatches)
 
 	for j := 0; j < numBatches; j++ {
 		end := (j + 1) * batchSize
@@ -117,12 +117,12 @@ func (i Index) AddDocumentsInBatches(documentsPtr interface{}, batchSize int, pr
 	return resp, nil
 }
 
-func (i Index) AddDocumentsCsv(documents []byte, primaryKey ...string) (resp *AsyncUpdateID, err error) {
+func (i Index) AddDocumentsCsv(documents []byte, primaryKey ...string) (resp *Task, err error) {
 	// []byte avoids JSON conversion in Client.sendRequest()
 	return i.addDocuments(documents, contentTypeCSV, primaryKey...)
 }
 
-func (i Index) AddDocumentsCsvFromReader(documents io.Reader, primaryKey ...string) (resp *AsyncUpdateID, err error) {
+func (i Index) AddDocumentsCsvFromReader(documents io.Reader, primaryKey ...string) (resp *Task, err error) {
 	// Using io.Reader would avoid JSON conversion in Client.sendRequest(), but
 	// read content to memory anyway because of problems with streamed bodies
 	data, err := ioutil.ReadAll(documents)
@@ -132,12 +132,12 @@ func (i Index) AddDocumentsCsvFromReader(documents io.Reader, primaryKey ...stri
 	return i.addDocuments(data, contentTypeCSV, primaryKey...)
 }
 
-func (i Index) AddDocumentsCsvInBatches(documents []byte, batchSize int, primaryKey ...string) (resp []AsyncUpdateID, err error) {
+func (i Index) AddDocumentsCsvInBatches(documents []byte, batchSize int, primaryKey ...string) (resp []Task, err error) {
 	// Reuse io.Reader implementation
 	return i.AddDocumentsCsvFromReaderInBatches(bytes.NewReader(documents), batchSize, primaryKey...)
 }
 
-func (i Index) AddDocumentsCsvFromReaderInBatches(documents io.Reader, batchSize int, primaryKey ...string) (resp []AsyncUpdateID, err error) {
+func (i Index) AddDocumentsCsvFromReaderInBatches(documents io.Reader, batchSize int, primaryKey ...string) (resp []Task, err error) {
 	// Because of the possibility of multiline fields it's not safe to split
 	// into batches by lines, we'll have to parse the file and reassemble it
 	// into smaller parts. RFC 4180 compliant input with a header row is
@@ -147,12 +147,12 @@ func (i Index) AddDocumentsCsvFromReaderInBatches(documents io.Reader, batchSize
 	// be added successfully.
 
 	var (
-		responses []AsyncUpdateID
+		responses []Task
 		header    []string
 		records   [][]string
 	)
 
-	sendCsvRecords := func(records [][]string) (*AsyncUpdateID, error) {
+	sendCsvRecords := func(records [][]string) (*Task, error) {
 		b := new(bytes.Buffer)
 		w := csv.NewWriter(b)
 		w.UseCRLF = true // Keep output RFC 4180 compliant
@@ -215,12 +215,12 @@ func (i Index) AddDocumentsCsvFromReaderInBatches(documents io.Reader, batchSize
 	return responses, nil
 }
 
-func (i Index) AddDocumentsNdjson(documents []byte, primaryKey ...string) (resp *AsyncUpdateID, err error) {
+func (i Index) AddDocumentsNdjson(documents []byte, primaryKey ...string) (resp *Task, err error) {
 	// []byte avoids JSON conversion in Client.sendRequest()
 	return i.addDocuments([]byte(documents), contentTypeNDJSON, primaryKey...)
 }
 
-func (i Index) AddDocumentsNdjsonFromReader(documents io.Reader, primaryKey ...string) (resp *AsyncUpdateID, err error) {
+func (i Index) AddDocumentsNdjsonFromReader(documents io.Reader, primaryKey ...string) (resp *Task, err error) {
 	// Using io.Reader would avoid JSON conversion in Client.sendRequest(), but
 	// read content to memory anyway because of problems with streamed bodies
 	data, err := ioutil.ReadAll(documents)
@@ -230,19 +230,19 @@ func (i Index) AddDocumentsNdjsonFromReader(documents io.Reader, primaryKey ...s
 	return i.addDocuments(data, contentTypeNDJSON, primaryKey...)
 }
 
-func (i Index) AddDocumentsNdjsonInBatches(documents []byte, batchSize int, primaryKey ...string) (resp []AsyncUpdateID, err error) {
+func (i Index) AddDocumentsNdjsonInBatches(documents []byte, batchSize int, primaryKey ...string) (resp []Task, err error) {
 	// Reuse io.Reader implementation
 	return i.AddDocumentsNdjsonFromReaderInBatches(bytes.NewReader(documents), batchSize, primaryKey...)
 }
 
-func (i Index) AddDocumentsNdjsonFromReaderInBatches(documents io.Reader, batchSize int, primaryKey ...string) (resp []AsyncUpdateID, err error) {
+func (i Index) AddDocumentsNdjsonFromReaderInBatches(documents io.Reader, batchSize int, primaryKey ...string) (resp []Task, err error) {
 	// NDJSON files supposed to contain a valid JSON document in each line, so
 	// it's safe to split by lines.
 	// Lines are read and sent continuously to avoid reading all content into
 	// memory. However, this means that only part of the documents might be
 	// added successfully.
 
-	sendNdjsonLines := func(lines []string) (*AsyncUpdateID, error) {
+	sendNdjsonLines := func(lines []string) (*Task, error) {
 		b := new(bytes.Buffer)
 		for _, line := range lines {
 			_, err := b.WriteString(line)
@@ -263,7 +263,7 @@ func (i Index) AddDocumentsNdjsonFromReaderInBatches(documents io.Reader, batchS
 	}
 
 	var (
-		responses []AsyncUpdateID
+		responses []Task
 		lines     []string
 	)
 
@@ -303,8 +303,8 @@ func (i Index) AddDocumentsNdjsonFromReaderInBatches(documents io.Reader, batchS
 	return responses, nil
 }
 
-func (i Index) UpdateDocuments(documentsPtr interface{}, primaryKey ...string) (resp *AsyncUpdateID, err error) {
-	resp = &AsyncUpdateID{}
+func (i Index) UpdateDocuments(documentsPtr interface{}, primaryKey ...string) (resp *Task, err error) {
+	resp = &Task{}
 	endpoint := ""
 	if primaryKey == nil {
 		endpoint = "/indexes/" + i.UID + "/documents"
@@ -327,11 +327,11 @@ func (i Index) UpdateDocuments(documentsPtr interface{}, primaryKey ...string) (
 	return resp, nil
 }
 
-func (i Index) UpdateDocumentsInBatches(documentsPtr interface{}, batchSize int, primaryKey ...string) (resp []AsyncUpdateID, err error) {
+func (i Index) UpdateDocumentsInBatches(documentsPtr interface{}, batchSize int, primaryKey ...string) (resp []Task, err error) {
 	arr := reflect.ValueOf(documentsPtr)
 	lenDocs := arr.Len()
 	numBatches := int(math.Ceil(float64(lenDocs) / float64(batchSize)))
-	resp = make([]AsyncUpdateID, numBatches)
+	resp = make([]Task, numBatches)
 
 	for j := 0; j < numBatches; j++ {
 		end := (j + 1) * batchSize
@@ -360,8 +360,8 @@ func (i Index) UpdateDocumentsInBatches(documentsPtr interface{}, batchSize int,
 	return resp, nil
 }
 
-func (i Index) DeleteDocument(identifier string) (resp *AsyncUpdateID, err error) {
-	resp = &AsyncUpdateID{}
+func (i Index) DeleteDocument(identifier string) (resp *Task, err error) {
+	resp = &Task{}
 	req := internalRequest{
 		endpoint:            "/indexes/" + i.UID + "/documents/" + identifier,
 		method:              http.MethodDelete,
@@ -376,8 +376,8 @@ func (i Index) DeleteDocument(identifier string) (resp *AsyncUpdateID, err error
 	return resp, nil
 }
 
-func (i Index) DeleteDocuments(identifier []string) (resp *AsyncUpdateID, err error) {
-	resp = &AsyncUpdateID{}
+func (i Index) DeleteDocuments(identifier []string) (resp *Task, err error) {
+	resp = &Task{}
 	req := internalRequest{
 		endpoint:            "/indexes/" + i.UID + "/documents/delete-batch",
 		method:              http.MethodPost,
@@ -393,8 +393,8 @@ func (i Index) DeleteDocuments(identifier []string) (resp *AsyncUpdateID, err er
 	return resp, nil
 }
 
-func (i Index) DeleteAllDocuments() (resp *AsyncUpdateID, err error) {
-	resp = &AsyncUpdateID{}
+func (i Index) DeleteAllDocuments() (resp *Task, err error) {
+	resp = &Task{}
 	req := internalRequest{
 		endpoint:            "/indexes/" + i.UID + "/documents",
 		method:              http.MethodDelete,

--- a/index_documents_test.go
+++ b/index_documents_test.go
@@ -22,39 +22,43 @@ func TestIndex_AddDocuments(t *testing.T) {
 	tests := []struct {
 		name          string
 		args          args
-		wantResp      *AsyncUpdateID
+		wantResp      *Task
 		expectedError Error
 	}{
 		{
 			name: "TestIndexBasicAddDocuments",
 			args: args{
-				UID:    "1",
+				UID:    "TestIndexBasicAddDocuments",
 				client: defaultClient,
 				documentsPtr: []map[string]interface{}{
 					{"ID": "123", "Name": "Pride and Prejudice"},
 				},
 			},
-			wantResp: &AsyncUpdateID{
-				UpdateID: 0,
+			wantResp: &Task{
+				UID:    0,
+				Status: "enqueued",
+				Type:   "documentAddition",
 			},
 		},
 		{
 			name: "TestIndexAddDocumentsWithCustomClient",
 			args: args{
-				UID:    "2",
+				UID:    "TestIndexAddDocumentsWithCustomClient",
 				client: customClient,
 				documentsPtr: []map[string]interface{}{
 					{"ID": "123", "Name": "Pride and Prejudice"},
 				},
 			},
-			wantResp: &AsyncUpdateID{
-				UpdateID: 0,
+			wantResp: &Task{
+				UID:    0,
+				Status: "enqueued",
+				Type:   "documentAddition",
 			},
 		},
 		{
 			name: "TestIndexMultipleAddDocuments",
 			args: args{
-				UID:    "2",
+				UID:    "TestIndexMultipleAddDocuments",
 				client: defaultClient,
 				documentsPtr: []map[string]interface{}{
 					{"ID": "1", "Name": "Alice In Wonderland"},
@@ -62,40 +66,46 @@ func TestIndex_AddDocuments(t *testing.T) {
 					{"ID": "456", "Name": "Le Petit Prince"},
 				},
 			},
-			wantResp: &AsyncUpdateID{
-				UpdateID: 0,
+			wantResp: &Task{
+				UID:    0,
+				Status: "enqueued",
+				Type:   "documentAddition",
 			},
 		},
 		{
 			name: "TestIndexBasicAddDocumentsWithIntID",
 			args: args{
-				UID:    "3",
+				UID:    "TestIndexBasicAddDocumentsWithIntID",
 				client: defaultClient,
 				documentsPtr: []map[string]interface{}{
 					{"BookID": float64(123), "Title": "Pride and Prejudice"},
 				},
 			},
-			wantResp: &AsyncUpdateID{
-				UpdateID: 0,
+			wantResp: &Task{
+				UID:    0,
+				Status: "enqueued",
+				Type:   "documentAddition",
 			},
 		},
 		{
 			name: "TestIndexAddDocumentsWithIntIDWithCustomClient",
 			args: args{
-				UID:    "4",
+				UID:    "TestIndexAddDocumentsWithIntIDWithCustomClient",
 				client: customClient,
 				documentsPtr: []map[string]interface{}{
 					{"BookID": float64(123), "Title": "Pride and Prejudice"},
 				},
 			},
-			wantResp: &AsyncUpdateID{
-				UpdateID: 0,
+			wantResp: &Task{
+				UID:    0,
+				Status: "enqueued",
+				Type:   "documentAddition",
 			},
 		},
 		{
 			name: "TestIndexMultipleAddDocumentsWithIntID",
 			args: args{
-				UID:    "5",
+				UID:    "TestIndexMultipleAddDocumentsWithIntID",
 				client: defaultClient,
 				documentsPtr: []map[string]interface{}{
 					{"BookID": float64(1), "Title": "Alice In Wonderland"},
@@ -103,8 +113,10 @@ func TestIndex_AddDocuments(t *testing.T) {
 					{"BookID": float64(456), "Title": "Le Petit Prince", "Tag": "Conte"},
 				},
 			},
-			wantResp: &AsyncUpdateID{
-				UpdateID: 0,
+			wantResp: &Task{
+				UID:    0,
+				Status: "enqueued",
+				Type:   "documentAddition",
 			},
 		},
 	}
@@ -115,9 +127,14 @@ func TestIndex_AddDocuments(t *testing.T) {
 			t.Cleanup(cleanup(c))
 
 			gotResp, err := i.AddDocuments(tt.args.documentsPtr)
-			require.GreaterOrEqual(t, gotResp.UpdateID, tt.wantResp.UpdateID)
+			require.GreaterOrEqual(t, gotResp.UID, tt.wantResp.UID)
+			require.Equal(t, gotResp.Status, tt.wantResp.Status)
+			require.Equal(t, gotResp.Type, tt.wantResp.Type)
+			require.Equal(t, gotResp.IndexUID, tt.args.UID)
+			require.NotZero(t, gotResp.EnqueuedAt)
 			require.NoError(t, err)
-			testWaitForPendingUpdate(t, i, gotResp)
+
+			testWaitForTask(t, i, gotResp)
 			var documents []map[string]interface{}
 			err = i.GetDocuments(&DocumentsRequest{
 				Limit: 3,
@@ -138,40 +155,44 @@ func TestIndex_AddDocumentsWithPrimaryKey(t *testing.T) {
 	tests := []struct {
 		name     string
 		args     args
-		wantResp *AsyncUpdateID
+		wantResp *Task
 	}{
 		{
 			name: "TestIndexBasicAddDocumentsWithPrimaryKey",
 			args: args{
-				UID:    "1",
+				UID:    "TestIndexBasicAddDocumentsWithPrimaryKey",
 				client: defaultClient,
 				documentsPtr: []map[string]interface{}{
 					{"key": "123", "Name": "Pride and Prejudice"},
 				},
 				primaryKey: "key",
 			},
-			wantResp: &AsyncUpdateID{
-				UpdateID: 0,
+			wantResp: &Task{
+				UID:    0,
+				Status: "enqueued",
+				Type:   "documentAddition",
 			},
 		},
 		{
 			name: "TestIndexAddDocumentsWithPrimaryKeyWithCustomClient",
 			args: args{
-				UID:    "2",
+				UID:    "TestIndexAddDocumentsWithPrimaryKeyWithCustomClient",
 				client: customClient,
 				documentsPtr: []map[string]interface{}{
 					{"key": "123", "Name": "Pride and Prejudice"},
 				},
 				primaryKey: "key",
 			},
-			wantResp: &AsyncUpdateID{
-				UpdateID: 0,
+			wantResp: &Task{
+				UID:    0,
+				Status: "enqueued",
+				Type:   "documentAddition",
 			},
 		},
 		{
 			name: "TestIndexMultipleAddDocumentsWithPrimaryKey",
 			args: args{
-				UID:    "3",
+				UID:    "TestIndexMultipleAddDocumentsWithPrimaryKey",
 				client: defaultClient,
 				documentsPtr: []map[string]interface{}{
 					{"key": "1", "Name": "Alice In Wonderland"},
@@ -180,28 +201,32 @@ func TestIndex_AddDocumentsWithPrimaryKey(t *testing.T) {
 				},
 				primaryKey: "key",
 			},
-			wantResp: &AsyncUpdateID{
-				UpdateID: 0,
+			wantResp: &Task{
+				UID:    0,
+				Status: "enqueued",
+				Type:   "documentAddition",
 			},
 		},
 		{
 			name: "TestIndexAddDocumentsWithPrimaryKeyWithIntID",
 			args: args{
-				UID:    "4",
+				UID:    "TestIndexAddDocumentsWithPrimaryKeyWithIntID",
 				client: defaultClient,
 				documentsPtr: []map[string]interface{}{
 					{"key": float64(123), "Name": "Pride and Prejudice"},
 				},
 				primaryKey: "key",
 			},
-			wantResp: &AsyncUpdateID{
-				UpdateID: 0,
+			wantResp: &Task{
+				UID:    0,
+				Status: "enqueued",
+				Type:   "documentAddition",
 			},
 		},
 		{
 			name: "TestIndexMultipleAddDocumentsWithPrimaryKeyWithIntID",
 			args: args{
-				UID:    "5",
+				UID:    "TestIndexMultipleAddDocumentsWithPrimaryKeyWithIntID",
 				client: defaultClient,
 				documentsPtr: []map[string]interface{}{
 					{"key": float64(1), "Name": "Alice In Wonderland"},
@@ -210,8 +235,10 @@ func TestIndex_AddDocumentsWithPrimaryKey(t *testing.T) {
 				},
 				primaryKey: "key",
 			},
-			wantResp: &AsyncUpdateID{
-				UpdateID: 0,
+			wantResp: &Task{
+				UID:    0,
+				Status: "enqueued",
+				Type:   "documentAddition",
 			},
 		},
 	}
@@ -222,10 +249,14 @@ func TestIndex_AddDocumentsWithPrimaryKey(t *testing.T) {
 			t.Cleanup(cleanup(c))
 
 			gotResp, err := i.AddDocuments(tt.args.documentsPtr, tt.args.primaryKey)
-			require.GreaterOrEqual(t, gotResp.UpdateID, tt.wantResp.UpdateID)
+			require.GreaterOrEqual(t, gotResp.UID, tt.wantResp.UID)
+			require.Equal(t, gotResp.Status, tt.wantResp.Status)
+			require.Equal(t, gotResp.Type, tt.wantResp.Type)
+			require.Equal(t, gotResp.IndexUID, tt.args.UID)
+			require.NotZero(t, gotResp.EnqueuedAt)
 			require.NoError(t, err)
 
-			testWaitForPendingUpdate(t, i, gotResp)
+			testWaitForTask(t, i, gotResp)
 
 			var documents []map[string]interface{}
 			err = i.GetDocuments(&DocumentsRequest{Limit: 3}, &documents)
@@ -254,13 +285,13 @@ func TestIndex_AddDocumentsInBatches(t *testing.T) {
 	testsNoKey := []struct {
 		name          string
 		args          argsNoKey
-		wantResp      []AsyncUpdateID
+		wantResp      []Task
 		expectedError Error
 	}{
 		{
 			name: "TestIndexBasicAddDocumentsInBatches",
 			args: argsNoKey{
-				UID:    "0",
+				UID:    "TestIndexBasicAddDocumentsInBatches",
 				client: defaultClient,
 				documentsPtr: []map[string]interface{}{
 					{"ID": "122", "Name": "Pride and Prejudice"},
@@ -270,9 +301,17 @@ func TestIndex_AddDocumentsInBatches(t *testing.T) {
 				},
 				batchSize: 2,
 			},
-			wantResp: []AsyncUpdateID{
-				{UpdateID: 0},
-				{UpdateID: 1},
+			wantResp: []Task{
+				{
+					UID:    0,
+					Status: "enqueued",
+					Type:   "documentAddition",
+				},
+				{
+					UID:    1,
+					Status: "enqueued",
+					Type:   "documentAddition",
+				},
 			},
 		},
 	}
@@ -280,13 +319,13 @@ func TestIndex_AddDocumentsInBatches(t *testing.T) {
 	testsWithKey := []struct {
 		name          string
 		args          argsWithKey
-		wantResp      []AsyncUpdateID
+		wantResp      []Task
 		expectedError Error
 	}{
 		{
-			name: "TestIndexBasicAddDocumentsInBatches",
+			name: "TestIndexBasicAddDocumentsInBatchesWithKey",
 			args: argsWithKey{
-				UID:    "0",
+				UID:    "TestIndexBasicAddDocumentsInBatchesWithKey",
 				client: defaultClient,
 				documentsPtr: []map[string]interface{}{
 					{"ID": "122", "Name": "Pride and Prejudice"},
@@ -297,9 +336,17 @@ func TestIndex_AddDocumentsInBatches(t *testing.T) {
 				batchSize:  2,
 				primaryKey: "ID",
 			},
-			wantResp: []AsyncUpdateID{
-				{UpdateID: 0},
-				{UpdateID: 1},
+			wantResp: []Task{
+				{
+					UID:    0,
+					Status: "enqueued",
+					Type:   "documentAddition",
+				},
+				{
+					UID:    1,
+					Status: "enqueued",
+					Type:   "documentAddition",
+				},
 			},
 		},
 	}
@@ -311,10 +358,17 @@ func TestIndex_AddDocumentsInBatches(t *testing.T) {
 			t.Cleanup(cleanup(c))
 
 			gotResp, err := i.AddDocumentsInBatches(tt.args.documentsPtr, tt.args.batchSize)
-			require.Equal(t, gotResp, tt.wantResp)
-			require.NoError(t, err)
 
-			testWaitForPendingBatchUpdate(t, i, gotResp)
+			require.NoError(t, err)
+			for i := 0; i < 2; i++ {
+				require.GreaterOrEqual(t, gotResp[i].UID, tt.wantResp[i].UID)
+				require.Equal(t, gotResp[i].Status, tt.wantResp[i].Status)
+				require.Equal(t, gotResp[i].Type, tt.wantResp[i].Type)
+				require.Equal(t, gotResp[i].IndexUID, tt.args.UID)
+				require.NotZero(t, gotResp[i].EnqueuedAt)
+			}
+
+			testWaitForBatchTask(t, i, gotResp)
 
 			var documents []map[string]interface{}
 			err = i.GetDocuments(&DocumentsRequest{
@@ -333,10 +387,17 @@ func TestIndex_AddDocumentsInBatches(t *testing.T) {
 			t.Cleanup(cleanup(c))
 
 			gotResp, err := i.AddDocumentsInBatches(tt.args.documentsPtr, tt.args.batchSize, tt.args.primaryKey)
-			require.Equal(t, gotResp, tt.wantResp)
-			require.NoError(t, err)
 
-			testWaitForPendingBatchUpdate(t, i, gotResp)
+			require.NoError(t, err)
+			for i := 0; i < 2; i++ {
+				require.GreaterOrEqual(t, gotResp[i].UID, tt.wantResp[i].UID)
+				require.Equal(t, gotResp[i].Status, tt.wantResp[i].Status)
+				require.Equal(t, gotResp[i].Type, tt.wantResp[i].Type)
+				require.Equal(t, gotResp[i].IndexUID, tt.args.UID)
+				require.NotZero(t, gotResp[i].EnqueuedAt)
+			}
+
+			testWaitForBatchTask(t, i, gotResp)
 
 			var documents []map[string]interface{}
 			err = i.GetDocuments(&DocumentsRequest{
@@ -384,25 +445,29 @@ var testCsvDocuments = []byte(`id,name
 
 func TestIndex_AddDocumentsCsv(t *testing.T) {
 	type args struct {
-		uid       string
+		UID       string
 		client    *Client
 		documents []byte
 	}
 	type testData struct {
 		name     string
 		args     args
-		wantResp *AsyncUpdateID
+		wantResp *Task
 	}
 
 	tests := []testData{
 		{
 			name: "TestIndexBasic",
 			args: args{
-				uid:       "csv",
+				UID:       "csv",
 				client:    defaultClient,
 				documents: testCsvDocuments,
 			},
-			wantResp: &AsyncUpdateID{UpdateID: 0},
+			wantResp: &Task{
+				UID:    0,
+				Status: "enqueued",
+				Type:   "documentAddition",
+			},
 		},
 	}
 
@@ -412,7 +477,7 @@ func TestIndex_AddDocumentsCsv(t *testing.T) {
 			name += "FromReader"
 		}
 
-		uid := tt.args.uid
+		uid := tt.args.UID
 		if testReader {
 			uid += "-reader"
 		} else {
@@ -427,7 +492,7 @@ func TestIndex_AddDocumentsCsv(t *testing.T) {
 			wantDocs := testParseCsvDocuments(t, bytes.NewReader(tt.args.documents))
 
 			var (
-				gotResp *AsyncUpdateID
+				gotResp *Task
 				err     error
 			)
 
@@ -438,9 +503,12 @@ func TestIndex_AddDocumentsCsv(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			require.Equal(t, gotResp, tt.wantResp)
+			require.GreaterOrEqual(t, gotResp.UID, tt.wantResp.UID)
+			require.Equal(t, gotResp.Status, tt.wantResp.Status)
+			require.Equal(t, gotResp.Type, tt.wantResp.Type)
+			require.NotZero(t, gotResp.EnqueuedAt)
 
-			testWaitForPendingUpdate(t, i, gotResp)
+			testWaitForTask(t, i, gotResp)
 
 			var documents []map[string]interface{}
 			err = i.GetDocuments(&DocumentsRequest{}, &documents)
@@ -458,7 +526,7 @@ func TestIndex_AddDocumentsCsv(t *testing.T) {
 
 func TestIndex_AddDocumentsCsvInBatches(t *testing.T) {
 	type args struct {
-		uid       string
+		UID       string
 		client    *Client
 		batchSize int
 		documents []byte
@@ -466,22 +534,34 @@ func TestIndex_AddDocumentsCsvInBatches(t *testing.T) {
 	type testData struct {
 		name     string
 		args     args
-		wantResp []AsyncUpdateID
+		wantResp []Task
 	}
 
 	tests := []testData{
 		{
 			name: "TestIndexBasic",
 			args: args{
-				uid:       "csvbatch",
+				UID:       "csvbatch",
 				client:    defaultClient,
 				batchSize: 2,
 				documents: testCsvDocuments,
 			},
-			wantResp: []AsyncUpdateID{
-				{UpdateID: 0},
-				{UpdateID: 1},
-				{UpdateID: 2},
+			wantResp: []Task{
+				{
+					UID:    0,
+					Status: "enqueued",
+					Type:   "documentAddition",
+				},
+				{
+					UID:    1,
+					Status: "enqueued",
+					Type:   "documentAddition",
+				},
+				{
+					UID:    2,
+					Status: "enqueued",
+					Type:   "documentAddition",
+				},
 			},
 		},
 	}
@@ -493,7 +573,7 @@ func TestIndex_AddDocumentsCsvInBatches(t *testing.T) {
 		}
 		name += "InBatches"
 
-		uid := tt.args.uid
+		uid := tt.args.UID
 		if testReader {
 			uid += "-reader"
 		} else {
@@ -508,7 +588,7 @@ func TestIndex_AddDocumentsCsvInBatches(t *testing.T) {
 			wantDocs := testParseCsvDocuments(t, bytes.NewReader(tt.args.documents))
 
 			var (
-				gotResp []AsyncUpdateID
+				gotResp []Task
 				err     error
 			)
 
@@ -519,9 +599,14 @@ func TestIndex_AddDocumentsCsvInBatches(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			require.Equal(t, gotResp, tt.wantResp)
+			for i := 0; i < 2; i++ {
+				require.GreaterOrEqual(t, gotResp[i].UID, tt.wantResp[i].UID)
+				require.Equal(t, gotResp[i].Status, tt.wantResp[i].Status)
+				require.Equal(t, gotResp[i].Type, tt.wantResp[i].Type)
+				require.NotZero(t, gotResp[i].EnqueuedAt)
+			}
 
-			testWaitForPendingBatchUpdate(t, i, gotResp)
+			testWaitForBatchTask(t, i, gotResp)
 
 			var documents []map[string]interface{}
 			err = i.GetDocuments(&DocumentsRequest{}, &documents)
@@ -563,25 +648,29 @@ var testNdjsonDocuments = []byte(`{"id": 1, "name": "Alice In Wonderland"}
 
 func TestIndex_AddDocumentsNdjson(t *testing.T) {
 	type args struct {
-		uid       string
+		UID       string
 		client    *Client
 		documents []byte
 	}
 	type testData struct {
 		name     string
 		args     args
-		wantResp *AsyncUpdateID
+		wantResp *Task
 	}
 
 	tests := []testData{
 		{
 			name: "TestIndexBasic",
 			args: args{
-				uid:       "ndjson",
+				UID:       "ndjson",
 				client:    defaultClient,
 				documents: testNdjsonDocuments,
 			},
-			wantResp: &AsyncUpdateID{UpdateID: 0},
+			wantResp: &Task{
+				UID:    0,
+				Status: "enqueued",
+				Type:   "documentAddition",
+			},
 		},
 	}
 
@@ -591,7 +680,7 @@ func TestIndex_AddDocumentsNdjson(t *testing.T) {
 			name += "FromReader"
 		}
 
-		uid := tt.args.uid
+		uid := tt.args.UID
 		if testReader {
 			uid += "-reader"
 		} else {
@@ -606,7 +695,7 @@ func TestIndex_AddDocumentsNdjson(t *testing.T) {
 			wantDocs := testParseNdjsonDocuments(t, bytes.NewReader(tt.args.documents))
 
 			var (
-				gotResp *AsyncUpdateID
+				gotResp *Task
 				err     error
 			)
 
@@ -617,9 +706,12 @@ func TestIndex_AddDocumentsNdjson(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			require.Equal(t, gotResp, tt.wantResp)
+			require.GreaterOrEqual(t, gotResp.UID, tt.wantResp.UID)
+			require.Equal(t, gotResp.Status, tt.wantResp.Status)
+			require.Equal(t, gotResp.Type, tt.wantResp.Type)
+			require.NotZero(t, gotResp.EnqueuedAt)
 
-			testWaitForPendingUpdate(t, i, gotResp)
+			testWaitForTask(t, i, gotResp)
 
 			var documents []map[string]interface{}
 			err = i.GetDocuments(&DocumentsRequest{}, &documents)
@@ -637,7 +729,7 @@ func TestIndex_AddDocumentsNdjson(t *testing.T) {
 
 func TestIndex_AddDocumentsNdjsonInBatches(t *testing.T) {
 	type args struct {
-		uid       string
+		UID       string
 		client    *Client
 		batchSize int
 		documents []byte
@@ -645,22 +737,34 @@ func TestIndex_AddDocumentsNdjsonInBatches(t *testing.T) {
 	type testData struct {
 		name     string
 		args     args
-		wantResp []AsyncUpdateID
+		wantResp []Task
 	}
 
 	tests := []testData{
 		{
 			name: "TestIndexBasic",
 			args: args{
-				uid:       "ndjsonbatch",
+				UID:       "ndjsonbatch",
 				client:    defaultClient,
 				batchSize: 2,
 				documents: testNdjsonDocuments,
 			},
-			wantResp: []AsyncUpdateID{
-				{UpdateID: 0},
-				{UpdateID: 1},
-				{UpdateID: 2},
+			wantResp: []Task{
+				{
+					UID:    0,
+					Status: "enqueued",
+					Type:   "documentAddition",
+				},
+				{
+					UID:    1,
+					Status: "enqueued",
+					Type:   "documentAddition",
+				},
+				{
+					UID:    2,
+					Status: "enqueued",
+					Type:   "documentAddition",
+				},
 			},
 		},
 	}
@@ -672,7 +776,7 @@ func TestIndex_AddDocumentsNdjsonInBatches(t *testing.T) {
 		}
 		name += "InBatches"
 
-		uid := tt.args.uid
+		uid := tt.args.UID
 		if testReader {
 			uid += "-reader"
 		} else {
@@ -687,7 +791,7 @@ func TestIndex_AddDocumentsNdjsonInBatches(t *testing.T) {
 			wantDocs := testParseNdjsonDocuments(t, bytes.NewReader(tt.args.documents))
 
 			var (
-				gotResp []AsyncUpdateID
+				gotResp []Task
 				err     error
 			)
 
@@ -698,9 +802,14 @@ func TestIndex_AddDocumentsNdjsonInBatches(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			require.Equal(t, gotResp, tt.wantResp)
+			for i := 0; i < 2; i++ {
+				require.GreaterOrEqual(t, gotResp[i].UID, tt.wantResp[i].UID)
+				require.Equal(t, gotResp[i].Status, tt.wantResp[i].Status)
+				require.Equal(t, gotResp[i].Type, tt.wantResp[i].Type)
+				require.NotZero(t, gotResp[i].EnqueuedAt)
+			}
 
-			testWaitForPendingBatchUpdate(t, i, gotResp)
+			testWaitForBatchTask(t, i, gotResp)
 
 			var documents []map[string]interface{}
 			err = i.GetDocuments(&DocumentsRequest{}, &documents)
@@ -724,26 +833,30 @@ func TestIndex_DeleteAllDocuments(t *testing.T) {
 	tests := []struct {
 		name     string
 		args     args
-		wantResp *AsyncUpdateID
+		wantResp *Task
 	}{
 		{
 			name: "TestIndexBasicDeleteAllDocuments",
 			args: args{
-				UID:    "indexUID",
+				UID:    "TestIndexBasicDeleteAllDocuments",
 				client: defaultClient,
 			},
-			wantResp: &AsyncUpdateID{
-				UpdateID: 1,
+			wantResp: &Task{
+				UID:    1,
+				Status: "enqueued",
+				Type:   "clearAll",
 			},
 		},
 		{
 			name: "TestIndexDeleteAllDocumentsWithCustomClient",
 			args: args{
-				UID:    "indexUID",
+				UID:    "TestIndexDeleteAllDocumentsWithCustomClient",
 				client: customClient,
 			},
-			wantResp: &AsyncUpdateID{
-				UpdateID: 1,
+			wantResp: &Task{
+				UID:    2,
+				Status: "enqueued",
+				Type:   "clearAll",
 			},
 		},
 	}
@@ -753,12 +866,15 @@ func TestIndex_DeleteAllDocuments(t *testing.T) {
 			i := c.Index(tt.args.UID)
 			t.Cleanup(cleanup(c))
 
-			SetUpBasicIndex()
+			SetUpBasicIndex(tt.args.UID)
 			gotResp, err := i.DeleteAllDocuments()
 			require.NoError(t, err)
-			require.Equal(t, gotResp, tt.wantResp)
+			require.GreaterOrEqual(t, gotResp.UID, tt.wantResp.UID)
+			require.Equal(t, gotResp.Status, tt.wantResp.Status)
+			require.Equal(t, gotResp.Type, tt.wantResp.Type)
+			require.NotZero(t, gotResp.EnqueuedAt)
 
-			testWaitForPendingUpdate(t, i, gotResp)
+			testWaitForTask(t, i, gotResp)
 
 			var documents interface{}
 			err = i.GetDocuments(&DocumentsRequest{Limit: 5}, &documents)
@@ -779,7 +895,7 @@ func TestIndex_DeleteOneDocument(t *testing.T) {
 	tests := []struct {
 		name     string
 		args     args
-		wantResp *AsyncUpdateID
+		wantResp *Task
 	}{
 		{
 			name: "TestIndexBasicDeleteOneDocument",
@@ -791,8 +907,10 @@ func TestIndex_DeleteOneDocument(t *testing.T) {
 					{"ID": "123", "Name": "Pride and Prejudice"},
 				},
 			},
-			wantResp: &AsyncUpdateID{
-				UpdateID: 0,
+			wantResp: &Task{
+				UID:    1,
+				Status: "enqueued",
+				Type:   "documentDeletion",
 			},
 		},
 		{
@@ -805,8 +923,10 @@ func TestIndex_DeleteOneDocument(t *testing.T) {
 					{"ID": "123", "Name": "Pride and Prejudice"},
 				},
 			},
-			wantResp: &AsyncUpdateID{
-				UpdateID: 0,
+			wantResp: &Task{
+				UID:    1,
+				Status: "enqueued",
+				Type:   "documentDeletion",
 			},
 		},
 		{
@@ -821,8 +941,10 @@ func TestIndex_DeleteOneDocument(t *testing.T) {
 					{"ID": "1", "Name": "Alice In Wonderland"},
 				},
 			},
-			wantResp: &AsyncUpdateID{
-				UpdateID: 0,
+			wantResp: &Task{
+				UID:    1,
+				Status: "enqueued",
+				Type:   "documentDeletion",
 			},
 		},
 		{
@@ -835,8 +957,10 @@ func TestIndex_DeleteOneDocument(t *testing.T) {
 					{"BookID": 123, "Title": "Pride and Prejudice"},
 				},
 			},
-			wantResp: &AsyncUpdateID{
-				UpdateID: 0,
+			wantResp: &Task{
+				UID:    1,
+				Status: "enqueued",
+				Type:   "documentDeletion",
 			},
 		},
 		{
@@ -849,8 +973,10 @@ func TestIndex_DeleteOneDocument(t *testing.T) {
 					{"BookID": 123, "Title": "Pride and Prejudice"},
 				},
 			},
-			wantResp: &AsyncUpdateID{
-				UpdateID: 0,
+			wantResp: &Task{
+				UID:    1,
+				Status: "enqueued",
+				Type:   "documentDeletion",
 			},
 		},
 		{
@@ -865,8 +991,10 @@ func TestIndex_DeleteOneDocument(t *testing.T) {
 					{"BookID": 1, "Title": "Alice In Wonderland"},
 				},
 			},
-			wantResp: &AsyncUpdateID{
-				UpdateID: 0,
+			wantResp: &Task{
+				UID:    1,
+				Status: "enqueued",
+				Type:   "documentDeletion",
 			},
 		},
 	}
@@ -877,16 +1005,19 @@ func TestIndex_DeleteOneDocument(t *testing.T) {
 			t.Cleanup(cleanup(c))
 
 			gotAddResp, err := i.AddDocuments(tt.args.documentsPtr)
-			require.GreaterOrEqual(t, gotAddResp.UpdateID, tt.wantResp.UpdateID)
+			require.GreaterOrEqual(t, gotAddResp.UID, tt.wantResp.UID)
 			require.NoError(t, err)
 
-			testWaitForPendingUpdate(t, i, gotAddResp)
+			testWaitForTask(t, i, gotAddResp)
 
 			gotResp, err := i.DeleteDocument(tt.args.identifier)
 			require.NoError(t, err)
-			require.GreaterOrEqual(t, gotResp.UpdateID, tt.wantResp.UpdateID)
+			require.GreaterOrEqual(t, gotResp.UID, tt.wantResp.UID)
+			require.Equal(t, gotResp.Status, tt.wantResp.Status)
+			require.Equal(t, gotResp.Type, tt.wantResp.Type)
+			require.NotZero(t, gotResp.EnqueuedAt)
 
-			testWaitForPendingUpdate(t, i, gotResp)
+			testWaitForTask(t, i, gotResp)
 
 			var document []map[string]interface{}
 			err = i.GetDocument(tt.args.identifier, &document)
@@ -906,7 +1037,7 @@ func TestIndex_DeleteDocuments(t *testing.T) {
 	tests := []struct {
 		name     string
 		args     args
-		wantResp *AsyncUpdateID
+		wantResp *Task
 	}{
 		{
 			name: "TestIndexBasicDeleteDocument",
@@ -918,8 +1049,10 @@ func TestIndex_DeleteDocuments(t *testing.T) {
 					{ID: "123", Name: "Pride and Prejudice"},
 				},
 			},
-			wantResp: &AsyncUpdateID{
-				UpdateID: 1,
+			wantResp: &Task{
+				UID:    1,
+				Status: "enqueued",
+				Type:   "documentDeletion",
 			},
 		},
 		{
@@ -932,8 +1065,10 @@ func TestIndex_DeleteDocuments(t *testing.T) {
 					{ID: "123", Name: "Pride and Prejudice"},
 				},
 			},
-			wantResp: &AsyncUpdateID{
-				UpdateID: 1,
+			wantResp: &Task{
+				UID:    1,
+				Status: "enqueued",
+				Type:   "documentDeletion",
 			},
 		},
 		{
@@ -948,8 +1083,10 @@ func TestIndex_DeleteDocuments(t *testing.T) {
 					{ID: "1", Name: "Alice In Wonderland"},
 				},
 			},
-			wantResp: &AsyncUpdateID{
-				UpdateID: 1,
+			wantResp: &Task{
+				UID:    1,
+				Status: "enqueued",
+				Type:   "documentDeletion",
 			},
 		},
 		{
@@ -964,8 +1101,10 @@ func TestIndex_DeleteDocuments(t *testing.T) {
 					{ID: "1", Name: "Alice In Wonderland"},
 				},
 			},
-			wantResp: &AsyncUpdateID{
-				UpdateID: 1,
+			wantResp: &Task{
+				UID:    1,
+				Status: "enqueued",
+				Type:   "documentDeletion",
 			},
 		},
 	}
@@ -978,13 +1117,16 @@ func TestIndex_DeleteDocuments(t *testing.T) {
 			gotAddResp, err := i.AddDocuments(tt.args.documentsPtr)
 			require.NoError(t, err)
 
-			testWaitForPendingUpdate(t, i, gotAddResp)
+			testWaitForTask(t, i, gotAddResp)
 
 			gotResp, err := i.DeleteDocuments(tt.args.identifier)
 			require.NoError(t, err)
-			require.Equal(t, gotResp, tt.wantResp)
+			require.GreaterOrEqual(t, gotResp.UID, tt.wantResp.UID)
+			require.Equal(t, gotResp.Status, tt.wantResp.Status)
+			require.Equal(t, gotResp.Type, tt.wantResp.Type)
+			require.NotZero(t, gotResp.EnqueuedAt)
 
-			testWaitForPendingUpdate(t, i, gotResp)
+			testWaitForTask(t, i, gotResp)
 
 			var document docTest
 			for _, identifier := range tt.args.identifier {
@@ -1011,7 +1153,7 @@ func TestIndex_GetDocument(t *testing.T) {
 		{
 			name: "TestIndexBasicGetDocument",
 			args: args{
-				UID:         "indexUID",
+				UID:         "TestIndexBasicGetDocument",
 				client:      defaultClient,
 				identifier:  "123",
 				documentPtr: &docTestBooks{},
@@ -1021,7 +1163,7 @@ func TestIndex_GetDocument(t *testing.T) {
 		{
 			name: "TestIndexGetDocumentWithCustomClient",
 			args: args{
-				UID:         "indexUID",
+				UID:         "TestIndexGetDocumentWithCustomClient",
 				client:      customClient,
 				identifier:  "123",
 				documentPtr: &docTestBooks{},
@@ -1031,7 +1173,7 @@ func TestIndex_GetDocument(t *testing.T) {
 		{
 			name: "TestIndexGetDocumentWithNoExistingDocument",
 			args: args{
-				UID:         "indexUID",
+				UID:         "TestIndexGetDocumentWithNoExistingDocument",
 				client:      defaultClient,
 				identifier:  "125",
 				documentPtr: &docTestBooks{},
@@ -1044,7 +1186,7 @@ func TestIndex_GetDocument(t *testing.T) {
 			c := tt.args.client
 			i := c.Index(tt.args.UID)
 			t.Cleanup(cleanup(c))
-			SetUpBasicIndex()
+			SetUpBasicIndex(tt.args.UID)
 
 			require.Empty(t, tt.args.documentPtr)
 			err := i.GetDocument(tt.args.identifier, tt.args.documentPtr)
@@ -1069,38 +1211,42 @@ func TestIndex_UpdateDocuments(t *testing.T) {
 	tests := []struct {
 		name string
 		args args
-		want *AsyncUpdateID
+		want *Task
 	}{
 		{
 			name: "TestIndexBasicUpdateDocument",
 			args: args{
-				UID:    "indexUID",
+				UID:    "TestIndexBasicUpdateDocument",
 				client: defaultClient,
 				documentsPtr: []docTestBooks{
 					{BookID: 123, Title: "One Hundred Years of Solitude"},
 				},
 			},
-			want: &AsyncUpdateID{
-				UpdateID: 1,
+			want: &Task{
+				UID:    1,
+				Status: "enqueued",
+				Type:   "documentPartial",
 			},
 		},
 		{
 			name: "TestIndexUpdateDocumentWithCustomClient",
 			args: args{
-				UID:    "indexUID",
+				UID:    "TestIndexUpdateDocumentWithCustomClient",
 				client: defaultClient,
 				documentsPtr: []docTestBooks{
 					{BookID: 123, Title: "One Hundred Years of Solitude"},
 				},
 			},
-			want: &AsyncUpdateID{
-				UpdateID: 1,
+			want: &Task{
+				UID:    1,
+				Status: "enqueued",
+				Type:   "documentPartial",
 			},
 		},
 		{
 			name: "TestIndexUpdateDocumentOnMultipleDocuments",
 			args: args{
-				UID:    "indexUID",
+				UID:    "TestIndexUpdateDocumentOnMultipleDocuments",
 				client: defaultClient,
 				documentsPtr: []docTestBooks{
 					{BookID: 123, Title: "One Hundred Years of Solitude"},
@@ -1109,27 +1255,31 @@ func TestIndex_UpdateDocuments(t *testing.T) {
 					{BookID: 42, Title: "The Great Gatsby"},
 				},
 			},
-			want: &AsyncUpdateID{
-				UpdateID: 1,
+			want: &Task{
+				UID:    1,
+				Status: "enqueued",
+				Type:   "documentPartial",
 			},
 		},
 		{
 			name: "TestIndexUpdateDocumentWithNoExistingDocument",
 			args: args{
-				UID:    "indexUID",
+				UID:    "TestIndexUpdateDocumentWithNoExistingDocument",
 				client: defaultClient,
 				documentsPtr: []docTestBooks{
 					{BookID: 237, Title: "One Hundred Years of Solitude"},
 				},
 			},
-			want: &AsyncUpdateID{
-				UpdateID: 1,
+			want: &Task{
+				UID:    1,
+				Status: "enqueued",
+				Type:   "documentPartial",
 			},
 		},
 		{
 			name: "TestIndexUpdateDocumentWithNoExistingMultipleDocuments",
 			args: args{
-				UID:    "indexUID",
+				UID:    "TestIndexUpdateDocumentWithNoExistingMultipleDocuments",
 				client: defaultClient,
 				documentsPtr: []docTestBooks{
 					{BookID: 246, Title: "One Hundred Years of Solitude"},
@@ -1138,8 +1288,10 @@ func TestIndex_UpdateDocuments(t *testing.T) {
 					{BookID: 594, Title: "The Great Gatsby"},
 				},
 			},
-			want: &AsyncUpdateID{
-				UpdateID: 1,
+			want: &Task{
+				UID:    1,
+				Status: "enqueued",
+				Type:   "documentPartial",
 			},
 		},
 	}
@@ -1148,13 +1300,16 @@ func TestIndex_UpdateDocuments(t *testing.T) {
 			c := tt.args.client
 			i := c.Index(tt.args.UID)
 			t.Cleanup(cleanup(c))
-			SetUpBasicIndex()
+			SetUpBasicIndex(tt.args.UID)
 
 			got, err := i.UpdateDocuments(tt.args.documentsPtr)
 			require.NoError(t, err)
-			require.Equal(t, got, tt.want)
+			require.GreaterOrEqual(t, got.UID, tt.want.UID)
+			require.Equal(t, got.Status, tt.want.Status)
+			require.Equal(t, got.Type, tt.want.Type)
+			require.NotZero(t, got.EnqueuedAt)
 
-			testWaitForPendingUpdate(t, i, got)
+			testWaitForTask(t, i, got)
 
 			var document docTestBooks
 			for _, identifier := range tt.args.documentsPtr {
@@ -1177,40 +1332,44 @@ func TestIndex_UpdateDocumentsWithPrimaryKey(t *testing.T) {
 	tests := []struct {
 		name string
 		args args
-		want *AsyncUpdateID
+		want *Task
 	}{
 		{
 			name: "TestIndexBasicUpdateDocumentsWithPrimaryKey",
 			args: args{
-				UID:    "indexUID",
+				UID:    "TestIndexBasicUpdateDocumentsWithPrimaryKey",
 				client: defaultClient,
 				documentsPtr: []docTestBooks{
 					{BookID: 123, Title: "One Hundred Years of Solitude"},
 				},
 				primaryKey: "book_id",
 			},
-			want: &AsyncUpdateID{
-				UpdateID: 1,
+			want: &Task{
+				UID:    1,
+				Status: "enqueued",
+				Type:   "documentPartial",
 			},
 		},
 		{
 			name: "TestIndexUpdateDocumentsWithPrimaryKeyWithCustomClient",
 			args: args{
-				UID:    "indexUID",
+				UID:    "TestIndexUpdateDocumentsWithPrimaryKeyWithCustomClient",
 				client: defaultClient,
 				documentsPtr: []docTestBooks{
 					{BookID: 123, Title: "One Hundred Years of Solitude"},
 				},
 				primaryKey: "book_id",
 			},
-			want: &AsyncUpdateID{
-				UpdateID: 1,
+			want: &Task{
+				UID:    1,
+				Status: "enqueued",
+				Type:   "documentPartial",
 			},
 		},
 		{
 			name: "TestIndexUpdateDocumentsWithPrimaryKeyOnMultipleDocuments",
 			args: args{
-				UID:    "indexUID",
+				UID:    "TestIndexUpdateDocumentsWithPrimaryKeyOnMultipleDocuments",
 				client: defaultClient,
 				documentsPtr: []docTestBooks{
 					{BookID: 123, Title: "One Hundred Years of Solitude"},
@@ -1220,28 +1379,32 @@ func TestIndex_UpdateDocumentsWithPrimaryKey(t *testing.T) {
 				},
 				primaryKey: "book_id",
 			},
-			want: &AsyncUpdateID{
-				UpdateID: 1,
+			want: &Task{
+				UID:    1,
+				Status: "enqueued",
+				Type:   "documentPartial",
 			},
 		},
 		{
 			name: "TestIndexUpdateDocumentsWithPrimaryKeyWithNoExistingDocument",
 			args: args{
-				UID:    "indexUID",
+				UID:    "TestIndexUpdateDocumentsWithPrimaryKeyWithNoExistingDocument",
 				client: defaultClient,
 				documentsPtr: []docTestBooks{
 					{BookID: 237, Title: "One Hundred Years of Solitude"},
 				},
 				primaryKey: "book_id",
 			},
-			want: &AsyncUpdateID{
-				UpdateID: 1,
+			want: &Task{
+				UID:    1,
+				Status: "enqueued",
+				Type:   "documentPartial",
 			},
 		},
 		{
 			name: "TestIndexUpdateDocumentsWithPrimaryKeyWithNoExistingMultipleDocuments",
 			args: args{
-				UID:    "indexUID",
+				UID:    "TestIndexUpdateDocumentsWithPrimaryKeyWithNoExistingMultipleDocuments",
 				client: defaultClient,
 				documentsPtr: []docTestBooks{
 					{BookID: 246, Title: "One Hundred Years of Solitude"},
@@ -1251,8 +1414,10 @@ func TestIndex_UpdateDocumentsWithPrimaryKey(t *testing.T) {
 				},
 				primaryKey: "book_id",
 			},
-			want: &AsyncUpdateID{
-				UpdateID: 1,
+			want: &Task{
+				UID:    1,
+				Status: "enqueued",
+				Type:   "documentPartial",
 			},
 		},
 	}
@@ -1261,13 +1426,16 @@ func TestIndex_UpdateDocumentsWithPrimaryKey(t *testing.T) {
 			c := tt.args.client
 			i := c.Index(tt.args.UID)
 			t.Cleanup(cleanup(c))
-			SetUpBasicIndex()
+			SetUpBasicIndex(tt.args.UID)
 
 			got, err := i.UpdateDocuments(tt.args.documentsPtr, tt.args.primaryKey)
 			require.NoError(t, err)
-			require.Equal(t, got, tt.want)
+			require.GreaterOrEqual(t, got.UID, tt.want.UID)
+			require.Equal(t, got.Status, tt.want.Status)
+			require.Equal(t, got.Type, tt.want.Type)
+			require.NotZero(t, got.EnqueuedAt)
 
-			testWaitForPendingUpdate(t, i, got)
+			testWaitForTask(t, i, got)
 
 			var document docTestBooks
 			for _, identifier := range tt.args.documentsPtr {
@@ -1299,12 +1467,12 @@ func TestIndex_UpdateDocumentsInBatches(t *testing.T) {
 	testsNoKey := []struct {
 		name string
 		args argsNoKey
-		want []AsyncUpdateID
+		want []Task
 	}{
 		{
 			name: "TestIndexBatchUpdateDocuments",
 			args: argsNoKey{
-				UID:    "indexUID",
+				UID:    "TestIndexBatchUpdateDocuments",
 				client: defaultClient,
 				documentsPtr: []docTestBooks{
 					{BookID: 123, Title: "One Hundred Years of Solitude"},
@@ -1312,9 +1480,17 @@ func TestIndex_UpdateDocumentsInBatches(t *testing.T) {
 				},
 				batchSize: 1,
 			},
-			want: []AsyncUpdateID{
-				{UpdateID: 1},
-				{UpdateID: 2},
+			want: []Task{
+				{
+					UID:    1,
+					Status: "enqueued",
+					Type:   "documentPartial",
+				},
+				{
+					UID:    2,
+					Status: "enqueued",
+					Type:   "documentPartial",
+				},
 			},
 		},
 	}
@@ -1322,12 +1498,12 @@ func TestIndex_UpdateDocumentsInBatches(t *testing.T) {
 	testsWithKey := []struct {
 		name string
 		args argsWithKey
-		want []AsyncUpdateID
+		want []Task
 	}{
 		{
 			name: "TestIndexBatchUpdateDocuments",
 			args: argsWithKey{
-				UID:    "indexUID",
+				UID:    "TestIndexBatchUpdateDocuments",
 				client: defaultClient,
 				documentsPtr: []docTestBooks{
 					{BookID: 123, Title: "One Hundred Years of Solitude"},
@@ -1336,9 +1512,17 @@ func TestIndex_UpdateDocumentsInBatches(t *testing.T) {
 				batchSize:  1,
 				primaryKey: "book_id",
 			},
-			want: []AsyncUpdateID{
-				{UpdateID: 1},
-				{UpdateID: 2},
+			want: []Task{
+				{
+					UID:    1,
+					Status: "enqueued",
+					Type:   "documentPartial",
+				},
+				{
+					UID:    2,
+					Status: "enqueued",
+					Type:   "documentPartial",
+				},
 			},
 		},
 	}
@@ -1348,13 +1532,18 @@ func TestIndex_UpdateDocumentsInBatches(t *testing.T) {
 			c := tt.args.client
 			i := c.Index(tt.args.UID)
 			t.Cleanup(cleanup(c))
-			SetUpBasicIndex()
+			SetUpBasicIndex(tt.args.UID)
 
 			got, err := i.UpdateDocumentsInBatches(tt.args.documentsPtr, tt.args.batchSize)
 			require.NoError(t, err)
-			require.Equal(t, got, tt.want)
+			for i := 0; i < 2; i++ {
+				require.GreaterOrEqual(t, got[i].UID, tt.want[i].UID)
+				require.Equal(t, got[i].Status, tt.want[i].Status)
+				require.Equal(t, got[i].Type, tt.want[i].Type)
+				require.NotZero(t, got[i].EnqueuedAt)
+			}
 
-			testWaitForPendingBatchUpdate(t, i, got)
+			testWaitForBatchTask(t, i, got)
 
 			var document docTestBooks
 			for _, identifier := range tt.args.documentsPtr {
@@ -1371,13 +1560,18 @@ func TestIndex_UpdateDocumentsInBatches(t *testing.T) {
 			c := tt.args.client
 			i := c.Index(tt.args.UID)
 			t.Cleanup(cleanup(c))
-			SetUpBasicIndex()
+			SetUpBasicIndex(tt.args.UID)
 
 			got, err := i.UpdateDocumentsInBatches(tt.args.documentsPtr, tt.args.batchSize, tt.args.primaryKey)
 			require.NoError(t, err)
-			require.Equal(t, got, tt.want)
+			for i := 0; i < 2; i++ {
+				require.GreaterOrEqual(t, got[i].UID, tt.want[i].UID)
+				require.Equal(t, got[i].Status, tt.want[i].Status)
+				require.Equal(t, got[i].Type, tt.want[i].Type)
+				require.NotZero(t, got[i].EnqueuedAt)
+			}
 
-			testWaitForPendingBatchUpdate(t, i, got)
+			testWaitForBatchTask(t, i, got)
 
 			var document docTestBooks
 			for _, identifier := range tt.args.documentsPtr {

--- a/index_search_test.go
+++ b/index_search_test.go
@@ -347,7 +347,7 @@ func TestIndex_SearchFacets(t *testing.T) {
 
 			updateFilter, err := i.UpdateFilterableAttributes(&tt.args.filterableAttributes)
 			require.NoError(t, err)
-			testWaitForPendingUpdate(t, i, updateFilter)
+			testWaitForTask(t, i, updateFilter)
 
 			got, err := i.Search(tt.args.query, &tt.args.request)
 			require.NoError(t, err)
@@ -666,7 +666,7 @@ func TestIndex_SearchWithFilters(t *testing.T) {
 
 			updateFilter, err := i.UpdateFilterableAttributes(&tt.args.filterableAttributes)
 			require.NoError(t, err)
-			testWaitForPendingUpdate(t, i, updateFilter)
+			testWaitForTask(t, i, updateFilter)
 
 			got, err := i.Search(tt.args.query, &tt.args.request)
 			require.NoError(t, err)
@@ -897,7 +897,7 @@ func TestIndex_SearchWithSort(t *testing.T) {
 
 			updateFilter, err := i.UpdateSortableAttributes(&tt.args.sortableAttributes)
 			require.NoError(t, err)
-			testWaitForPendingUpdate(t, i, updateFilter)
+			testWaitForTask(t, i, updateFilter)
 
 			got, err := i.Search(tt.args.query, &tt.args.request)
 			require.NoError(t, err)

--- a/index_settings.go
+++ b/index_settings.go
@@ -20,8 +20,8 @@ func (i Index) GetSettings() (resp *Settings, err error) {
 	return resp, nil
 }
 
-func (i Index) UpdateSettings(request *Settings) (resp *AsyncUpdateID, err error) {
-	resp = &AsyncUpdateID{}
+func (i Index) UpdateSettings(request *Settings) (resp *Task, err error) {
+	resp = &Task{}
 	req := internalRequest{
 		endpoint:            "/indexes/" + i.UID + "/settings",
 		method:              http.MethodPost,
@@ -37,8 +37,8 @@ func (i Index) UpdateSettings(request *Settings) (resp *AsyncUpdateID, err error
 	return resp, nil
 }
 
-func (i Index) ResetSettings() (resp *AsyncUpdateID, err error) {
-	resp = &AsyncUpdateID{}
+func (i Index) ResetSettings() (resp *Task, err error) {
+	resp = &Task{}
 	req := internalRequest{
 		endpoint:            "/indexes/" + i.UID + "/settings",
 		method:              http.MethodDelete,
@@ -69,8 +69,8 @@ func (i Index) GetRankingRules() (resp *[]string, err error) {
 	return resp, nil
 }
 
-func (i Index) UpdateRankingRules(request *[]string) (resp *AsyncUpdateID, err error) {
-	resp = &AsyncUpdateID{}
+func (i Index) UpdateRankingRules(request *[]string) (resp *Task, err error) {
+	resp = &Task{}
 	req := internalRequest{
 		endpoint:            "/indexes/" + i.UID + "/settings/ranking-rules",
 		method:              http.MethodPost,
@@ -86,8 +86,8 @@ func (i Index) UpdateRankingRules(request *[]string) (resp *AsyncUpdateID, err e
 	return resp, nil
 }
 
-func (i Index) ResetRankingRules() (resp *AsyncUpdateID, err error) {
-	resp = &AsyncUpdateID{}
+func (i Index) ResetRankingRules() (resp *Task, err error) {
+	resp = &Task{}
 	req := internalRequest{
 		endpoint:            "/indexes/" + i.UID + "/settings/ranking-rules",
 		method:              http.MethodDelete,
@@ -119,8 +119,8 @@ func (i Index) GetDistinctAttribute() (resp *string, err error) {
 	return resp, nil
 }
 
-func (i Index) UpdateDistinctAttribute(request string) (resp *AsyncUpdateID, err error) {
-	resp = &AsyncUpdateID{}
+func (i Index) UpdateDistinctAttribute(request string) (resp *Task, err error) {
+	resp = &Task{}
 	req := internalRequest{
 		endpoint:            "/indexes/" + i.UID + "/settings/distinct-attribute",
 		method:              http.MethodPost,
@@ -136,8 +136,8 @@ func (i Index) UpdateDistinctAttribute(request string) (resp *AsyncUpdateID, err
 	return resp, nil
 }
 
-func (i Index) ResetDistinctAttribute() (resp *AsyncUpdateID, err error) {
-	resp = &AsyncUpdateID{}
+func (i Index) ResetDistinctAttribute() (resp *Task, err error) {
+	resp = &Task{}
 	req := internalRequest{
 		endpoint:            "/indexes/" + i.UID + "/settings/distinct-attribute",
 		method:              http.MethodDelete,
@@ -168,8 +168,8 @@ func (i Index) GetSearchableAttributes() (resp *[]string, err error) {
 	return resp, nil
 }
 
-func (i Index) UpdateSearchableAttributes(request *[]string) (resp *AsyncUpdateID, err error) {
-	resp = &AsyncUpdateID{}
+func (i Index) UpdateSearchableAttributes(request *[]string) (resp *Task, err error) {
+	resp = &Task{}
 	req := internalRequest{
 		endpoint:            "/indexes/" + i.UID + "/settings/searchable-attributes",
 		method:              http.MethodPost,
@@ -185,8 +185,8 @@ func (i Index) UpdateSearchableAttributes(request *[]string) (resp *AsyncUpdateI
 	return resp, nil
 }
 
-func (i Index) ResetSearchableAttributes() (resp *AsyncUpdateID, err error) {
-	resp = &AsyncUpdateID{}
+func (i Index) ResetSearchableAttributes() (resp *Task, err error) {
+	resp = &Task{}
 	req := internalRequest{
 		endpoint:            "/indexes/" + i.UID + "/settings/searchable-attributes",
 		method:              http.MethodDelete,
@@ -217,8 +217,8 @@ func (i Index) GetDisplayedAttributes() (resp *[]string, err error) {
 	return resp, nil
 }
 
-func (i Index) UpdateDisplayedAttributes(request *[]string) (resp *AsyncUpdateID, err error) {
-	resp = &AsyncUpdateID{}
+func (i Index) UpdateDisplayedAttributes(request *[]string) (resp *Task, err error) {
+	resp = &Task{}
 	req := internalRequest{
 		endpoint:            "/indexes/" + i.UID + "/settings/displayed-attributes",
 		method:              http.MethodPost,
@@ -234,8 +234,8 @@ func (i Index) UpdateDisplayedAttributes(request *[]string) (resp *AsyncUpdateID
 	return resp, nil
 }
 
-func (i Index) ResetDisplayedAttributes() (resp *AsyncUpdateID, err error) {
-	resp = &AsyncUpdateID{}
+func (i Index) ResetDisplayedAttributes() (resp *Task, err error) {
+	resp = &Task{}
 	req := internalRequest{
 		endpoint:            "/indexes/" + i.UID + "/settings/displayed-attributes",
 		method:              http.MethodDelete,
@@ -266,8 +266,8 @@ func (i Index) GetStopWords() (resp *[]string, err error) {
 	return resp, nil
 }
 
-func (i Index) UpdateStopWords(request *[]string) (resp *AsyncUpdateID, err error) {
-	resp = &AsyncUpdateID{}
+func (i Index) UpdateStopWords(request *[]string) (resp *Task, err error) {
+	resp = &Task{}
 	req := internalRequest{
 		endpoint:            "/indexes/" + i.UID + "/settings/stop-words",
 		method:              http.MethodPost,
@@ -283,8 +283,8 @@ func (i Index) UpdateStopWords(request *[]string) (resp *AsyncUpdateID, err erro
 	return resp, nil
 }
 
-func (i Index) ResetStopWords() (resp *AsyncUpdateID, err error) {
-	resp = &AsyncUpdateID{}
+func (i Index) ResetStopWords() (resp *Task, err error) {
+	resp = &Task{}
 	req := internalRequest{
 		endpoint:            "/indexes/" + i.UID + "/settings/stop-words",
 		method:              http.MethodDelete,
@@ -315,8 +315,8 @@ func (i Index) GetSynonyms() (resp *map[string][]string, err error) {
 	return resp, nil
 }
 
-func (i Index) UpdateSynonyms(request *map[string][]string) (resp *AsyncUpdateID, err error) {
-	resp = &AsyncUpdateID{}
+func (i Index) UpdateSynonyms(request *map[string][]string) (resp *Task, err error) {
+	resp = &Task{}
 	req := internalRequest{
 		endpoint:            "/indexes/" + i.UID + "/settings/synonyms",
 		method:              http.MethodPost,
@@ -332,8 +332,8 @@ func (i Index) UpdateSynonyms(request *map[string][]string) (resp *AsyncUpdateID
 	return resp, nil
 }
 
-func (i Index) ResetSynonyms() (resp *AsyncUpdateID, err error) {
-	resp = &AsyncUpdateID{}
+func (i Index) ResetSynonyms() (resp *Task, err error) {
+	resp = &Task{}
 	req := internalRequest{
 		endpoint:            "/indexes/" + i.UID + "/settings/synonyms",
 		method:              http.MethodDelete,
@@ -364,8 +364,8 @@ func (i Index) GetFilterableAttributes() (resp *[]string, err error) {
 	return resp, nil
 }
 
-func (i Index) UpdateFilterableAttributes(request *[]string) (resp *AsyncUpdateID, err error) {
-	resp = &AsyncUpdateID{}
+func (i Index) UpdateFilterableAttributes(request *[]string) (resp *Task, err error) {
+	resp = &Task{}
 	req := internalRequest{
 		endpoint:            "/indexes/" + i.UID + "/settings/filterable-attributes",
 		method:              http.MethodPost,
@@ -381,8 +381,8 @@ func (i Index) UpdateFilterableAttributes(request *[]string) (resp *AsyncUpdateI
 	return resp, nil
 }
 
-func (i Index) ResetFilterableAttributes() (resp *AsyncUpdateID, err error) {
-	resp = &AsyncUpdateID{}
+func (i Index) ResetFilterableAttributes() (resp *Task, err error) {
+	resp = &Task{}
 	req := internalRequest{
 		endpoint:            "/indexes/" + i.UID + "/settings/filterable-attributes",
 		method:              http.MethodDelete,
@@ -413,8 +413,8 @@ func (i Index) GetSortableAttributes() (resp *[]string, err error) {
 	return resp, nil
 }
 
-func (i Index) UpdateSortableAttributes(request *[]string) (resp *AsyncUpdateID, err error) {
-	resp = &AsyncUpdateID{}
+func (i Index) UpdateSortableAttributes(request *[]string) (resp *Task, err error) {
+	resp = &Task{}
 	req := internalRequest{
 		endpoint:            "/indexes/" + i.UID + "/settings/sortable-attributes",
 		method:              http.MethodPost,
@@ -430,8 +430,8 @@ func (i Index) UpdateSortableAttributes(request *[]string) (resp *AsyncUpdateID,
 	return resp, nil
 }
 
-func (i Index) ResetSortableAttributes() (resp *AsyncUpdateID, err error) {
-	resp = &AsyncUpdateID{}
+func (i Index) ResetSortableAttributes() (resp *Task, err error) {
+	resp = &Task{}
 	req := internalRequest{
 		endpoint:            "/indexes/" + i.UID + "/settings/sortable-attributes",
 		method:              http.MethodDelete,

--- a/index_settings_test.go
+++ b/index_settings_test.go
@@ -35,6 +35,7 @@ func TestIndex_GetFilterableAttributes(t *testing.T) {
 			SetUpIndexForFaceting()
 			c := tt.args.client
 			i := c.Index(tt.args.UID)
+			t.Cleanup(cleanup(c))
 
 			gotResp, err := i.GetFilterableAttributes()
 			require.NoError(t, err)
@@ -368,6 +369,7 @@ func TestIndex_GetSortableAttributes(t *testing.T) {
 			SetUpIndexForFaceting()
 			c := tt.args.client
 			i := c.Index(tt.args.UID)
+			t.Cleanup(cleanup(c))
 
 			gotResp, err := i.GetSortableAttributes()
 			require.NoError(t, err)
@@ -382,9 +384,9 @@ func TestIndex_ResetFilterableAttributes(t *testing.T) {
 		client *Client
 	}
 	tests := []struct {
-		name       string
-		args       args
-		wantUpdate *AsyncUpdateID
+		name     string
+		args     args
+		wantTask *Task
 	}{
 		{
 			name: "TestIndexBasicResetFilterableAttributes",
@@ -392,8 +394,8 @@ func TestIndex_ResetFilterableAttributes(t *testing.T) {
 				UID:    "indexUID",
 				client: defaultClient,
 			},
-			wantUpdate: &AsyncUpdateID{
-				UpdateID: 1,
+			wantTask: &Task{
+				UID: 1,
 			},
 		},
 		{
@@ -402,8 +404,8 @@ func TestIndex_ResetFilterableAttributes(t *testing.T) {
 				UID:    "indexUID",
 				client: customClient,
 			},
-			wantUpdate: &AsyncUpdateID{
-				UpdateID: 1,
+			wantTask: &Task{
+				UID: 1,
 			},
 		},
 	}
@@ -414,10 +416,10 @@ func TestIndex_ResetFilterableAttributes(t *testing.T) {
 			i := c.Index(tt.args.UID)
 			t.Cleanup(cleanup(c))
 
-			gotUpdate, err := i.ResetFilterableAttributes()
+			gotTask, err := i.ResetFilterableAttributes()
 			require.NoError(t, err)
-			require.GreaterOrEqual(t, gotUpdate.UpdateID, tt.wantUpdate.UpdateID)
-			testWaitForPendingUpdate(t, i, gotUpdate)
+			require.GreaterOrEqual(t, gotTask.UID, tt.wantTask.UID)
+			testWaitForTask(t, i, gotTask)
 
 			gotResp, err := i.GetFilterableAttributes()
 			require.NoError(t, err)
@@ -432,10 +434,10 @@ func TestIndex_ResetDisplayedAttributes(t *testing.T) {
 		client *Client
 	}
 	tests := []struct {
-		name       string
-		args       args
-		wantUpdate *AsyncUpdateID
-		wantResp   *[]string
+		name     string
+		args     args
+		wantTask *Task
+		wantResp *[]string
 	}{
 		{
 			name: "TestIndexBasicResetDisplayedAttributes",
@@ -443,8 +445,8 @@ func TestIndex_ResetDisplayedAttributes(t *testing.T) {
 				UID:    "indexUID",
 				client: defaultClient,
 			},
-			wantUpdate: &AsyncUpdateID{
-				UpdateID: 1,
+			wantTask: &Task{
+				UID: 1,
 			},
 			wantResp: &[]string{"*"},
 		},
@@ -454,8 +456,8 @@ func TestIndex_ResetDisplayedAttributes(t *testing.T) {
 				UID:    "indexUID",
 				client: customClient,
 			},
-			wantUpdate: &AsyncUpdateID{
-				UpdateID: 1,
+			wantTask: &Task{
+				UID: 1,
 			},
 			wantResp: &[]string{"*"},
 		},
@@ -467,10 +469,10 @@ func TestIndex_ResetDisplayedAttributes(t *testing.T) {
 			i := c.Index(tt.args.UID)
 			t.Cleanup(cleanup(c))
 
-			gotUpdate, err := i.ResetDisplayedAttributes()
+			gotTask, err := i.ResetDisplayedAttributes()
 			require.NoError(t, err)
-			require.GreaterOrEqual(t, gotUpdate.UpdateID, tt.wantUpdate.UpdateID)
-			testWaitForPendingUpdate(t, i, gotUpdate)
+			require.GreaterOrEqual(t, gotTask.UID, tt.wantTask.UID)
+			testWaitForTask(t, i, gotTask)
 
 			gotResp, err := i.GetDisplayedAttributes()
 			require.NoError(t, err)
@@ -485,9 +487,9 @@ func TestIndex_ResetDistinctAttribute(t *testing.T) {
 		client *Client
 	}
 	tests := []struct {
-		name       string
-		args       args
-		wantUpdate *AsyncUpdateID
+		name     string
+		args     args
+		wantTask *Task
 	}{
 		{
 			name: "TestIndexBasicResetDistinctAttribute",
@@ -495,8 +497,8 @@ func TestIndex_ResetDistinctAttribute(t *testing.T) {
 				UID:    "indexUID",
 				client: defaultClient,
 			},
-			wantUpdate: &AsyncUpdateID{
-				UpdateID: 1,
+			wantTask: &Task{
+				UID: 1,
 			},
 		},
 		{
@@ -505,8 +507,8 @@ func TestIndex_ResetDistinctAttribute(t *testing.T) {
 				UID:    "indexUID",
 				client: customClient,
 			},
-			wantUpdate: &AsyncUpdateID{
-				UpdateID: 1,
+			wantTask: &Task{
+				UID: 1,
 			},
 		},
 	}
@@ -517,10 +519,10 @@ func TestIndex_ResetDistinctAttribute(t *testing.T) {
 			i := c.Index(tt.args.UID)
 			t.Cleanup(cleanup(c))
 
-			gotUpdate, err := i.ResetDistinctAttribute()
+			gotTask, err := i.ResetDistinctAttribute()
 			require.NoError(t, err)
-			require.GreaterOrEqual(t, gotUpdate.UpdateID, tt.wantUpdate.UpdateID)
-			testWaitForPendingUpdate(t, i, gotUpdate)
+			require.GreaterOrEqual(t, gotTask.UID, tt.wantTask.UID)
+			testWaitForTask(t, i, gotTask)
 
 			gotResp, err := i.GetDistinctAttribute()
 			require.NoError(t, err)
@@ -535,10 +537,10 @@ func TestIndex_ResetRankingRules(t *testing.T) {
 		client *Client
 	}
 	tests := []struct {
-		name       string
-		args       args
-		wantUpdate *AsyncUpdateID
-		wantResp   *[]string
+		name     string
+		args     args
+		wantTask *Task
+		wantResp *[]string
 	}{
 		{
 			name: "TestIndexBasicResetRankingRules",
@@ -546,8 +548,8 @@ func TestIndex_ResetRankingRules(t *testing.T) {
 				UID:    "indexUID",
 				client: defaultClient,
 			},
-			wantUpdate: &AsyncUpdateID{
-				UpdateID: 1,
+			wantTask: &Task{
+				UID: 1,
 			},
 			wantResp: &defaultRankingRules,
 		},
@@ -557,8 +559,8 @@ func TestIndex_ResetRankingRules(t *testing.T) {
 				UID:    "indexUID",
 				client: customClient,
 			},
-			wantUpdate: &AsyncUpdateID{
-				UpdateID: 1,
+			wantTask: &Task{
+				UID: 1,
 			},
 			wantResp: &defaultRankingRules,
 		},
@@ -570,10 +572,10 @@ func TestIndex_ResetRankingRules(t *testing.T) {
 			i := c.Index(tt.args.UID)
 			t.Cleanup(cleanup(c))
 
-			gotUpdate, err := i.ResetRankingRules()
+			gotTask, err := i.ResetRankingRules()
 			require.NoError(t, err)
-			require.GreaterOrEqual(t, gotUpdate.UpdateID, tt.wantUpdate.UpdateID)
-			testWaitForPendingUpdate(t, i, gotUpdate)
+			require.GreaterOrEqual(t, gotTask.UID, tt.wantTask.UID)
+			testWaitForTask(t, i, gotTask)
 
 			gotResp, err := i.GetRankingRules()
 			require.NoError(t, err)
@@ -588,10 +590,10 @@ func TestIndex_ResetSearchableAttributes(t *testing.T) {
 		client *Client
 	}
 	tests := []struct {
-		name       string
-		args       args
-		wantUpdate *AsyncUpdateID
-		wantResp   *[]string
+		name     string
+		args     args
+		wantTask *Task
+		wantResp *[]string
 	}{
 		{
 			name: "TestIndexBasicResetSearchableAttributes",
@@ -599,8 +601,8 @@ func TestIndex_ResetSearchableAttributes(t *testing.T) {
 				UID:    "indexUID",
 				client: defaultClient,
 			},
-			wantUpdate: &AsyncUpdateID{
-				UpdateID: 1,
+			wantTask: &Task{
+				UID: 1,
 			},
 			wantResp: &[]string{"*"},
 		},
@@ -610,8 +612,8 @@ func TestIndex_ResetSearchableAttributes(t *testing.T) {
 				UID:    "indexUID",
 				client: customClient,
 			},
-			wantUpdate: &AsyncUpdateID{
-				UpdateID: 1,
+			wantTask: &Task{
+				UID: 1,
 			},
 			wantResp: &[]string{"*"},
 		},
@@ -623,10 +625,10 @@ func TestIndex_ResetSearchableAttributes(t *testing.T) {
 			i := c.Index(tt.args.UID)
 			t.Cleanup(cleanup(c))
 
-			gotUpdate, err := i.ResetSearchableAttributes()
+			gotTask, err := i.ResetSearchableAttributes()
 			require.NoError(t, err)
-			require.GreaterOrEqual(t, gotUpdate.UpdateID, tt.wantUpdate.UpdateID)
-			testWaitForPendingUpdate(t, i, gotUpdate)
+			require.GreaterOrEqual(t, gotTask.UID, tt.wantTask.UID)
+			testWaitForTask(t, i, gotTask)
 
 			gotResp, err := i.GetSearchableAttributes()
 			require.NoError(t, err)
@@ -641,10 +643,10 @@ func TestIndex_ResetSettings(t *testing.T) {
 		client *Client
 	}
 	tests := []struct {
-		name       string
-		args       args
-		wantUpdate *AsyncUpdateID
-		wantResp   *Settings
+		name     string
+		args     args
+		wantTask *Task
+		wantResp *Settings
 	}{
 		{
 			name: "TestIndexBasicResetSettings",
@@ -652,8 +654,8 @@ func TestIndex_ResetSettings(t *testing.T) {
 				UID:    "indexUID",
 				client: defaultClient,
 			},
-			wantUpdate: &AsyncUpdateID{
-				UpdateID: 1,
+			wantTask: &Task{
+				UID: 1,
 			},
 			wantResp: &Settings{
 				RankingRules:         defaultRankingRules,
@@ -672,8 +674,8 @@ func TestIndex_ResetSettings(t *testing.T) {
 				UID:    "indexUID",
 				client: customClient,
 			},
-			wantUpdate: &AsyncUpdateID{
-				UpdateID: 1,
+			wantTask: &Task{
+				UID: 1,
 			},
 			wantResp: &Settings{
 				RankingRules:         defaultRankingRules,
@@ -694,10 +696,10 @@ func TestIndex_ResetSettings(t *testing.T) {
 			i := c.Index(tt.args.UID)
 			t.Cleanup(cleanup(c))
 
-			gotUpdate, err := i.ResetSettings()
+			gotTask, err := i.ResetSettings()
 			require.NoError(t, err)
-			require.GreaterOrEqual(t, gotUpdate.UpdateID, tt.wantUpdate.UpdateID)
-			testWaitForPendingUpdate(t, i, gotUpdate)
+			require.GreaterOrEqual(t, gotTask.UID, tt.wantTask.UID)
+			testWaitForTask(t, i, gotTask)
 
 			gotResp, err := i.GetSettings()
 			require.NoError(t, err)
@@ -712,9 +714,9 @@ func TestIndex_ResetStopWords(t *testing.T) {
 		client *Client
 	}
 	tests := []struct {
-		name       string
-		args       args
-		wantUpdate *AsyncUpdateID
+		name     string
+		args     args
+		wantTask *Task
 	}{
 		{
 			name: "TestIndexBasicResetStopWords",
@@ -722,8 +724,8 @@ func TestIndex_ResetStopWords(t *testing.T) {
 				UID:    "indexUID",
 				client: defaultClient,
 			},
-			wantUpdate: &AsyncUpdateID{
-				UpdateID: 1,
+			wantTask: &Task{
+				UID: 1,
 			},
 		},
 		{
@@ -732,8 +734,8 @@ func TestIndex_ResetStopWords(t *testing.T) {
 				UID:    "indexUID",
 				client: customClient,
 			},
-			wantUpdate: &AsyncUpdateID{
-				UpdateID: 1,
+			wantTask: &Task{
+				UID: 1,
 			},
 		},
 	}
@@ -744,10 +746,10 @@ func TestIndex_ResetStopWords(t *testing.T) {
 			i := c.Index(tt.args.UID)
 			t.Cleanup(cleanup(c))
 
-			gotUpdate, err := i.ResetStopWords()
+			gotTask, err := i.ResetStopWords()
 			require.NoError(t, err)
-			require.GreaterOrEqual(t, gotUpdate.UpdateID, tt.wantUpdate.UpdateID)
-			testWaitForPendingUpdate(t, i, gotUpdate)
+			require.GreaterOrEqual(t, gotTask.UID, tt.wantTask.UID)
+			testWaitForTask(t, i, gotTask)
 
 			gotResp, err := i.GetStopWords()
 			require.NoError(t, err)
@@ -762,9 +764,9 @@ func TestIndex_ResetSynonyms(t *testing.T) {
 		client *Client
 	}
 	tests := []struct {
-		name       string
-		args       args
-		wantUpdate *AsyncUpdateID
+		name     string
+		args     args
+		wantTask *Task
 	}{
 		{
 			name: "TestIndexBasicResetSynonyms",
@@ -772,8 +774,8 @@ func TestIndex_ResetSynonyms(t *testing.T) {
 				UID:    "indexUID",
 				client: defaultClient,
 			},
-			wantUpdate: &AsyncUpdateID{
-				UpdateID: 1,
+			wantTask: &Task{
+				UID: 1,
 			},
 		},
 		{
@@ -782,8 +784,8 @@ func TestIndex_ResetSynonyms(t *testing.T) {
 				UID:    "indexUID",
 				client: customClient,
 			},
-			wantUpdate: &AsyncUpdateID{
-				UpdateID: 1,
+			wantTask: &Task{
+				UID: 1,
 			},
 		},
 	}
@@ -794,10 +796,10 @@ func TestIndex_ResetSynonyms(t *testing.T) {
 			i := c.Index(tt.args.UID)
 			t.Cleanup(cleanup(c))
 
-			gotUpdate, err := i.ResetSynonyms()
+			gotTask, err := i.ResetSynonyms()
 			require.NoError(t, err)
-			require.GreaterOrEqual(t, gotUpdate.UpdateID, tt.wantUpdate.UpdateID)
-			testWaitForPendingUpdate(t, i, gotUpdate)
+			require.GreaterOrEqual(t, gotTask.UID, tt.wantTask.UID)
+			testWaitForTask(t, i, gotTask)
 
 			gotResp, err := i.GetSynonyms()
 			require.NoError(t, err)
@@ -812,9 +814,9 @@ func TestIndex_ResetSortableAttributes(t *testing.T) {
 		client *Client
 	}
 	tests := []struct {
-		name       string
-		args       args
-		wantUpdate *AsyncUpdateID
+		name     string
+		args     args
+		wantTask *Task
 	}{
 		{
 			name: "TestIndexBasicResetSortableAttributes",
@@ -822,8 +824,8 @@ func TestIndex_ResetSortableAttributes(t *testing.T) {
 				UID:    "indexUID",
 				client: defaultClient,
 			},
-			wantUpdate: &AsyncUpdateID{
-				UpdateID: 1,
+			wantTask: &Task{
+				UID: 1,
 			},
 		},
 		{
@@ -832,8 +834,8 @@ func TestIndex_ResetSortableAttributes(t *testing.T) {
 				UID:    "indexUID",
 				client: customClient,
 			},
-			wantUpdate: &AsyncUpdateID{
-				UpdateID: 1,
+			wantTask: &Task{
+				UID: 1,
 			},
 		},
 	}
@@ -844,10 +846,10 @@ func TestIndex_ResetSortableAttributes(t *testing.T) {
 			i := c.Index(tt.args.UID)
 			t.Cleanup(cleanup(c))
 
-			gotUpdate, err := i.ResetSortableAttributes()
+			gotTask, err := i.ResetSortableAttributes()
 			require.NoError(t, err)
-			require.GreaterOrEqual(t, gotUpdate.UpdateID, tt.wantUpdate.UpdateID)
-			testWaitForPendingUpdate(t, i, gotUpdate)
+			require.GreaterOrEqual(t, gotTask.UID, tt.wantTask.UID)
+			testWaitForTask(t, i, gotTask)
 
 			gotResp, err := i.GetSortableAttributes()
 			require.NoError(t, err)
@@ -863,9 +865,9 @@ func TestIndex_UpdateFilterableAttributes(t *testing.T) {
 		request []string
 	}
 	tests := []struct {
-		name       string
-		args       args
-		wantUpdate *AsyncUpdateID
+		name     string
+		args     args
+		wantTask *Task
 	}{
 		{
 			name: "TestIndexBasicUpdateFilterableAttributes",
@@ -876,8 +878,8 @@ func TestIndex_UpdateFilterableAttributes(t *testing.T) {
 					"title",
 				},
 			},
-			wantUpdate: &AsyncUpdateID{
-				UpdateID: 1,
+			wantTask: &Task{
+				UID: 1,
 			},
 		},
 		{
@@ -889,8 +891,8 @@ func TestIndex_UpdateFilterableAttributes(t *testing.T) {
 					"title",
 				},
 			},
-			wantUpdate: &AsyncUpdateID{
-				UpdateID: 1,
+			wantTask: &Task{
+				UID: 1,
 			},
 		},
 	}
@@ -905,10 +907,10 @@ func TestIndex_UpdateFilterableAttributes(t *testing.T) {
 			require.NoError(t, err)
 			require.Empty(t, gotResp)
 
-			gotUpdate, err := i.UpdateFilterableAttributes(&tt.args.request)
+			gotTask, err := i.UpdateFilterableAttributes(&tt.args.request)
 			require.NoError(t, err)
-			require.GreaterOrEqual(t, gotUpdate.UpdateID, tt.wantUpdate.UpdateID)
-			testWaitForPendingUpdate(t, i, gotUpdate)
+			require.GreaterOrEqual(t, gotTask.UID, tt.wantTask.UID)
+			testWaitForTask(t, i, gotTask)
 
 			gotResp, err = i.GetFilterableAttributes()
 			require.NoError(t, err)
@@ -924,10 +926,10 @@ func TestIndex_UpdateDisplayedAttributes(t *testing.T) {
 		request []string
 	}
 	tests := []struct {
-		name       string
-		args       args
-		wantUpdate *AsyncUpdateID
-		wantResp   *[]string
+		name     string
+		args     args
+		wantTask *Task
+		wantResp *[]string
 	}{
 		{
 			name: "TestIndexBasicUpdateDisplayedAttributes",
@@ -938,8 +940,8 @@ func TestIndex_UpdateDisplayedAttributes(t *testing.T) {
 					"book_id", "tag", "title",
 				},
 			},
-			wantUpdate: &AsyncUpdateID{
-				UpdateID: 1,
+			wantTask: &Task{
+				UID: 1,
 			},
 			wantResp: &[]string{"*"},
 		},
@@ -952,8 +954,8 @@ func TestIndex_UpdateDisplayedAttributes(t *testing.T) {
 					"book_id", "tag", "title",
 				},
 			},
-			wantUpdate: &AsyncUpdateID{
-				UpdateID: 1,
+			wantTask: &Task{
+				UID: 1,
 			},
 			wantResp: &[]string{"*"},
 		},
@@ -969,10 +971,10 @@ func TestIndex_UpdateDisplayedAttributes(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tt.wantResp, gotResp)
 
-			gotUpdate, err := i.UpdateDisplayedAttributes(&tt.args.request)
+			gotTask, err := i.UpdateDisplayedAttributes(&tt.args.request)
 			require.NoError(t, err)
-			require.GreaterOrEqual(t, gotUpdate.UpdateID, tt.wantUpdate.UpdateID)
-			testWaitForPendingUpdate(t, i, gotUpdate)
+			require.GreaterOrEqual(t, gotTask.UID, tt.wantTask.UID)
+			testWaitForTask(t, i, gotTask)
 
 			gotResp, err = i.GetDisplayedAttributes()
 			require.NoError(t, err)
@@ -988,9 +990,9 @@ func TestIndex_UpdateDistinctAttribute(t *testing.T) {
 		request string
 	}
 	tests := []struct {
-		name       string
-		args       args
-		wantUpdate *AsyncUpdateID
+		name     string
+		args     args
+		wantTask *Task
 	}{
 		{
 			name: "TestIndexBasicUpdateDistinctAttribute",
@@ -999,8 +1001,8 @@ func TestIndex_UpdateDistinctAttribute(t *testing.T) {
 				client:  defaultClient,
 				request: "movie_id",
 			},
-			wantUpdate: &AsyncUpdateID{
-				UpdateID: 1,
+			wantTask: &Task{
+				UID: 1,
 			},
 		},
 		{
@@ -1010,8 +1012,8 @@ func TestIndex_UpdateDistinctAttribute(t *testing.T) {
 				client:  customClient,
 				request: "movie_id",
 			},
-			wantUpdate: &AsyncUpdateID{
-				UpdateID: 1,
+			wantTask: &Task{
+				UID: 1,
 			},
 		},
 	}
@@ -1026,10 +1028,10 @@ func TestIndex_UpdateDistinctAttribute(t *testing.T) {
 			require.NoError(t, err)
 			require.Empty(t, gotResp)
 
-			gotUpdate, err := i.UpdateDistinctAttribute(tt.args.request)
+			gotTask, err := i.UpdateDistinctAttribute(tt.args.request)
 			require.NoError(t, err)
-			require.GreaterOrEqual(t, gotUpdate.UpdateID, tt.wantUpdate.UpdateID)
-			testWaitForPendingUpdate(t, i, gotUpdate)
+			require.GreaterOrEqual(t, gotTask.UID, tt.wantTask.UID)
+			testWaitForTask(t, i, gotTask)
 
 			gotResp, err = i.GetDistinctAttribute()
 			require.NoError(t, err)
@@ -1045,10 +1047,10 @@ func TestIndex_UpdateRankingRules(t *testing.T) {
 		request []string
 	}
 	tests := []struct {
-		name       string
-		args       args
-		wantUpdate *AsyncUpdateID
-		wantResp   *[]string
+		name     string
+		args     args
+		wantTask *Task
+		wantResp *[]string
 	}{
 		{
 			name: "TestIndexBasicUpdateRankingRules",
@@ -1059,8 +1061,8 @@ func TestIndex_UpdateRankingRules(t *testing.T) {
 					"typo", "words",
 				},
 			},
-			wantUpdate: &AsyncUpdateID{
-				UpdateID: 1,
+			wantTask: &Task{
+				UID: 1,
 			},
 			wantResp: &defaultRankingRules,
 		},
@@ -1073,8 +1075,8 @@ func TestIndex_UpdateRankingRules(t *testing.T) {
 					"typo", "words",
 				},
 			},
-			wantUpdate: &AsyncUpdateID{
-				UpdateID: 1,
+			wantTask: &Task{
+				UID: 1,
 			},
 			wantResp: &defaultRankingRules,
 		},
@@ -1087,8 +1089,8 @@ func TestIndex_UpdateRankingRules(t *testing.T) {
 					"BookID:asc",
 				},
 			},
-			wantUpdate: &AsyncUpdateID{
-				UpdateID: 1,
+			wantTask: &Task{
+				UID: 1,
 			},
 			wantResp: &defaultRankingRules,
 		},
@@ -1104,10 +1106,10 @@ func TestIndex_UpdateRankingRules(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tt.wantResp, gotResp)
 
-			gotUpdate, err := i.UpdateRankingRules(&tt.args.request)
+			gotTask, err := i.UpdateRankingRules(&tt.args.request)
 			require.NoError(t, err)
-			require.GreaterOrEqual(t, gotUpdate.UpdateID, tt.wantUpdate.UpdateID)
-			testWaitForPendingUpdate(t, i, gotUpdate)
+			require.GreaterOrEqual(t, gotTask.UID, tt.wantTask.UID)
+			testWaitForTask(t, i, gotTask)
 
 			gotResp, err = i.GetRankingRules()
 			require.NoError(t, err)
@@ -1123,10 +1125,10 @@ func TestIndex_UpdateSearchableAttributes(t *testing.T) {
 		request []string
 	}
 	tests := []struct {
-		name       string
-		args       args
-		wantUpdate *AsyncUpdateID
-		wantResp   *[]string
+		name     string
+		args     args
+		wantTask *Task
+		wantResp *[]string
 	}{
 		{
 			name: "TestIndexBasicUpdateSearchableAttributes",
@@ -1137,8 +1139,8 @@ func TestIndex_UpdateSearchableAttributes(t *testing.T) {
 					"title", "tag",
 				},
 			},
-			wantUpdate: &AsyncUpdateID{
-				UpdateID: 1,
+			wantTask: &Task{
+				UID: 1,
 			},
 			wantResp: &[]string{"*"},
 		},
@@ -1151,8 +1153,8 @@ func TestIndex_UpdateSearchableAttributes(t *testing.T) {
 					"title", "tag",
 				},
 			},
-			wantUpdate: &AsyncUpdateID{
-				UpdateID: 1,
+			wantTask: &Task{
+				UID: 1,
 			},
 			wantResp: &[]string{"*"},
 		},
@@ -1168,10 +1170,10 @@ func TestIndex_UpdateSearchableAttributes(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tt.wantResp, gotResp)
 
-			gotUpdate, err := i.UpdateSearchableAttributes(&tt.args.request)
+			gotTask, err := i.UpdateSearchableAttributes(&tt.args.request)
 			require.NoError(t, err)
-			require.GreaterOrEqual(t, gotUpdate.UpdateID, tt.wantUpdate.UpdateID)
-			testWaitForPendingUpdate(t, i, gotUpdate)
+			require.GreaterOrEqual(t, gotTask.UID, tt.wantTask.UID)
+			testWaitForTask(t, i, gotTask)
 
 			gotResp, err = i.GetSearchableAttributes()
 			require.NoError(t, err)
@@ -1187,10 +1189,10 @@ func TestIndex_UpdateSettings(t *testing.T) {
 		request Settings
 	}
 	tests := []struct {
-		name       string
-		args       args
-		wantUpdate *AsyncUpdateID
-		wantResp   *Settings
+		name     string
+		args     args
+		wantTask *Task
+		wantResp *Settings
 	}{
 		{
 			name: "TestIndexBasicUpdateSettings",
@@ -1222,8 +1224,8 @@ func TestIndex_UpdateSettings(t *testing.T) {
 					},
 				},
 			},
-			wantUpdate: &AsyncUpdateID{
-				UpdateID: 1,
+			wantTask: &Task{
+				UID: 1,
 			},
 			wantResp: &Settings{
 				RankingRules:         defaultRankingRules,
@@ -1266,8 +1268,8 @@ func TestIndex_UpdateSettings(t *testing.T) {
 					},
 				},
 			},
-			wantUpdate: &AsyncUpdateID{
-				UpdateID: 1,
+			wantTask: &Task{
+				UID: 1,
 			},
 			wantResp: &Settings{
 				RankingRules:         defaultRankingRules,
@@ -1292,10 +1294,10 @@ func TestIndex_UpdateSettings(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tt.wantResp, gotResp)
 
-			gotUpdate, err := i.UpdateSettings(&tt.args.request)
+			gotTask, err := i.UpdateSettings(&tt.args.request)
 			require.NoError(t, err)
-			require.GreaterOrEqual(t, gotUpdate.UpdateID, tt.wantUpdate.UpdateID)
-			testWaitForPendingUpdate(t, i, gotUpdate)
+			require.GreaterOrEqual(t, gotTask.UID, tt.wantTask.UID)
+			testWaitForTask(t, i, gotTask)
 
 			gotResp, err = i.GetSettings()
 			require.NoError(t, err)
@@ -1314,10 +1316,10 @@ func TestIndex_UpdateSettingsOneByOne(t *testing.T) {
 		secondResponse Settings
 	}
 	tests := []struct {
-		name       string
-		args       args
-		wantUpdate *AsyncUpdateID
-		wantResp   *Settings
+		name     string
+		args     args
+		wantTask *Task
+		wantResp *Settings
 	}{
 		{
 			name: "TestIndexUpdateJustSynonyms",
@@ -1366,8 +1368,8 @@ func TestIndex_UpdateSettingsOneByOne(t *testing.T) {
 					SortableAttributes:   []string{},
 				},
 			},
-			wantUpdate: &AsyncUpdateID{
-				UpdateID: 1,
+			wantTask: &Task{
+				UID: 1,
 			},
 			wantResp: &Settings{
 				RankingRules:         defaultRankingRules,
@@ -1427,8 +1429,8 @@ func TestIndex_UpdateSettingsOneByOne(t *testing.T) {
 					SortableAttributes:   []string{},
 				},
 			},
-			wantUpdate: &AsyncUpdateID{
-				UpdateID: 1,
+			wantTask: &Task{
+				UID: 1,
 			},
 			wantResp: &Settings{
 				RankingRules:         defaultRankingRules,
@@ -1488,8 +1490,8 @@ func TestIndex_UpdateSettingsOneByOne(t *testing.T) {
 					SortableAttributes:   []string{},
 				},
 			},
-			wantUpdate: &AsyncUpdateID{
-				UpdateID: 1,
+			wantTask: &Task{
+				UID: 1,
 			},
 			wantResp: &Settings{
 				RankingRules:         defaultRankingRules,
@@ -1549,8 +1551,8 @@ func TestIndex_UpdateSettingsOneByOne(t *testing.T) {
 					SortableAttributes:   []string{},
 				},
 			},
-			wantUpdate: &AsyncUpdateID{
-				UpdateID: 1,
+			wantTask: &Task{
+				UID: 1,
 			},
 			wantResp: &Settings{
 				RankingRules:         defaultRankingRules,
@@ -1610,8 +1612,8 @@ func TestIndex_UpdateSettingsOneByOne(t *testing.T) {
 					SortableAttributes:   []string{},
 				},
 			},
-			wantUpdate: &AsyncUpdateID{
-				UpdateID: 1,
+			wantTask: &Task{
+				UID: 1,
 			},
 			wantResp: &Settings{
 				RankingRules:         defaultRankingRules,
@@ -1671,8 +1673,8 @@ func TestIndex_UpdateSettingsOneByOne(t *testing.T) {
 					SortableAttributes: []string{},
 				},
 			},
-			wantUpdate: &AsyncUpdateID{
-				UpdateID: 1,
+			wantTask: &Task{
+				UID: 1,
 			},
 			wantResp: &Settings{
 				RankingRules:         defaultRankingRules,
@@ -1732,8 +1734,8 @@ func TestIndex_UpdateSettingsOneByOne(t *testing.T) {
 					},
 				},
 			},
-			wantUpdate: &AsyncUpdateID{
-				UpdateID: 1,
+			wantTask: &Task{
+				UID: 1,
 			},
 			wantResp: &Settings{
 				RankingRules:         defaultRankingRules,
@@ -1758,20 +1760,20 @@ func TestIndex_UpdateSettingsOneByOne(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tt.wantResp, gotResp)
 
-			gotUpdate, err := i.UpdateSettings(&tt.args.firstRequest)
+			gotTask, err := i.UpdateSettings(&tt.args.firstRequest)
 			require.NoError(t, err)
-			require.GreaterOrEqual(t, gotUpdate.UpdateID, tt.wantUpdate.UpdateID)
-			testWaitForPendingUpdate(t, i, gotUpdate)
+			require.GreaterOrEqual(t, gotTask.UID, tt.wantTask.UID)
+			testWaitForTask(t, i, gotTask)
 
 			gotResp, err = i.GetSettings()
 			require.NoError(t, err)
 			require.Equal(t, &tt.args.firstResponse, gotResp)
 
-			gotUpdate, err = i.UpdateSettings(&tt.args.secondRequest)
+			gotTask, err = i.UpdateSettings(&tt.args.secondRequest)
 			require.NoError(t, err)
-			require.GreaterOrEqual(t, gotUpdate.UpdateID, tt.wantUpdate.UpdateID)
+			require.GreaterOrEqual(t, gotTask.UID, tt.wantTask.UID)
 
-			testWaitForPendingUpdate(t, i, gotUpdate)
+			testWaitForTask(t, i, gotTask)
 
 			gotResp, err = i.GetSettings()
 			require.NoError(t, err)
@@ -1787,9 +1789,9 @@ func TestIndex_UpdateStopWords(t *testing.T) {
 		request []string
 	}
 	tests := []struct {
-		name       string
-		args       args
-		wantUpdate *AsyncUpdateID
+		name     string
+		args     args
+		wantTask *Task
 	}{
 		{
 			name: "TestIndexBasicUpdateStopWords",
@@ -1800,8 +1802,8 @@ func TestIndex_UpdateStopWords(t *testing.T) {
 					"of", "the", "to",
 				},
 			},
-			wantUpdate: &AsyncUpdateID{
-				UpdateID: 1,
+			wantTask: &Task{
+				UID: 1,
 			},
 		},
 		{
@@ -1813,8 +1815,8 @@ func TestIndex_UpdateStopWords(t *testing.T) {
 					"of", "the", "to",
 				},
 			},
-			wantUpdate: &AsyncUpdateID{
-				UpdateID: 1,
+			wantTask: &Task{
+				UID: 1,
 			},
 		},
 	}
@@ -1829,10 +1831,10 @@ func TestIndex_UpdateStopWords(t *testing.T) {
 			require.NoError(t, err)
 			require.Empty(t, gotResp)
 
-			gotUpdate, err := i.UpdateStopWords(&tt.args.request)
+			gotTask, err := i.UpdateStopWords(&tt.args.request)
 			require.NoError(t, err)
-			require.GreaterOrEqual(t, gotUpdate.UpdateID, tt.wantUpdate.UpdateID)
-			testWaitForPendingUpdate(t, i, gotUpdate)
+			require.GreaterOrEqual(t, gotTask.UID, tt.wantTask.UID)
+			testWaitForTask(t, i, gotTask)
 
 			gotResp, err = i.GetStopWords()
 			require.NoError(t, err)
@@ -1848,9 +1850,9 @@ func TestIndex_UpdateSynonyms(t *testing.T) {
 		request map[string][]string
 	}
 	tests := []struct {
-		name       string
-		args       args
-		wantUpdate *AsyncUpdateID
+		name     string
+		args     args
+		wantTask *Task
 	}{
 		{
 			name: "TestIndexBasicUpdateSynonyms",
@@ -1861,8 +1863,8 @@ func TestIndex_UpdateSynonyms(t *testing.T) {
 					"wolverine": {"logan", "xmen"},
 				},
 			},
-			wantUpdate: &AsyncUpdateID{
-				UpdateID: 1,
+			wantTask: &Task{
+				UID: 1,
 			},
 		},
 		{
@@ -1874,8 +1876,8 @@ func TestIndex_UpdateSynonyms(t *testing.T) {
 					"wolverine": {"logan", "xmen"},
 				},
 			},
-			wantUpdate: &AsyncUpdateID{
-				UpdateID: 1,
+			wantTask: &Task{
+				UID: 1,
 			},
 		},
 	}
@@ -1890,10 +1892,10 @@ func TestIndex_UpdateSynonyms(t *testing.T) {
 			require.NoError(t, err)
 			require.Empty(t, gotResp)
 
-			gotUpdate, err := i.UpdateSynonyms(&tt.args.request)
+			gotTask, err := i.UpdateSynonyms(&tt.args.request)
 			require.NoError(t, err)
-			require.GreaterOrEqual(t, gotUpdate.UpdateID, tt.wantUpdate.UpdateID)
-			testWaitForPendingUpdate(t, i, gotUpdate)
+			require.GreaterOrEqual(t, gotTask.UID, tt.wantTask.UID)
+			testWaitForTask(t, i, gotTask)
 
 			gotResp, err = i.GetSynonyms()
 			require.NoError(t, err)
@@ -1909,9 +1911,9 @@ func TestIndex_UpdateSortableAttributes(t *testing.T) {
 		request []string
 	}
 	tests := []struct {
-		name       string
-		args       args
-		wantUpdate *AsyncUpdateID
+		name     string
+		args     args
+		wantTask *Task
 	}{
 		{
 			name: "TestIndexBasicUpdateSortableAttributes",
@@ -1922,8 +1924,8 @@ func TestIndex_UpdateSortableAttributes(t *testing.T) {
 					"title",
 				},
 			},
-			wantUpdate: &AsyncUpdateID{
-				UpdateID: 1,
+			wantTask: &Task{
+				UID: 1,
 			},
 		},
 		{
@@ -1935,8 +1937,8 @@ func TestIndex_UpdateSortableAttributes(t *testing.T) {
 					"title",
 				},
 			},
-			wantUpdate: &AsyncUpdateID{
-				UpdateID: 1,
+			wantTask: &Task{
+				UID: 1,
 			},
 		},
 	}
@@ -1951,10 +1953,10 @@ func TestIndex_UpdateSortableAttributes(t *testing.T) {
 			require.NoError(t, err)
 			require.Empty(t, gotResp)
 
-			gotUpdate, err := i.UpdateSortableAttributes(&tt.args.request)
+			gotTask, err := i.UpdateSortableAttributes(&tt.args.request)
 			require.NoError(t, err)
-			require.GreaterOrEqual(t, gotUpdate.UpdateID, tt.wantUpdate.UpdateID)
-			testWaitForPendingUpdate(t, i, gotUpdate)
+			require.GreaterOrEqual(t, gotTask.UID, tt.wantTask.UID)
+			testWaitForTask(t, i, gotTask)
 
 			gotResp, err = i.GetSortableAttributes()
 			require.NoError(t, err)

--- a/index_test.go
+++ b/index_test.go
@@ -249,7 +249,7 @@ func TestIndex_GetTask(t *testing.T) {
 			task, err := i.AddDocuments(tt.args.document)
 			require.NoError(t, err)
 
-			_, err = c.DefaultWaitForTask(task)
+			_, err = c.WaitForTask(task)
 			require.NoError(t, err)
 
 			gotResp, err := i.GetTask(task.UID)
@@ -307,7 +307,7 @@ func TestIndex_GetTasks(t *testing.T) {
 			task, err := i.AddDocuments(tt.args.document)
 			require.NoError(t, err)
 
-			_, err = c.DefaultWaitForTask(task)
+			_, err = c.WaitForTask(task)
 			require.NoError(t, err)
 
 			gotResp, err := i.GetTasks()
@@ -315,63 +315,6 @@ func TestIndex_GetTasks(t *testing.T) {
 			require.NotNil(t, (*gotResp).Results[0].Status)
 			require.NotZero(t, (*gotResp).Results[0].UID)
 			require.NotNil(t, (*gotResp).Results[0].Type)
-		})
-	}
-}
-
-func TestIndex_DefaultWaitForTask(t *testing.T) {
-	type args struct {
-		UID      string
-		client   *Client
-		taskID   *Task
-		document []docTest
-	}
-	tests := []struct {
-		name string
-		args args
-		want TaskStatus
-	}{
-		{
-			name: "TestDefaultWaitForTask",
-			args: args{
-				UID:    "TestDefaultWaitForTask",
-				client: defaultClient,
-				taskID: &Task{
-					UID: 0,
-				},
-				document: []docTest{
-					{ID: "123", Name: "Pride and Prejudice"},
-				},
-			},
-			want: "succeeded",
-		},
-		{
-			name: "TestDefaultWaitForTaskWithCustomClient",
-			args: args{
-				UID:    "TestDefaultWaitForTaskWithCustomClient",
-				client: customClient,
-				taskID: &Task{
-					UID: 0,
-				},
-				document: []docTest{
-					{ID: "123", Name: "Pride and Prejudice"},
-				},
-			},
-			want: "succeeded",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c := tt.args.client
-			i := c.Index(tt.args.UID)
-			t.Cleanup(cleanup(c))
-
-			task, err := i.AddDocuments(tt.args.document)
-			require.NoError(t, err)
-
-			gotTask, err := i.DefaultWaitForTask(task)
-			require.NoError(t, err)
-			require.Equal(t, tt.want, gotTask.Status)
 		})
 	}
 }
@@ -391,9 +334,9 @@ func TestIndex_WaitForTask(t *testing.T) {
 		want TaskStatus
 	}{
 		{
-			name: "TestDefaultWaitForTask50",
+			name: "TestWaitForTask50",
 			args: args{
-				UID:      "TestDefaultWaitForTask50",
+				UID:      "TestWaitForTask50",
 				client:   defaultClient,
 				interval: time.Millisecond * 50,
 				timeout:  time.Second * 5,
@@ -409,9 +352,9 @@ func TestIndex_WaitForTask(t *testing.T) {
 			want: "succeeded",
 		},
 		{
-			name: "TestDefaultWaitForTask50WithCustomClient",
+			name: "TestWaitForTask50WithCustomClient",
 			args: args{
-				UID:      "TestDefaultWaitForTask50WithCustomClient",
+				UID:      "TestWaitForTask50WithCustomClient",
 				client:   customClient,
 				interval: time.Millisecond * 50,
 				timeout:  time.Second * 5,
@@ -427,9 +370,9 @@ func TestIndex_WaitForTask(t *testing.T) {
 			want: "succeeded",
 		},
 		{
-			name: "TestDefaultWaitForTask10",
+			name: "TestWaitForTask10",
 			args: args{
-				UID:      "TestDefaultWaitForTask10",
+				UID:      "TestWaitForTask10",
 				client:   defaultClient,
 				interval: time.Millisecond * 10,
 				timeout:  time.Second * 5,
@@ -445,9 +388,9 @@ func TestIndex_WaitForTask(t *testing.T) {
 			want: "succeeded",
 		},
 		{
-			name: "TestDefaultWaitForTaskWithTimeout",
+			name: "TestWaitForTaskWithTimeout",
 			args: args{
-				UID:      "TestDefaultWaitForTaskWithTimeout",
+				UID:      "TestWaitForTaskWithTimeout",
 				client:   defaultClient,
 				interval: time.Millisecond * 50,
 				timeout:  time.Millisecond * 10,
@@ -475,7 +418,7 @@ func TestIndex_WaitForTask(t *testing.T) {
 			ctx, cancelFunc := context.WithTimeout(context.Background(), tt.args.timeout)
 			defer cancelFunc()
 
-			gotTask, err := i.WaitForTask(ctx, tt.args.interval, task)
+			gotTask, err := i.WaitForTask(task, waitParams{Context: ctx, Interval: tt.args.interval})
 			if tt.args.timeout < tt.args.interval {
 				require.Error(t, err)
 			} else {
@@ -633,7 +576,7 @@ func TestIndex_UpdateIndex(t *testing.T) {
 			gotResp, err := i.UpdateIndex(tt.args.primaryKey)
 			require.NoError(t, err)
 
-			_, err = c.DefaultWaitForTask(gotResp)
+			_, err = c.WaitForTask(gotResp)
 			require.NoError(t, err)
 
 			require.NoError(t, err)

--- a/index_test.go
+++ b/index_test.go
@@ -14,53 +14,52 @@ func TestIndex_Delete(t *testing.T) {
 		deleteUid []string
 	}
 	tests := []struct {
-		name          string
-		client        *Client
-		args          args
-		wantErr       bool
-		expectedError []Error
+		name   string
+		client *Client
+		args   args
 	}{
 		{
 			name:   "TestIndexDeleteOneIndex",
 			client: defaultClient,
 			args: args{
-				createUid: []string{"1"},
-				deleteUid: []string{"1"},
+				createUid: []string{"TestIndexDeleteOneIndex"},
+				deleteUid: []string{"TestIndexDeleteOneIndex"},
 			},
-			wantErr: false,
 		},
 		{
 			name:   "TestIndexDeleteOneIndexWithCustomClient",
 			client: customClient,
 			args: args{
-				createUid: []string{"1"},
-				deleteUid: []string{"1"},
+				createUid: []string{"TestIndexDeleteOneIndexWithCustomClient"},
+				deleteUid: []string{"TestIndexDeleteOneIndexWithCustomClient"},
 			},
-			wantErr: false,
 		},
 		{
 			name:   "TestIndexDeleteMultipleIndex",
 			client: defaultClient,
 			args: args{
-				createUid: []string{"1", "2", "3", "4", "5"},
-				deleteUid: []string{"1", "2", "3", "4", "5"},
+				createUid: []string{
+					"TestIndexDeleteMultipleIndex_1",
+					"TestIndexDeleteMultipleIndex_2",
+					"TestIndexDeleteMultipleIndex_3",
+					"TestIndexDeleteMultipleIndex_4",
+					"TestIndexDeleteMultipleIndex_5",
+				},
+				deleteUid: []string{
+					"TestIndexDeleteMultipleIndex_1",
+					"TestIndexDeleteMultipleIndex_2",
+					"TestIndexDeleteMultipleIndex_3",
+					"TestIndexDeleteMultipleIndex_4",
+					"TestIndexDeleteMultipleIndex_5",
+				},
 			},
-			wantErr: false,
 		},
 		{
 			name:   "TestIndexDeleteNotExistingIndex",
 			client: defaultClient,
 			args: args{
 				createUid: []string{},
-				deleteUid: []string{"1"},
-			},
-			wantErr: true,
-			expectedError: []Error{
-				{
-					MeilisearchApiError: meilisearchApiError{
-						Code: "index_not_found",
-					},
-				},
+				deleteUid: []string{"TestIndexDeleteNotExistingIndex"},
 			},
 		},
 		{
@@ -68,24 +67,10 @@ func TestIndex_Delete(t *testing.T) {
 			client: defaultClient,
 			args: args{
 				createUid: []string{},
-				deleteUid: []string{"1", "2", "3"},
-			},
-			wantErr: true,
-			expectedError: []Error{
-				{
-					MeilisearchApiError: meilisearchApiError{
-						Code: "index_not_found",
-					},
-				},
-				{
-					MeilisearchApiError: meilisearchApiError{
-						Code: "index_not_found",
-					},
-				},
-				{
-					MeilisearchApiError: meilisearchApiError{
-						Code: "index_not_found",
-					},
+				deleteUid: []string{
+					"TestIndexDeleteMultipleNotExistingIndex_1",
+					"TestIndexDeleteMultipleNotExistingIndex_2",
+					"TestIndexDeleteMultipleNotExistingIndex_3",
 				},
 			},
 		},
@@ -93,21 +78,17 @@ func TestIndex_Delete(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := tt.client
+			t.Cleanup(cleanup(c))
+
 			for _, uid := range tt.args.createUid {
-				_, err := c.CreateIndex(&IndexConfig{Uid: uid})
+				_, err := SetUpEmptyIndex(&IndexConfig{Uid: uid})
 				require.NoError(t, err, "CreateIndex() in DeleteTest error should be nil")
 			}
 			for k := range tt.args.deleteUid {
 				i := c.Index(tt.args.deleteUid[k])
-				gotOk, err := i.Delete(tt.args.deleteUid[k])
-				if tt.wantErr {
-					require.Error(t, err)
-					require.Equal(t, tt.expectedError[k].MeilisearchApiError.Code,
-						err.(*Error).MeilisearchApiError.Code)
-				} else {
-					require.NoError(t, err)
-					require.True(t, gotOk)
-				}
+				gotResp, err := i.Delete(tt.args.deleteUid[k])
+				require.True(t, gotResp)
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -126,7 +107,7 @@ func TestIndex_GetStats(t *testing.T) {
 		{
 			name: "TestIndexBasicGetStats",
 			args: args{
-				UID:    "indexUID",
+				UID:    "TestIndexBasicGetStats",
 				client: defaultClient,
 			},
 			wantResp: &StatsIndex{
@@ -138,7 +119,7 @@ func TestIndex_GetStats(t *testing.T) {
 		{
 			name: "TestIndexGetStatsWithCustomClient",
 			args: args{
-				UID:    "indexUID",
+				UID:    "TestIndexGetStatsWithCustomClient",
 				client: customClient,
 			},
 			wantResp: &StatsIndex{
@@ -150,7 +131,7 @@ func TestIndex_GetStats(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			SetUpBasicIndex()
+			SetUpBasicIndex(tt.args.UID)
 			c := tt.args.client
 			i := c.Index(tt.args.UID)
 			t.Cleanup(cleanup(c))
@@ -187,10 +168,10 @@ func Test_newIndex(t *testing.T) {
 			name: "TestNewIndexCustomClient",
 			args: args{
 				client: customClient,
-				uid:    "TestBasicNewIndex",
+				uid:    "TestNewIndexCustomClient",
 			},
 			want: &Index{
-				UID:    "TestBasicNewIndex",
+				UID:    "TestNewIndexCustomClient",
 				client: customClient,
 			},
 		},
@@ -210,11 +191,11 @@ func Test_newIndex(t *testing.T) {
 	}
 }
 
-func TestIndex_GetUpdateStatus(t *testing.T) {
+func TestIndex_GetTask(t *testing.T) {
 	type args struct {
 		UID      string
 		client   *Client
-		updateID int64
+		taskID   int64
 		document []docTest
 	}
 	tests := []struct {
@@ -222,33 +203,33 @@ func TestIndex_GetUpdateStatus(t *testing.T) {
 		args args
 	}{
 		{
-			name: "TestBasicGetUpdateStatus",
+			name: "TestIndexBasicGetTask",
 			args: args{
-				UID:      "1",
-				client:   defaultClient,
-				updateID: 0,
+				UID:    "TestIndexBasicGetTask",
+				client: defaultClient,
+				taskID: 0,
 				document: []docTest{
 					{ID: "123", Name: "Pride and Prejudice"},
 				},
 			},
 		},
 		{
-			name: "TestGetUpdateStatusWithCustomClient",
+			name: "TestIndexGetTaskWithCustomClient",
 			args: args{
-				UID:      "1",
-				client:   customClient,
-				updateID: 0,
+				UID:    "TestIndexGetTaskWithCustomClient",
+				client: customClient,
+				taskID: 0,
 				document: []docTest{
 					{ID: "123", Name: "Pride and Prejudice"},
 				},
 			},
 		},
 		{
-			name: "TestGetUpdateStatus",
+			name: "TestIndexGetTask",
 			args: args{
-				UID:      "1",
-				client:   defaultClient,
-				updateID: 1,
+				UID:    "TestIndexGetTask",
+				client: defaultClient,
+				taskID: 0,
 				document: []docTest{
 					{ID: "456", Name: "Le Petit Prince"},
 					{ID: "1", Name: "Alice In Wonderland"},
@@ -263,113 +244,58 @@ func TestIndex_GetUpdateStatus(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := tt.args.client
 			i := c.Index(tt.args.UID)
+			t.Cleanup(cleanup(c))
 
-			update, err := i.AddDocuments(tt.args.document)
+			task, err := i.AddDocuments(tt.args.document)
 			require.NoError(t, err)
 
-			gotResp, err := i.GetUpdateStatus(update.UpdateID)
+			_, err = c.DefaultWaitForTask(task)
+			require.NoError(t, err)
+
+			gotResp, err := i.GetTask(task.UID)
 			require.NoError(t, err)
 			require.NotNil(t, gotResp)
-			require.GreaterOrEqual(t, gotResp.UpdateID, tt.args.updateID)
-			require.NotNil(t, gotResp.UpdateID)
+			require.GreaterOrEqual(t, gotResp.UID, tt.args.taskID)
+			require.Equal(t, gotResp.IndexUID, tt.args.UID)
+			require.Equal(t, gotResp.Status, TaskStatusSucceeded)
+
+			// Make sure that timestamps are also retrieved
+			require.NotZero(t, gotResp.EnqueuedAt)
+			require.NotZero(t, gotResp.StartedAt)
+			require.NotZero(t, gotResp.FinishedAt)
 		})
 	}
 }
 
-func TestIndex_GetAllUpdateStatus(t *testing.T) {
-	type args struct {
-		UID    string
-		client *Client
-	}
-	tests := []struct {
-		name     string
-		args     args
-		wantResp []Update
-	}{
-		{
-			name: "TestIndexBasicGetAllUpdateStatus",
-			args: args{
-				UID:    "indexUID",
-				client: defaultClient,
-			},
-			wantResp: []Update{
-				{
-					Status:   "processed",
-					UpdateID: 0,
-					Error:    "",
-				},
-			},
-		},
-		{
-			name: "TestIndexGetAllUpdateStatusWithCustomClient",
-			args: args{
-				UID:    "indexUID",
-				client: customClient,
-			},
-			wantResp: []Update{
-				{
-					Status:   "processed",
-					UpdateID: 0,
-					Error:    "",
-				},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c := tt.args.client
-			i := c.Index(tt.args.UID)
-
-			SetUpBasicIndex()
-
-			gotResp, err := i.GetAllUpdateStatus()
-			require.NoError(t, err)
-			require.Equal(t, tt.wantResp[0].Status, (*gotResp)[0].Status)
-			require.Equal(t, tt.wantResp[0].UpdateID, (*gotResp)[0].UpdateID)
-			require.Equal(t, tt.wantResp[0].Error, (*gotResp)[0].Error)
-		})
-	}
-}
-
-func TestIndex_DefaultWaitForPendingUpdate(t *testing.T) {
+func TestIndex_GetTasks(t *testing.T) {
 	type args struct {
 		UID      string
 		client   *Client
-		updateID *AsyncUpdateID
 		document []docTest
 	}
 	tests := []struct {
 		name string
 		args args
-		want UpdateStatus
 	}{
 		{
-			name: "TestDefaultWaitForPendingUpdate",
+			name: "TestIndexBasicGetTasks",
 			args: args{
-				UID:    "1",
+				UID:    "indexUID",
 				client: defaultClient,
-				updateID: &AsyncUpdateID{
-					UpdateID: 0,
-				},
 				document: []docTest{
 					{ID: "123", Name: "Pride and Prejudice"},
 				},
 			},
-			want: "processed",
 		},
 		{
-			name: "TestDefaultWaitForPendingUpdateWithCustomClient",
+			name: "TestIndexGetTasksWithCustomClient",
 			args: args{
-				UID:    "1",
+				UID:    "indexUID",
 				client: customClient,
-				updateID: &AsyncUpdateID{
-					UpdateID: 0,
-				},
 				document: []docTest{
 					{ID: "123", Name: "Pride and Prejudice"},
 				},
 			},
-			want: "processed",
 		},
 	}
 	for _, tt := range tests {
@@ -378,39 +304,101 @@ func TestIndex_DefaultWaitForPendingUpdate(t *testing.T) {
 			i := c.Index(tt.args.UID)
 			t.Cleanup(cleanup(c))
 
-			update, err := i.AddDocuments(tt.args.document)
+			task, err := i.AddDocuments(tt.args.document)
 			require.NoError(t, err)
 
-			got, err := i.DefaultWaitForPendingUpdate(update)
+			_, err = c.DefaultWaitForTask(task)
 			require.NoError(t, err)
-			require.Equal(t, tt.want, got)
+
+			gotResp, err := i.GetTasks()
+			require.NoError(t, err)
+			require.NotNil(t, (*gotResp).Results[0].Status)
+			require.NotZero(t, (*gotResp).Results[0].UID)
+			require.NotNil(t, (*gotResp).Results[0].Type)
 		})
 	}
 }
 
-func TestIndex_WaitForPendingUpdate(t *testing.T) {
+func TestIndex_DefaultWaitForTask(t *testing.T) {
+	type args struct {
+		UID      string
+		client   *Client
+		taskID   *Task
+		document []docTest
+	}
+	tests := []struct {
+		name string
+		args args
+		want TaskStatus
+	}{
+		{
+			name: "TestDefaultWaitForTask",
+			args: args{
+				UID:    "TestDefaultWaitForTask",
+				client: defaultClient,
+				taskID: &Task{
+					UID: 0,
+				},
+				document: []docTest{
+					{ID: "123", Name: "Pride and Prejudice"},
+				},
+			},
+			want: "succeeded",
+		},
+		{
+			name: "TestDefaultWaitForTaskWithCustomClient",
+			args: args{
+				UID:    "TestDefaultWaitForTaskWithCustomClient",
+				client: customClient,
+				taskID: &Task{
+					UID: 0,
+				},
+				document: []docTest{
+					{ID: "123", Name: "Pride and Prejudice"},
+				},
+			},
+			want: "succeeded",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := tt.args.client
+			i := c.Index(tt.args.UID)
+			t.Cleanup(cleanup(c))
+
+			task, err := i.AddDocuments(tt.args.document)
+			require.NoError(t, err)
+
+			gotTask, err := i.DefaultWaitForTask(task)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, gotTask.Status)
+		})
+	}
+}
+
+func TestIndex_WaitForTask(t *testing.T) {
 	type args struct {
 		UID      string
 		client   *Client
 		interval time.Duration
 		timeout  time.Duration
-		updateID *AsyncUpdateID
+		taskID   *Task
 		document []docTest
 	}
 	tests := []struct {
 		name string
 		args args
-		want UpdateStatus
+		want TaskStatus
 	}{
 		{
-			name: "TestDefaultWaitForPendingUpdate50",
+			name: "TestDefaultWaitForTask50",
 			args: args{
-				UID:      "1",
+				UID:      "TestDefaultWaitForTask50",
 				client:   defaultClient,
 				interval: time.Millisecond * 50,
 				timeout:  time.Second * 5,
-				updateID: &AsyncUpdateID{
-					UpdateID: 0,
+				taskID: &Task{
+					UID: 0,
 				},
 				document: []docTest{
 					{ID: "123", Name: "Pride and Prejudice"},
@@ -418,17 +406,17 @@ func TestIndex_WaitForPendingUpdate(t *testing.T) {
 					{ID: "1", Name: "Alice In Wonderland"},
 				},
 			},
-			want: "processed",
+			want: "succeeded",
 		},
 		{
-			name: "TestDefaultWaitForPendingUpdate50WithCustomClient",
+			name: "TestDefaultWaitForTask50WithCustomClient",
 			args: args{
-				UID:      "1",
+				UID:      "TestDefaultWaitForTask50WithCustomClient",
 				client:   customClient,
 				interval: time.Millisecond * 50,
 				timeout:  time.Second * 5,
-				updateID: &AsyncUpdateID{
-					UpdateID: 0,
+				taskID: &Task{
+					UID: 0,
 				},
 				document: []docTest{
 					{ID: "123", Name: "Pride and Prejudice"},
@@ -436,17 +424,17 @@ func TestIndex_WaitForPendingUpdate(t *testing.T) {
 					{ID: "1", Name: "Alice In Wonderland"},
 				},
 			},
-			want: "processed",
+			want: "succeeded",
 		},
 		{
-			name: "TestDefaultWaitForPendingUpdate10",
+			name: "TestDefaultWaitForTask10",
 			args: args{
-				UID:      "1",
+				UID:      "TestDefaultWaitForTask10",
 				client:   defaultClient,
 				interval: time.Millisecond * 10,
 				timeout:  time.Second * 5,
-				updateID: &AsyncUpdateID{
-					UpdateID: 1,
+				taskID: &Task{
+					UID: 1,
 				},
 				document: []docTest{
 					{ID: "123", Name: "Pride and Prejudice"},
@@ -454,17 +442,17 @@ func TestIndex_WaitForPendingUpdate(t *testing.T) {
 					{ID: "1", Name: "Alice In Wonderland"},
 				},
 			},
-			want: "processed",
+			want: "succeeded",
 		},
 		{
-			name: "TestDefaultWaitForPendingUpdateWithTimeout",
+			name: "TestDefaultWaitForTaskWithTimeout",
 			args: args{
-				UID:      "1",
+				UID:      "TestDefaultWaitForTaskWithTimeout",
 				client:   defaultClient,
 				interval: time.Millisecond * 50,
 				timeout:  time.Millisecond * 10,
-				updateID: &AsyncUpdateID{
-					UpdateID: 1,
+				taskID: &Task{
+					UID: 1,
 				},
 				document: []docTest{
 					{ID: "123", Name: "Pride and Prejudice"},
@@ -472,7 +460,7 @@ func TestIndex_WaitForPendingUpdate(t *testing.T) {
 					{ID: "1", Name: "Alice In Wonderland"},
 				},
 			},
-			want: "processed",
+			want: "succeeded",
 		},
 	}
 	for _, tt := range tests {
@@ -481,18 +469,18 @@ func TestIndex_WaitForPendingUpdate(t *testing.T) {
 			i := c.Index(tt.args.UID)
 			t.Cleanup(cleanup(c))
 
-			update, err := i.AddDocuments(tt.args.document)
+			task, err := i.AddDocuments(tt.args.document)
 			require.NoError(t, err)
 
 			ctx, cancelFunc := context.WithTimeout(context.Background(), tt.args.timeout)
 			defer cancelFunc()
 
-			got, err := i.WaitForPendingUpdate(ctx, tt.args.interval, update)
+			gotTask, err := i.WaitForTask(ctx, tt.args.interval, task)
 			if tt.args.timeout < tt.args.interval {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
-				require.Equal(t, tt.want, got)
+				require.Equal(t, tt.want, gotTask.Status)
 			}
 		})
 	}
@@ -511,29 +499,29 @@ func TestIndex_FetchInfo(t *testing.T) {
 		{
 			name: "TestIndexBasicFetchInfo",
 			args: args{
-				UID:    "indexUID",
+				UID:    "TestIndexBasicFetchInfo",
 				client: defaultClient,
 			},
 			wantResp: &Index{
-				UID:        "indexUID",
+				UID:        "TestIndexBasicFetchInfo",
 				PrimaryKey: "book_id",
 			},
 		},
 		{
 			name: "TestIndexFetchInfoWithCustomClient",
 			args: args{
-				UID:    "indexUID",
+				UID:    "TestIndexFetchInfoWithCustomClient",
 				client: customClient,
 			},
 			wantResp: &Index{
-				UID:        "indexUID",
+				UID:        "TestIndexFetchInfoWithCustomClient",
 				PrimaryKey: "book_id",
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			SetUpBasicIndex()
+			SetUpBasicIndex(tt.args.UID)
 			c := tt.args.client
 			i := c.Index(tt.args.UID)
 			t.Cleanup(cleanup(c))
@@ -562,7 +550,7 @@ func TestIndex_FetchPrimaryKey(t *testing.T) {
 		{
 			name: "TestIndexBasicFetchPrimaryKey",
 			args: args{
-				UID:    "indexUID",
+				UID:    "TestIndexBasicFetchPrimaryKey",
 				client: defaultClient,
 			},
 			wantPrimaryKey: "book_id",
@@ -570,7 +558,7 @@ func TestIndex_FetchPrimaryKey(t *testing.T) {
 		{
 			name: "TestIndexFetchPrimaryKeyWithCustomClient",
 			args: args{
-				UID:    "indexUID",
+				UID:    "TestIndexFetchPrimaryKeyWithCustomClient",
 				client: customClient,
 			},
 			wantPrimaryKey: "book_id",
@@ -578,7 +566,7 @@ func TestIndex_FetchPrimaryKey(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			SetUpBasicIndex()
+			SetUpBasicIndex(tt.args.UID)
 			c := tt.args.client
 			i := c.Index(tt.args.UID)
 			t.Cleanup(cleanup(c))
@@ -634,22 +622,29 @@ func TestIndex_UpdateIndex(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := tt.args.client
 			t.Cleanup(cleanup(c))
-			i, err := c.CreateIndex(&tt.args.config)
+
+			i, err := SetUpEmptyIndex(&tt.args.config)
 			require.NoError(t, err)
 			require.Equal(t, tt.args.config.Uid, i.UID)
-			require.Equal(t, tt.args.config.PrimaryKey, i.PrimaryKey)
 			// Store original timestamps
 			createdAt := i.CreatedAt
 			updatedAt := i.UpdatedAt
 
 			gotResp, err := i.UpdateIndex(tt.args.primaryKey)
+			require.NoError(t, err)
+
+			_, err = c.DefaultWaitForTask(gotResp)
+			require.NoError(t, err)
 
 			require.NoError(t, err)
-			require.Equal(t, tt.wantResp.UID, gotResp.UID)
-			require.Equal(t, tt.wantResp.PrimaryKey, gotResp.PrimaryKey)
+			require.Equal(t, tt.wantResp.UID, gotResp.IndexUID)
+
+			gotIndex, err := c.GetIndex(tt.args.config.Uid)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantResp.PrimaryKey, gotIndex.PrimaryKey)
 			// Make sure that timestamps were correctly updated as well
-			require.Equal(t, createdAt, gotResp.CreatedAt)
-			require.NotEqual(t, updatedAt, gotResp.UpdatedAt)
+			require.Equal(t, createdAt, gotIndex.CreatedAt)
+			require.NotEqual(t, updatedAt, gotIndex.UpdatedAt)
 		})
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -29,7 +29,11 @@ func deleteAllIndexes(client ClientInterface) (ok bool, err error) {
 	}
 
 	for _, index := range list {
-		_, _ = client.DeleteIndex(index.UID)
+		task, _ := client.DeleteIndex(index.UID)
+		_, err := client.DefaultWaitForTask(task)
+		if err != nil {
+			return false, err
+		}
 	}
 
 	return true, nil
@@ -41,24 +45,41 @@ func cleanup(c ClientInterface) func() {
 	}
 }
 
-func testWaitForPendingUpdate(t *testing.T, i *Index, u *AsyncUpdateID) {
-	_, err := i.DefaultWaitForPendingUpdate(u)
+func testWaitForTask(t *testing.T, i *Index, u *Task) {
+	_, err := i.DefaultWaitForTask(u)
 	require.NoError(t, err)
 }
 
-func testWaitForPendingBatchUpdate(t *testing.T, i *Index, u []AsyncUpdateID) {
+func testWaitForBatchTask(t *testing.T, i *Index, u []Task) {
 	for _, id := range u {
-		_, err := i.DefaultWaitForPendingUpdate(&id)
+		_, err := i.DefaultWaitForTask(&id)
 		require.NoError(t, err)
 	}
 }
 
-func SetUpBasicIndex() {
+func SetUpEmptyIndex(index *IndexConfig) (resp *Index, err error) {
 	client := NewClient(ClientConfig{
 		Host:   "http://localhost:7700",
 		APIKey: masterKey,
 	})
-	index := client.Index("indexUID")
+	task, err := client.CreateIndex(index)
+	if err != nil {
+		fmt.Println(err)
+		return nil, err
+	}
+	finalTask, _ := client.DefaultWaitForTask(task)
+	if finalTask.Status != "succeeded" {
+		os.Exit(1)
+	}
+	return client.GetIndex(index.Uid)
+}
+
+func SetUpBasicIndex(indexUID string) {
+	client := NewClient(ClientConfig{
+		Host:   "http://localhost:7700",
+		APIKey: masterKey,
+	})
+	index := client.Index(indexUID)
 
 	documents := []map[string]interface{}{
 		{"book_id": 123, "title": "Pride and Prejudice"},
@@ -68,13 +89,13 @@ func SetUpBasicIndex() {
 		{"book_id": 4, "title": "Harry Potter and the Half-Blood Prince"},
 		{"book_id": 42, "title": "The Hitchhiker's Guide to the Galaxy"},
 	}
-	update, err := index.AddDocuments(documents)
+	task, err := index.AddDocuments(documents)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
-	finalUpdateStatus, _ := index.DefaultWaitForPendingUpdate(update)
-	if finalUpdateStatus != "processed" {
+	finalTask, _ := index.DefaultWaitForTask(task)
+	if finalTask.Status != "succeeded" {
 		os.Exit(1)
 	}
 }
@@ -108,13 +129,13 @@ func SetUpIndexForFaceting() {
 		{BookID: 921, Title: "The Brothers Karamazov", Tag: "Novel", Year: 1879},
 		{BookID: 1032, Title: "Crime and Punishment", Tag: "Crime fiction", Year: 1866},
 	}
-	update, err := index.AddDocuments(booksTest)
+	task, err := index.AddDocuments(booksTest)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
-	finalUpdateStatus, _ := index.DefaultWaitForPendingUpdate(update)
-	if finalUpdateStatus != "processed" {
+	finalTask, _ := index.DefaultWaitForTask(task)
+	if finalTask.Status != "succeeded" {
 		os.Exit(1)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -30,7 +30,7 @@ func deleteAllIndexes(client ClientInterface) (ok bool, err error) {
 
 	for _, index := range list {
 		task, _ := client.DeleteIndex(index.UID)
-		_, err := client.DefaultWaitForTask(task)
+		_, err := client.WaitForTask(task)
 		if err != nil {
 			return false, err
 		}
@@ -46,13 +46,13 @@ func cleanup(c ClientInterface) func() {
 }
 
 func testWaitForTask(t *testing.T, i *Index, u *Task) {
-	_, err := i.DefaultWaitForTask(u)
+	_, err := i.WaitForTask(u)
 	require.NoError(t, err)
 }
 
 func testWaitForBatchTask(t *testing.T, i *Index, u []Task) {
 	for _, id := range u {
-		_, err := i.DefaultWaitForTask(&id)
+		_, err := i.WaitForTask(&id)
 		require.NoError(t, err)
 	}
 }
@@ -67,7 +67,7 @@ func SetUpEmptyIndex(index *IndexConfig) (resp *Index, err error) {
 		fmt.Println(err)
 		return nil, err
 	}
-	finalTask, _ := client.DefaultWaitForTask(task)
+	finalTask, _ := client.WaitForTask(task)
 	if finalTask.Status != "succeeded" {
 		os.Exit(1)
 	}
@@ -94,7 +94,7 @@ func SetUpBasicIndex(indexUID string) {
 		fmt.Println(err)
 		os.Exit(1)
 	}
-	finalTask, _ := index.DefaultWaitForTask(task)
+	finalTask, _ := index.WaitForTask(task)
 	if finalTask.Status != "succeeded" {
 		os.Exit(1)
 	}
@@ -134,7 +134,7 @@ func SetUpIndexForFaceting() {
 		fmt.Println(err)
 		os.Exit(1)
 	}
-	finalTask, _ := index.DefaultWaitForTask(task)
+	finalTask, _ := index.WaitForTask(task)
 	if finalTask.Status != "succeeded" {
 		os.Exit(1)
 	}

--- a/types.go
+++ b/types.go
@@ -58,42 +58,44 @@ type Stats struct {
 	Indexes      map[string]StatsIndex `json:"indexes"`
 }
 
-// UpdateStatus is the status of an update.
-type UpdateStatus string
+// TaskStatus is the status of a task.
+type TaskStatus string
 
 const (
-	// UpdateStatusUnknown is the default UpdateStatus, should not exist
-	UpdateStatusUnknown UpdateStatus = "unknown"
-	// UpdateStatusEnqueued means the server know the update but didn't handle it yet
-	UpdateStatusEnqueued UpdateStatus = "enqueued"
-	// UpdateStatusProcessing means the server is processing the update and all went well
-	UpdateStatusProcessing UpdateStatus = "processing"
-	// UpdateStatusProcessed means the server has processed the update and all went well
-	UpdateStatusProcessed UpdateStatus = "processed"
-	// UpdateStatusFailed means the server has processed the update and an error has been reported
-	UpdateStatusFailed UpdateStatus = "failed"
+	// TaskStatusUnknown is the default TaskStatus, should not exist
+	TaskStatusUnknown TaskStatus = "unknown"
+	// TaskStatusEnqueued the task request has been received and will be processed soon
+	TaskStatusEnqueued TaskStatus = "enqueued"
+	// TaskStatusProcessing the task is being processed
+	TaskStatusProcessing TaskStatus = "processing"
+	// TaskStatusSucceeded the task has been successfully processed
+	TaskStatusSucceeded TaskStatus = "succeeded"
+	// TaskStatusFailed a failure occurred when processing the task, no changes were made to the database
+	TaskStatusFailed TaskStatus = "failed"
 )
 
-// Update indicate information about an update
-type Update struct {
-	Status      UpdateStatus `json:"status"`
-	UpdateID    int64        `json:"updateId"`
-	Type        Unknown      `json:"type"`
-	Error       string       `json:"error"`
-	EnqueuedAt  time.Time    `json:"enqueuedAt"`
-	ProcessedAt time.Time    `json:"processedAt"`
+// Task indicate information about a task is returned for asynchronous method
+//
+// Documentation: https://docs.meilisearch.com/learn/advanced/asynchronous_operations.html
+type Task struct {
+	Status     TaskStatus          `json:"status"`
+	UID        int64               `json:"uid"`
+	IndexUID   string              `json:"indexUid"`
+	Type       string              `json:"type"`
+	Error      meilisearchApiError `json:"error,omitempty"`
+	Duration   string              `json:"duration,omitempty"`
+	EnqueuedAt time.Time           `json:"enqueuedAt"`
+	StartedAt  time.Time           `json:"startedAt,omitempty"`
+	FinishedAt time.Time           `json:"finishedAt,omitempty"`
 }
 
-// AsyncUpdateID is returned for asynchronous method
-//
-// Documentation: https://docs.meilisearch.com/learn/advanced/asynchronous_updates.html
-type AsyncUpdateID struct {
-	UpdateID int64 `json:"updateId"`
+type ResultTask struct {
+	Results []Task `json:"results"`
 }
 
 // Keys allow the user to connect to the MeiliSearch instance
 //
-// Documentation: https://docs.meilisearch.com/learn/advanced/asynchronous_updates.html
+// Documentation: https://docs.meilisearch.com/learn/advanced/security.html#protecting-a-meilisearch-instance
 type Keys struct {
 	Public  string `json:"public,omitempty"`
 	Private string `json:"private,omitempty"`

--- a/types_easyjson.go
+++ b/types_easyjson.go
@@ -163,7 +163,7 @@ func (v *UpdateIndexRequest) UnmarshalJSON(data []byte) error {
 func (v *UpdateIndexRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo1(l, v)
 }
-func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo2(in *jlexer.Lexer, out *Update) {
+func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo2(in *jlexer.Lexer, out *Task) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -183,40 +183,28 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo2(in *jlexer.Lexer, 
 		}
 		switch key {
 		case "status":
-			out.Status = UpdateStatus(in.String())
-		case "updateId":
-			out.UpdateID = int64(in.Int64())
+			out.Status = TaskStatus(in.String())
+		case "uid":
+			out.UID = int64(in.Int64())
+		case "indexUid":
+			out.IndexUID = string(in.String())
 		case "type":
-			if in.IsNull() {
-				in.Skip()
-			} else {
-				in.Delim('{')
-				out.Type = make(Unknown)
-				for !in.IsDelim('}') {
-					key := string(in.String())
-					in.WantColon()
-					var v1 interface{}
-					if m, ok := v1.(easyjson.Unmarshaler); ok {
-						m.UnmarshalEasyJSON(in)
-					} else if m, ok := v1.(json.Unmarshaler); ok {
-						_ = m.UnmarshalJSON(in.Raw())
-					} else {
-						v1 = in.Interface()
-					}
-					(out.Type)[key] = v1
-					in.WantComma()
-				}
-				in.Delim('}')
-			}
+			out.Type = string(in.String())
 		case "error":
-			out.Error = string(in.String())
+			easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo3(in, &out.Error)
+		case "duration":
+			out.Duration = string(in.String())
 		case "enqueuedAt":
 			if data := in.Raw(); in.Ok() {
 				in.AddError((out.EnqueuedAt).UnmarshalJSON(data))
 			}
-		case "processedAt":
+		case "startedAt":
 			if data := in.Raw(); in.Ok() {
-				in.AddError((out.ProcessedAt).UnmarshalJSON(data))
+				in.AddError((out.StartedAt).UnmarshalJSON(data))
+			}
+		case "finishedAt":
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.FinishedAt).UnmarshalJSON(data))
 			}
 		default:
 			in.SkipRecursive()
@@ -228,7 +216,7 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo2(in *jlexer.Lexer, 
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo2(out *jwriter.Writer, in Update) {
+func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo2(out *jwriter.Writer, in Task) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -238,79 +226,135 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo2(out *jwriter.Write
 		out.String(string(in.Status))
 	}
 	{
-		const prefix string = ",\"updateId\":"
+		const prefix string = ",\"uid\":"
 		out.RawString(prefix)
-		out.Int64(int64(in.UpdateID))
+		out.Int64(int64(in.UID))
+	}
+	{
+		const prefix string = ",\"indexUid\":"
+		out.RawString(prefix)
+		out.String(string(in.IndexUID))
 	}
 	{
 		const prefix string = ",\"type\":"
 		out.RawString(prefix)
-		if in.Type == nil && (out.Flags&jwriter.NilMapAsEmpty) == 0 {
-			out.RawString(`null`)
-		} else {
-			out.RawByte('{')
-			v2First := true
-			for v2Name, v2Value := range in.Type {
-				if v2First {
-					v2First = false
-				} else {
-					out.RawByte(',')
-				}
-				out.String(string(v2Name))
-				out.RawByte(':')
-				if m, ok := v2Value.(easyjson.Marshaler); ok {
-					m.MarshalEasyJSON(out)
-				} else if m, ok := v2Value.(json.Marshaler); ok {
-					out.Raw(m.MarshalJSON())
-				} else {
-					out.Raw(json.Marshal(v2Value))
-				}
-			}
-			out.RawByte('}')
-		}
+		out.String(string(in.Type))
 	}
-	{
+	if true {
 		const prefix string = ",\"error\":"
 		out.RawString(prefix)
-		out.String(string(in.Error))
+		easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo3(out, in.Error)
+	}
+	if in.Duration != "" {
+		const prefix string = ",\"duration\":"
+		out.RawString(prefix)
+		out.String(string(in.Duration))
 	}
 	{
 		const prefix string = ",\"enqueuedAt\":"
 		out.RawString(prefix)
 		out.Raw((in.EnqueuedAt).MarshalJSON())
 	}
-	{
-		const prefix string = ",\"processedAt\":"
+	if true {
+		const prefix string = ",\"startedAt\":"
 		out.RawString(prefix)
-		out.Raw((in.ProcessedAt).MarshalJSON())
+		out.Raw((in.StartedAt).MarshalJSON())
+	}
+	if true {
+		const prefix string = ",\"finishedAt\":"
+		out.RawString(prefix)
+		out.Raw((in.FinishedAt).MarshalJSON())
 	}
 	out.RawByte('}')
 }
 
 // MarshalJSON supports json.Marshaler interface
-func (v Update) MarshalJSON() ([]byte, error) {
+func (v Task) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
 	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo2(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v Update) MarshalEasyJSON(w *jwriter.Writer) {
+func (v Task) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo2(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
-func (v *Update) UnmarshalJSON(data []byte) error {
+func (v *Task) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
 	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo2(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *Update) UnmarshalEasyJSON(l *jlexer.Lexer) {
+func (v *Task) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo2(l, v)
 }
-func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo3(in *jlexer.Lexer, out *StatsIndex) {
+func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo3(in *jlexer.Lexer, out *meilisearchApiError) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "message":
+			out.Message = string(in.String())
+		case "code":
+			out.Code = string(in.String())
+		case "type":
+			out.Type = string(in.String())
+		case "link":
+			out.Link = string(in.String())
+		default:
+			in.SkipRecursive()
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo3(out *jwriter.Writer, in meilisearchApiError) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	{
+		const prefix string = ",\"message\":"
+		out.RawString(prefix[1:])
+		out.String(string(in.Message))
+	}
+	{
+		const prefix string = ",\"code\":"
+		out.RawString(prefix)
+		out.String(string(in.Code))
+	}
+	{
+		const prefix string = ",\"type\":"
+		out.RawString(prefix)
+		out.String(string(in.Type))
+	}
+	{
+		const prefix string = ",\"link\":"
+		out.RawString(prefix)
+		out.String(string(in.Link))
+	}
+	out.RawByte('}')
+}
+func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo4(in *jlexer.Lexer, out *StatsIndex) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -342,9 +386,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo3(in *jlexer.Lexer, 
 				for !in.IsDelim('}') {
 					key := string(in.String())
 					in.WantColon()
-					var v3 int64
-					v3 = int64(in.Int64())
-					(out.FieldDistribution)[key] = v3
+					var v1 int64
+					v1 = int64(in.Int64())
+					(out.FieldDistribution)[key] = v1
 					in.WantComma()
 				}
 				in.Delim('}')
@@ -359,7 +403,7 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo3(in *jlexer.Lexer, 
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo3(out *jwriter.Writer, in StatsIndex) {
+func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo4(out *jwriter.Writer, in StatsIndex) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -380,16 +424,16 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo3(out *jwriter.Write
 			out.RawString(`null`)
 		} else {
 			out.RawByte('{')
-			v4First := true
-			for v4Name, v4Value := range in.FieldDistribution {
-				if v4First {
-					v4First = false
+			v2First := true
+			for v2Name, v2Value := range in.FieldDistribution {
+				if v2First {
+					v2First = false
 				} else {
 					out.RawByte(',')
 				}
-				out.String(string(v4Name))
+				out.String(string(v2Name))
 				out.RawByte(':')
-				out.Int64(int64(v4Value))
+				out.Int64(int64(v2Value))
 			}
 			out.RawByte('}')
 		}
@@ -400,27 +444,27 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo3(out *jwriter.Write
 // MarshalJSON supports json.Marshaler interface
 func (v StatsIndex) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo3(&w, v)
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo4(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v StatsIndex) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo3(w, v)
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo4(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *StatsIndex) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo3(&r, v)
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo4(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *StatsIndex) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo3(l, v)
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo4(l, v)
 }
-func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo4(in *jlexer.Lexer, out *Stats) {
+func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo5(in *jlexer.Lexer, out *Stats) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -454,9 +498,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo4(in *jlexer.Lexer, 
 				for !in.IsDelim('}') {
 					key := string(in.String())
 					in.WantColon()
-					var v5 StatsIndex
-					(v5).UnmarshalEasyJSON(in)
-					(out.Indexes)[key] = v5
+					var v3 StatsIndex
+					(v3).UnmarshalEasyJSON(in)
+					(out.Indexes)[key] = v3
 					in.WantComma()
 				}
 				in.Delim('}')
@@ -471,7 +515,7 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo4(in *jlexer.Lexer, 
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo4(out *jwriter.Writer, in Stats) {
+func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo5(out *jwriter.Writer, in Stats) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -492,16 +536,16 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo4(out *jwriter.Write
 			out.RawString(`null`)
 		} else {
 			out.RawByte('{')
-			v6First := true
-			for v6Name, v6Value := range in.Indexes {
-				if v6First {
-					v6First = false
+			v4First := true
+			for v4Name, v4Value := range in.Indexes {
+				if v4First {
+					v4First = false
 				} else {
 					out.RawByte(',')
 				}
-				out.String(string(v6Name))
+				out.String(string(v4Name))
 				out.RawByte(':')
-				(v6Value).MarshalEasyJSON(out)
+				(v4Value).MarshalEasyJSON(out)
 			}
 			out.RawByte('}')
 		}
@@ -512,27 +556,27 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo4(out *jwriter.Write
 // MarshalJSON supports json.Marshaler interface
 func (v Stats) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo4(&w, v)
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo5(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v Stats) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo4(w, v)
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo5(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *Stats) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo4(&r, v)
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo5(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *Stats) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo4(l, v)
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo5(l, v)
 }
-func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo5(in *jlexer.Lexer, out *Settings) {
+func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo6(in *jlexer.Lexer, out *Settings) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -567,9 +611,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo5(in *jlexer.Lexer, 
 					out.RankingRules = (out.RankingRules)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v7 string
-					v7 = string(in.String())
-					out.RankingRules = append(out.RankingRules, v7)
+					var v5 string
+					v5 = string(in.String())
+					out.RankingRules = append(out.RankingRules, v5)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -600,9 +644,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo5(in *jlexer.Lexer, 
 					out.SearchableAttributes = (out.SearchableAttributes)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v8 string
-					v8 = string(in.String())
-					out.SearchableAttributes = append(out.SearchableAttributes, v8)
+					var v6 string
+					v6 = string(in.String())
+					out.SearchableAttributes = append(out.SearchableAttributes, v6)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -623,9 +667,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo5(in *jlexer.Lexer, 
 					out.DisplayedAttributes = (out.DisplayedAttributes)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v9 string
-					v9 = string(in.String())
-					out.DisplayedAttributes = append(out.DisplayedAttributes, v9)
+					var v7 string
+					v7 = string(in.String())
+					out.DisplayedAttributes = append(out.DisplayedAttributes, v7)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -646,9 +690,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo5(in *jlexer.Lexer, 
 					out.StopWords = (out.StopWords)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v10 string
-					v10 = string(in.String())
-					out.StopWords = append(out.StopWords, v10)
+					var v8 string
+					v8 = string(in.String())
+					out.StopWords = append(out.StopWords, v8)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -666,30 +710,30 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo5(in *jlexer.Lexer, 
 				for !in.IsDelim('}') {
 					key := string(in.String())
 					in.WantColon()
-					var v11 []string
+					var v9 []string
 					if in.IsNull() {
 						in.Skip()
-						v11 = nil
+						v9 = nil
 					} else {
 						in.Delim('[')
-						if v11 == nil {
+						if v9 == nil {
 							if !in.IsDelim(']') {
-								v11 = make([]string, 0, 4)
+								v9 = make([]string, 0, 4)
 							} else {
-								v11 = []string{}
+								v9 = []string{}
 							}
 						} else {
-							v11 = (v11)[:0]
+							v9 = (v9)[:0]
 						}
 						for !in.IsDelim(']') {
-							var v12 string
-							v12 = string(in.String())
-							v11 = append(v11, v12)
+							var v10 string
+							v10 = string(in.String())
+							v9 = append(v9, v10)
 							in.WantComma()
 						}
 						in.Delim(']')
 					}
-					(out.Synonyms)[key] = v11
+					(out.Synonyms)[key] = v9
 					in.WantComma()
 				}
 				in.Delim('}')
@@ -710,9 +754,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo5(in *jlexer.Lexer, 
 					out.FilterableAttributes = (out.FilterableAttributes)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v13 string
-					v13 = string(in.String())
-					out.FilterableAttributes = append(out.FilterableAttributes, v13)
+					var v11 string
+					v11 = string(in.String())
+					out.FilterableAttributes = append(out.FilterableAttributes, v11)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -733,9 +777,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo5(in *jlexer.Lexer, 
 					out.SortableAttributes = (out.SortableAttributes)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v14 string
-					v14 = string(in.String())
-					out.SortableAttributes = append(out.SortableAttributes, v14)
+					var v12 string
+					v12 = string(in.String())
+					out.SortableAttributes = append(out.SortableAttributes, v12)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -750,7 +794,7 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo5(in *jlexer.Lexer, 
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo5(out *jwriter.Writer, in Settings) {
+func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo6(out *jwriter.Writer, in Settings) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -760,11 +804,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo5(out *jwriter.Write
 		out.RawString(prefix[1:])
 		{
 			out.RawByte('[')
-			for v15, v16 := range in.RankingRules {
-				if v15 > 0 {
+			for v13, v14 := range in.RankingRules {
+				if v13 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v16))
+				out.String(string(v14))
 			}
 			out.RawByte(']')
 		}
@@ -789,11 +833,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo5(out *jwriter.Write
 		}
 		{
 			out.RawByte('[')
-			for v17, v18 := range in.SearchableAttributes {
-				if v17 > 0 {
+			for v15, v16 := range in.SearchableAttributes {
+				if v15 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v18))
+				out.String(string(v16))
 			}
 			out.RawByte(']')
 		}
@@ -808,11 +852,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo5(out *jwriter.Write
 		}
 		{
 			out.RawByte('[')
-			for v19, v20 := range in.DisplayedAttributes {
-				if v19 > 0 {
+			for v17, v18 := range in.DisplayedAttributes {
+				if v17 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v20))
+				out.String(string(v18))
 			}
 			out.RawByte(']')
 		}
@@ -827,11 +871,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo5(out *jwriter.Write
 		}
 		{
 			out.RawByte('[')
-			for v21, v22 := range in.StopWords {
-				if v21 > 0 {
+			for v19, v20 := range in.StopWords {
+				if v19 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v22))
+				out.String(string(v20))
 			}
 			out.RawByte(']')
 		}
@@ -846,24 +890,24 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo5(out *jwriter.Write
 		}
 		{
 			out.RawByte('{')
-			v23First := true
-			for v23Name, v23Value := range in.Synonyms {
-				if v23First {
-					v23First = false
+			v21First := true
+			for v21Name, v21Value := range in.Synonyms {
+				if v21First {
+					v21First = false
 				} else {
 					out.RawByte(',')
 				}
-				out.String(string(v23Name))
+				out.String(string(v21Name))
 				out.RawByte(':')
-				if v23Value == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+				if v21Value == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
 					out.RawString("null")
 				} else {
 					out.RawByte('[')
-					for v24, v25 := range v23Value {
-						if v24 > 0 {
+					for v22, v23 := range v21Value {
+						if v22 > 0 {
 							out.RawByte(',')
 						}
-						out.String(string(v25))
+						out.String(string(v23))
 					}
 					out.RawByte(']')
 				}
@@ -881,11 +925,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo5(out *jwriter.Write
 		}
 		{
 			out.RawByte('[')
-			for v26, v27 := range in.FilterableAttributes {
-				if v26 > 0 {
+			for v24, v25 := range in.FilterableAttributes {
+				if v24 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v27))
+				out.String(string(v25))
 			}
 			out.RawByte(']')
 		}
@@ -900,11 +944,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo5(out *jwriter.Write
 		}
 		{
 			out.RawByte('[')
-			for v28, v29 := range in.SortableAttributes {
-				if v28 > 0 {
+			for v26, v27 := range in.SortableAttributes {
+				if v26 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v29))
+				out.String(string(v27))
 			}
 			out.RawByte(']')
 		}
@@ -915,27 +959,27 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo5(out *jwriter.Write
 // MarshalJSON supports json.Marshaler interface
 func (v Settings) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo5(&w, v)
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo6(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v Settings) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo5(w, v)
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo6(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *Settings) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo5(&r, v)
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo6(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *Settings) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo5(l, v)
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo6(l, v)
 }
-func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo6(in *jlexer.Lexer, out *SearchResponse) {
+func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo7(in *jlexer.Lexer, out *SearchResponse) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -970,15 +1014,15 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo6(in *jlexer.Lexer, 
 					out.Hits = (out.Hits)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v30 interface{}
-					if m, ok := v30.(easyjson.Unmarshaler); ok {
+					var v28 interface{}
+					if m, ok := v28.(easyjson.Unmarshaler); ok {
 						m.UnmarshalEasyJSON(in)
-					} else if m, ok := v30.(json.Unmarshaler); ok {
+					} else if m, ok := v28.(json.Unmarshaler); ok {
 						_ = m.UnmarshalJSON(in.Raw())
 					} else {
-						v30 = in.Interface()
+						v28 = in.Interface()
 					}
-					out.Hits = append(out.Hits, v30)
+					out.Hits = append(out.Hits, v28)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1021,7 +1065,7 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo6(in *jlexer.Lexer, 
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo6(out *jwriter.Writer, in SearchResponse) {
+func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo7(out *jwriter.Writer, in SearchResponse) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1032,16 +1076,16 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo6(out *jwriter.Write
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v31, v32 := range in.Hits {
-				if v31 > 0 {
+			for v29, v30 := range in.Hits {
+				if v29 > 0 {
 					out.RawByte(',')
 				}
-				if m, ok := v32.(easyjson.Marshaler); ok {
+				if m, ok := v30.(easyjson.Marshaler); ok {
 					m.MarshalEasyJSON(out)
-				} else if m, ok := v32.(json.Marshaler); ok {
+				} else if m, ok := v30.(json.Marshaler); ok {
 					out.Raw(m.MarshalJSON())
 				} else {
-					out.Raw(json.Marshal(v32))
+					out.Raw(json.Marshal(v30))
 				}
 			}
 			out.RawByte(']')
@@ -1105,27 +1149,27 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo6(out *jwriter.Write
 // MarshalJSON supports json.Marshaler interface
 func (v SearchResponse) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo6(&w, v)
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo7(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v SearchResponse) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo6(w, v)
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo7(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *SearchResponse) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo6(&r, v)
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo7(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *SearchResponse) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo6(l, v)
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo7(l, v)
 }
-func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo7(in *jlexer.Lexer, out *SearchRequest) {
+func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo8(in *jlexer.Lexer, out *SearchRequest) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -1164,9 +1208,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo7(in *jlexer.Lexer, 
 					out.AttributesToRetrieve = (out.AttributesToRetrieve)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v33 string
-					v33 = string(in.String())
-					out.AttributesToRetrieve = append(out.AttributesToRetrieve, v33)
+					var v31 string
+					v31 = string(in.String())
+					out.AttributesToRetrieve = append(out.AttributesToRetrieve, v31)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1187,9 +1231,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo7(in *jlexer.Lexer, 
 					out.AttributesToCrop = (out.AttributesToCrop)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v34 string
-					v34 = string(in.String())
-					out.AttributesToCrop = append(out.AttributesToCrop, v34)
+					var v32 string
+					v32 = string(in.String())
+					out.AttributesToCrop = append(out.AttributesToCrop, v32)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1212,9 +1256,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo7(in *jlexer.Lexer, 
 					out.AttributesToHighlight = (out.AttributesToHighlight)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v35 string
-					v35 = string(in.String())
-					out.AttributesToHighlight = append(out.AttributesToHighlight, v35)
+					var v33 string
+					v33 = string(in.String())
+					out.AttributesToHighlight = append(out.AttributesToHighlight, v33)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1245,9 +1289,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo7(in *jlexer.Lexer, 
 					out.FacetsDistribution = (out.FacetsDistribution)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v36 string
-					v36 = string(in.String())
-					out.FacetsDistribution = append(out.FacetsDistribution, v36)
+					var v34 string
+					v34 = string(in.String())
+					out.FacetsDistribution = append(out.FacetsDistribution, v34)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1270,9 +1314,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo7(in *jlexer.Lexer, 
 					out.Sort = (out.Sort)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v37 string
-					v37 = string(in.String())
-					out.Sort = append(out.Sort, v37)
+					var v35 string
+					v35 = string(in.String())
+					out.Sort = append(out.Sort, v35)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1287,7 +1331,7 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo7(in *jlexer.Lexer, 
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo7(out *jwriter.Writer, in SearchRequest) {
+func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo8(out *jwriter.Writer, in SearchRequest) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1308,11 +1352,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo7(out *jwriter.Write
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v38, v39 := range in.AttributesToRetrieve {
-				if v38 > 0 {
+			for v36, v37 := range in.AttributesToRetrieve {
+				if v36 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v39))
+				out.String(string(v37))
 			}
 			out.RawByte(']')
 		}
@@ -1324,11 +1368,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo7(out *jwriter.Write
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v40, v41 := range in.AttributesToCrop {
-				if v40 > 0 {
+			for v38, v39 := range in.AttributesToCrop {
+				if v38 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v41))
+				out.String(string(v39))
 			}
 			out.RawByte(']')
 		}
@@ -1345,11 +1389,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo7(out *jwriter.Write
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v42, v43 := range in.AttributesToHighlight {
-				if v42 > 0 {
+			for v40, v41 := range in.AttributesToHighlight {
+				if v40 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v43))
+				out.String(string(v41))
 			}
 			out.RawByte(']')
 		}
@@ -1377,11 +1421,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo7(out *jwriter.Write
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v44, v45 := range in.FacetsDistribution {
-				if v44 > 0 {
+			for v42, v43 := range in.FacetsDistribution {
+				if v42 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v45))
+				out.String(string(v43))
 			}
 			out.RawByte(']')
 		}
@@ -1398,11 +1442,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo7(out *jwriter.Write
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v46, v47 := range in.Sort {
-				if v46 > 0 {
+			for v44, v45 := range in.Sort {
+				if v44 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v47))
+				out.String(string(v45))
 			}
 			out.RawByte(']')
 		}
@@ -1413,27 +1457,125 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo7(out *jwriter.Write
 // MarshalJSON supports json.Marshaler interface
 func (v SearchRequest) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo7(&w, v)
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo8(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v SearchRequest) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo7(w, v)
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo8(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *SearchRequest) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo7(&r, v)
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo8(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *SearchRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo7(l, v)
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo8(l, v)
 }
-func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo8(in *jlexer.Lexer, out *Keys) {
+func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo9(in *jlexer.Lexer, out *ResultTask) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "results":
+			if in.IsNull() {
+				in.Skip()
+				out.Results = nil
+			} else {
+				in.Delim('[')
+				if out.Results == nil {
+					if !in.IsDelim(']') {
+						out.Results = make([]Task, 0, 0)
+					} else {
+						out.Results = []Task{}
+					}
+				} else {
+					out.Results = (out.Results)[:0]
+				}
+				for !in.IsDelim(']') {
+					var v46 Task
+					(v46).UnmarshalEasyJSON(in)
+					out.Results = append(out.Results, v46)
+					in.WantComma()
+				}
+				in.Delim(']')
+			}
+		default:
+			in.SkipRecursive()
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo9(out *jwriter.Writer, in ResultTask) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	{
+		const prefix string = ",\"results\":"
+		out.RawString(prefix[1:])
+		if in.Results == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+			out.RawString("null")
+		} else {
+			out.RawByte('[')
+			for v47, v48 := range in.Results {
+				if v47 > 0 {
+					out.RawByte(',')
+				}
+				(v48).MarshalEasyJSON(out)
+			}
+			out.RawByte(']')
+		}
+	}
+	out.RawByte('}')
+}
+
+// MarshalJSON supports json.Marshaler interface
+func (v ResultTask) MarshalJSON() ([]byte, error) {
+	w := jwriter.Writer{}
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo9(&w, v)
+	return w.Buffer.BuildBytes(), w.Error
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v ResultTask) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo9(w, v)
+}
+
+// UnmarshalJSON supports json.Unmarshaler interface
+func (v *ResultTask) UnmarshalJSON(data []byte) error {
+	r := jlexer.Lexer{Data: data}
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo9(&r, v)
+	return r.Error()
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *ResultTask) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo9(l, v)
+}
+func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo10(in *jlexer.Lexer, out *Keys) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -1466,7 +1608,7 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo8(in *jlexer.Lexer, 
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo8(out *jwriter.Writer, in Keys) {
+func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo10(out *jwriter.Writer, in Keys) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1492,27 +1634,27 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo8(out *jwriter.Write
 // MarshalJSON supports json.Marshaler interface
 func (v Keys) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo8(&w, v)
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo10(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v Keys) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo8(w, v)
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo10(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *Keys) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo8(&r, v)
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo10(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *Keys) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo8(l, v)
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo10(l, v)
 }
-func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo9(in *jlexer.Lexer, out *Index) {
+func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo11(in *jlexer.Lexer, out *Index) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -1553,7 +1695,7 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo9(in *jlexer.Lexer, 
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo9(out *jwriter.Writer, in Index) {
+func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo11(out *jwriter.Writer, in Index) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1583,27 +1725,27 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo9(out *jwriter.Write
 // MarshalJSON supports json.Marshaler interface
 func (v Index) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo9(&w, v)
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo11(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v Index) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo9(w, v)
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo11(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *Index) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo9(&r, v)
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo11(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *Index) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo9(l, v)
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo11(l, v)
 }
-func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo10(in *jlexer.Lexer, out *Health) {
+func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo12(in *jlexer.Lexer, out *Health) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -1634,7 +1776,7 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo10(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo10(out *jwriter.Writer, in Health) {
+func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo12(out *jwriter.Writer, in Health) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1649,27 +1791,27 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo10(out *jwriter.Writ
 // MarshalJSON supports json.Marshaler interface
 func (v Health) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo10(&w, v)
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo12(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v Health) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo10(w, v)
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo12(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *Health) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo10(&r, v)
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo12(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *Health) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo10(l, v)
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo12(l, v)
 }
-func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo11(in *jlexer.Lexer, out *Dump) {
+func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo13(in *jlexer.Lexer, out *Dump) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -1710,7 +1852,7 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo11(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo11(out *jwriter.Writer, in Dump) {
+func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo13(out *jwriter.Writer, in Dump) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1740,27 +1882,27 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo11(out *jwriter.Writ
 // MarshalJSON supports json.Marshaler interface
 func (v Dump) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo11(&w, v)
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo13(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v Dump) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo11(w, v)
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo13(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *Dump) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo11(&r, v)
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo13(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *Dump) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo11(l, v)
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo13(l, v)
 }
-func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo12(in *jlexer.Lexer, out *DocumentsRequest) {
+func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo14(in *jlexer.Lexer, out *DocumentsRequest) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -1799,9 +1941,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo12(in *jlexer.Lexer,
 					out.AttributesToRetrieve = (out.AttributesToRetrieve)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v48 string
-					v48 = string(in.String())
-					out.AttributesToRetrieve = append(out.AttributesToRetrieve, v48)
+					var v49 string
+					v49 = string(in.String())
+					out.AttributesToRetrieve = append(out.AttributesToRetrieve, v49)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1816,7 +1958,7 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo12(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo12(out *jwriter.Writer, in DocumentsRequest) {
+func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo14(out *jwriter.Writer, in DocumentsRequest) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1846,11 +1988,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo12(out *jwriter.Writ
 		}
 		{
 			out.RawByte('[')
-			for v49, v50 := range in.AttributesToRetrieve {
-				if v49 > 0 {
+			for v50, v51 := range in.AttributesToRetrieve {
+				if v50 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v50))
+				out.String(string(v51))
 			}
 			out.RawByte(']')
 		}
@@ -1861,27 +2003,27 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo12(out *jwriter.Writ
 // MarshalJSON supports json.Marshaler interface
 func (v DocumentsRequest) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo12(&w, v)
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo14(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v DocumentsRequest) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo12(w, v)
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo14(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *DocumentsRequest) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo12(&r, v)
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo14(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *DocumentsRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo12(l, v)
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo14(l, v)
 }
-func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo13(in *jlexer.Lexer, out *CreateIndexRequest) {
+func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo15(in *jlexer.Lexer, out *CreateIndexRequest) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -1914,7 +2056,7 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo13(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo13(out *jwriter.Writer, in CreateIndexRequest) {
+func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo15(out *jwriter.Writer, in CreateIndexRequest) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1940,27 +2082,27 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo13(out *jwriter.Writ
 // MarshalJSON supports json.Marshaler interface
 func (v CreateIndexRequest) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo13(&w, v)
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo15(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v CreateIndexRequest) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo13(w, v)
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo15(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *CreateIndexRequest) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo13(&r, v)
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo15(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *CreateIndexRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo13(l, v)
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo15(l, v)
 }
-func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo14(in *jlexer.Lexer, out *Client) {
+func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo16(in *jlexer.Lexer, out *Client) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -1989,7 +2131,7 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo14(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo14(out *jwriter.Writer, in Client) {
+func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo16(out *jwriter.Writer, in Client) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1999,89 +2141,23 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo14(out *jwriter.Writ
 // MarshalJSON supports json.Marshaler interface
 func (v Client) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo14(&w, v)
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo16(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v Client) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo14(w, v)
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo16(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *Client) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo14(&r, v)
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo16(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *Client) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo14(l, v)
-}
-func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo15(in *jlexer.Lexer, out *AsyncUpdateID) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "updateId":
-			out.UpdateID = int64(in.Int64())
-		default:
-			in.SkipRecursive()
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo15(out *jwriter.Writer, in AsyncUpdateID) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	{
-		const prefix string = ",\"updateId\":"
-		out.RawString(prefix[1:])
-		out.Int64(int64(in.UpdateID))
-	}
-	out.RawByte('}')
-}
-
-// MarshalJSON supports json.Marshaler interface
-func (v AsyncUpdateID) MarshalJSON() ([]byte, error) {
-	w := jwriter.Writer{}
-	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo15(&w, v)
-	return w.Buffer.BuildBytes(), w.Error
-}
-
-// MarshalEasyJSON supports easyjson.Marshaler interface
-func (v AsyncUpdateID) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo15(w, v)
-}
-
-// UnmarshalJSON supports json.Unmarshaler interface
-func (v *AsyncUpdateID) UnmarshalJSON(data []byte) error {
-	r := jlexer.Lexer{Data: data}
-	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo15(&r, v)
-	return r.Error()
-}
-
-// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *AsyncUpdateID) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo15(l, v)
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo16(l, v)
 }


### PR DESCRIPTION
### Breaking Changes
All the actions on indexes are now asynchronous:
- `CreateIndex()`, `UpdateIndex()`, `DeleteIndex()` return a `Task` response instead of an `Index`.
- `index.Create` and `index.Delete` from index return a `task`.
- `WaitForPendingUpdate()`
    - is renamed into `WaitForTask`
    - the current `index.WaitForTask()` method call `/tasks/:uid`
- `index.GetUpdateStatus` is renamed `index.GetTask`
- `index.GetAllUpdateStatus` is renamed `index.GetTasks`

**Notes:** The only two methods that now return an `Index` are `client.Index()` and `client.GetIndex()`

### Enhancements
- new method `client.WaitForTask()` call `/tasks/:uid`
- new method `client.WaitForTask()`
- new method `client.GetTasks` that calls `/tasks`
- new method `client.GetTask` that calls `/tasks/:uid`
