### PR TITLE
Add new search parameters highlightPreTag, highlightPostTag and cropMarker

### DIFF
--- a/index_search.go
+++ b/index_search.go
@@ -38,6 +38,15 @@ func (i Index) Search(query string, request *SearchRequest) (*SearchResponse, er
 	if request.CropLength != 0 {
 		searchPostRequestParams["cropLength"] = request.CropLength
 	}
+	if request.CropMarker != "" {
+		searchPostRequestParams["cropMarker"] = request.CropMarker
+	}
+	if request.HighlightPreTag != "" {
+		searchPostRequestParams["highlightPreTag"] = request.HighlightPreTag
+	}
+	if request.HighlightPostTag != "" {
+		searchPostRequestParams["highlightPostTag"] = request.HighlightPostTag
+	}
 	if len(request.AttributesToRetrieve) != 0 {
 		searchPostRequestParams["attributesToRetrieve"] = request.AttributesToRetrieve
 	}

--- a/index_search_test.go
+++ b/index_search_test.go
@@ -100,7 +100,7 @@ func TestIndex_Search(t *testing.T) {
 			want: &SearchResponse{
 				Hits: []interface{}{
 					map[string]interface{}{
-						"book_id": float64(1), "title": "Alice In Wonderland",
+						"book_id": float64(123), "title": "Pride and Prejudice",
 					},
 				},
 				NbHits:           20,
@@ -192,13 +192,13 @@ func TestIndex_Search(t *testing.T) {
 			want: &SearchResponse{
 				Hits: []interface{}{
 					map[string]interface{}{
-						"book_id": float64(1032), "title": "Crime and Punishment",
-					},
-					map[string]interface{}{
 						"book_id": float64(123), "title": "Pride and Prejudice",
 					},
 					map[string]interface{}{
 						"book_id": float64(730), "title": "War and Peace",
+					},
+					map[string]interface{}{
+						"book_id": float64(1032), "title": "Crime and Punishment",
 					},
 					map[string]interface{}{
 						"book_id": float64(4), "title": "Harry Potter and the Half-Blood Prince",
@@ -532,13 +532,13 @@ func TestIndex_SearchWithFilters(t *testing.T) {
 			want: &SearchResponse{
 				Hits: []interface{}{
 					map[string]interface{}{
+						"book_id": float64(742), "title": "The Great Gatsby",
+					},
+					map[string]interface{}{
 						"book_id": float64(17), "title": "In Search of Lost Time",
 					},
 					map[string]interface{}{
 						"book_id": float64(204), "title": "Ulysses",
-					},
-					map[string]interface{}{
-						"book_id": float64(742), "title": "The Great Gatsby",
 					},
 				},
 				NbHits:           3,
@@ -590,13 +590,13 @@ func TestIndex_SearchWithFilters(t *testing.T) {
 			want: &SearchResponse{
 				Hits: []interface{}{
 					map[string]interface{}{
+						"book_id": float64(456), "title": "Le Petit Prince",
+					},
+					map[string]interface{}{
 						"book_id": float64(1), "title": "Alice In Wonderland",
 					},
 					map[string]interface{}{
 						"book_id": float64(4), "title": "Harry Potter and the Half-Blood Prince",
-					},
-					map[string]interface{}{
-						"book_id": float64(456), "title": "Le Petit Prince",
 					},
 				},
 				NbHits:           3,

--- a/index_search_test.go
+++ b/index_search_test.go
@@ -236,7 +236,7 @@ func TestIndex_Search(t *testing.T) {
 			},
 		},
 		{
-			name: "TestIndexSearchWithAttributeToHighlightWithCustomPreAndPostTag",
+			name: "TestIndexSearchWithCustomPreAndPostHighlightTags",
 			args: args{
 				UID:    "indexUID",
 				client: defaultClient,

--- a/types.go
+++ b/types.go
@@ -197,7 +197,10 @@ type SearchRequest struct {
 	AttributesToRetrieve  []string
 	AttributesToCrop      []string
 	CropLength            int64
+	CropMarker            string
 	AttributesToHighlight []string
+	HighlightPreTag       string
+	HighlightPostTag      string
 	Filter                interface{}
 	Matches               bool
 	FacetsDistribution    []string

--- a/types_easyjson.go
+++ b/types_easyjson.go
@@ -1456,6 +1456,8 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo10(in *jlexer.Lexer,
 			}
 		case "CropLength":
 			out.CropLength = int64(in.Int64())
+		case "CropMarker":
+			out.CropMarker = string(in.String())
 		case "AttributesToHighlight":
 			if in.IsNull() {
 				in.Skip()
@@ -1479,6 +1481,10 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo10(in *jlexer.Lexer,
 				}
 				in.Delim(']')
 			}
+		case "HighlightPreTag":
+			out.HighlightPreTag = string(in.String())
+		case "HighlightPostTag":
+			out.HighlightPostTag = string(in.String())
 		case "Filter":
 			if m, ok := out.Filter.(easyjson.Unmarshaler); ok {
 				m.UnmarshalEasyJSON(in)
@@ -1599,6 +1605,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo10(out *jwriter.Writ
 		out.Int64(int64(in.CropLength))
 	}
 	{
+		const prefix string = ",\"CropMarker\":"
+		out.RawString(prefix)
+		out.String(string(in.CropMarker))
+	}
+	{
 		const prefix string = ",\"AttributesToHighlight\":"
 		out.RawString(prefix)
 		if in.AttributesToHighlight == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
@@ -1613,6 +1624,16 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo10(out *jwriter.Writ
 			}
 			out.RawByte(']')
 		}
+	}
+	{
+		const prefix string = ",\"HighlightPreTag\":"
+		out.RawString(prefix)
+		out.String(string(in.HighlightPreTag))
+	}
+	{
+		const prefix string = ",\"HighlightPostTag\":"
+		out.RawString(prefix)
+		out.String(string(in.HighlightPostTag))
 	}
 	{
 		const prefix string = ",\"Filter\":"


### PR DESCRIPTION
As per https://github.com/meilisearch/meilisearch/issues/2214 new search parameters are introduced: 

- `highlightPreTag`
- `highlightPostTag`
- `cropMarker`
