### PR TITLE
Add a new Github workflow step to release

### DIFF
--- a/.github/scripts/check-release.sh
+++ b/.github/scripts/check-release.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# Checking if current tag matches the package version
+current_tag=$(echo $GITHUB_REF | tr -d 'refs/tags/')
+file1='version.go'
+file_tag1=$(grep 'const VERSION' -A 0 $file1 | cut -d '=' -f2 | tr -d '"' | tr -d ' ')
+
+if [ "$current_tag" != "$file_tag1" ]; then
+  echo "Error: the current tag does not match the version in package file(s)."
+  echo "$file1: found $file_tag1 - expected $current_tag"
+  exit 1
+fi
+
+echo 'OK'
+exit 0

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -1,0 +1,15 @@
+name: Validate release version
+
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  publish:
+    name: Validate release version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check release validity
+        run: sh .github/scripts/check-release.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,6 +110,12 @@ _[Read more about this](https://github.com/meilisearch/integration-guides/blob/m
 
 ⚠️ Before doing anything, make sure you got through the guide about [Releasing an Integration](https://github.com/meilisearch/integration-guides/blob/main/resources/integration-release.md).
 
+Make a PR updating the version with the new one on this file:
+- [`version.go`](/version.go):
+  ```go
+    const VERSION = "X.X.X"
+  ```
+
 Once the changes are merged on `main`, you can publish the current draft release via the [GitHub interface](https://github.com/meilisearch/meilisearch-go/releases): on this page, click on `Edit` (related to the draft release) > update the description (be sure you apply [these recommandations](https://github.com/meilisearch/integration-guides/blob/main/resources/integration-release.md#writting-the-release-description)) > when you are ready, click on `Publish release`.
 
 <hr>


### PR DESCRIPTION
Since the adoption of this new release system *(now we need to update the version of the constant defined in the version.go file). We now need to validate that we are following this step.

Related to #279 
