### PR TITLE
Feature/Analytics

### DIFF
--- a/client_request.go
+++ b/client_request.go
@@ -137,6 +137,8 @@ func (c *Client) sendRequest(req *internalRequest, internalError *Error, respons
 		request.Header.Set("Authorization", "Bearer "+c.config.APIKey)
 	}
 
+	request.Header.Set("User-Agent", GetQualifiedVersion())
+
 	// request is sent
 	if c.config.Timeout != 0 {
 		err = c.httpClient.DoTimeout(request, response, c.config.Timeout)

--- a/version.go
+++ b/version.go
@@ -1,0 +1,13 @@
+package meilisearch
+
+import "fmt"
+
+const VERSION = "0.19.1"
+
+func GetQualifiedVersion() (qualifiedVersion string) {
+	return getQualifiedVersion(VERSION)
+}
+
+func getQualifiedVersion(version string) (qualifiedVersion string) {
+	return fmt.Sprintf("Meilisearch Go (v%s)", version)
+}

--- a/version_test.go
+++ b/version_test.go
@@ -1,0 +1,30 @@
+package meilisearch
+
+import (
+	"testing"
+	"fmt"
+	"regexp"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVersion_GetQualifiedVersion(t *testing.T) {
+	version := GetQualifiedVersion()
+
+	require.NotNil(t, version)
+	require.Equal(t, version, fmt.Sprintf("Meilisearch Go (v%s)", VERSION))
+}
+
+func TestVersion_qualifiedVersionFormat(t *testing.T) {
+	version := getQualifiedVersion("2.2.5")
+
+	require.NotNil(t, version)
+	require.Equal(t, version, "Meilisearch Go (v2.2.5)")
+}
+
+func TestVersion_constVERSIONFormat(t *testing.T) {
+	match, _ := regexp.MatchString("[0-9]+.[0-9]+.[0-9]+", VERSION)
+
+	assert.True(t, match)
+}


### PR DESCRIPTION
- Add `User-Agent` inside the pre-defined headers

Add Go support as requested here meilisearch/integration-guides#150

I tried other options, but they do not fit so well:

- https://pkg.go.dev/debug/buildinfo (does not work very well :/ has a lot of issues https://github.com/golang/go/issues/29814, https://github.com/golang/go/issues/33975
- https://github.com/ahmetb/govvv (I think it is not an option since it seems to be not maintained anymore).
