### PR TITLE
Apply search changes

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -306,7 +306,7 @@ search_parameter_guide_highlight_tag_1: |-
   })
 search_parameter_guide_matches_1: |-
   resp, err := client.Index("movies").Search("winter feast", &meilisearch.SearchRequest{
-    Matches:               true,
+    ShowMatchesPosition:    true,
   })
 settings_guide_synonyms_1: |-
   settings := meilisearch.Settings{
@@ -578,7 +578,7 @@ faceted_search_filter_1: |-
   })
 faceted_search_facets_distribution_1: |-
   resp, err := client.Index("movies").Search("Batman", &meilisearch.SearchRequest{
-    FacetsDistribution: []string{
+    Facets: []string{
       "genres",
     },
   })

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ searchRes, err := index.Search("wonder",
   ],
   "offset": 0,
   "limit": 20,
-  "nbHits": 1,
+  "estimatedTotalHits": 1,
   "processingTimeMs": 0,
   "query": "wonder"
 }

--- a/index_search.go
+++ b/index_search.go
@@ -26,8 +26,8 @@ func (i Index) Search(query string, request *SearchRequest) (*SearchResponse, er
 	if request.Limit != DefaultLimit {
 		searchPostRequestParams["limit"] = request.Limit
 	}
-	if request.Matches {
-		searchPostRequestParams["matches"] = request.Matches
+	if request.ShowMatchesPosition {
+		searchPostRequestParams["showMatchesPosition"] = request.ShowMatchesPosition
 	}
 	if request.Filter != nil {
 		searchPostRequestParams["filter"] = request.Filter
@@ -56,8 +56,8 @@ func (i Index) Search(query string, request *SearchRequest) (*SearchResponse, er
 	if len(request.AttributesToHighlight) != 0 {
 		searchPostRequestParams["attributesToHighlight"] = request.AttributesToHighlight
 	}
-	if len(request.FacetsDistribution) != 0 {
-		searchPostRequestParams["facetsDistribution"] = request.FacetsDistribution
+	if len(request.Facets) != 0 {
+		searchPostRequestParams["facets"] = request.Facets
 	}
 	if len(request.Sort) != 0 {
 		searchPostRequestParams["sort"] = request.Sort

--- a/index_search_test.go
+++ b/index_search_test.go
@@ -36,10 +36,9 @@ func TestIndex_Search(t *testing.T) {
 						"Tag": "Epic fantasy", "book_id": float64(4), "title": "Harry Potter and the Half-Blood Prince",
 					},
 				},
-				NbHits:           2,
-				Offset:           0,
-				Limit:            20,
-				ExhaustiveNbHits: false,
+				EstimatedTotalHits: 2,
+				Offset:             0,
+				Limit:              20,
 			},
 		},
 		{
@@ -59,10 +58,9 @@ func TestIndex_Search(t *testing.T) {
 						"Tag": "Epic fantasy", "book_id": float64(4), "title": "Harry Potter and the Half-Blood Prince",
 					},
 				},
-				NbHits:           2,
-				Offset:           0,
-				Limit:            20,
-				ExhaustiveNbHits: false,
+				EstimatedTotalHits: 2,
+				Offset:             0,
+				Limit:              20,
 			},
 		},
 		{
@@ -81,10 +79,9 @@ func TestIndex_Search(t *testing.T) {
 						"book_id": float64(456), "title": "Le Petit Prince",
 					},
 				},
-				NbHits:           2,
-				Offset:           0,
-				Limit:            1,
-				ExhaustiveNbHits: false,
+				EstimatedTotalHits: 2,
+				Offset:             0,
+				Limit:              1,
 			},
 		},
 		{
@@ -103,10 +100,9 @@ func TestIndex_Search(t *testing.T) {
 						"book_id": float64(123), "title": "Pride and Prejudice",
 					},
 				},
-				NbHits:           20,
-				Offset:           0,
-				Limit:            1,
-				ExhaustiveNbHits: false,
+				EstimatedTotalHits: 20,
+				Offset:             0,
+				Limit:              1,
 			},
 		},
 		{
@@ -125,10 +121,9 @@ func TestIndex_Search(t *testing.T) {
 						"book_id": float64(4), "title": "Harry Potter and the Half-Blood Prince",
 					},
 				},
-				NbHits:           2,
-				Offset:           1,
-				Limit:            20,
-				ExhaustiveNbHits: false,
+				EstimatedTotalHits: 2,
+				Offset:             1,
+				Limit:              20,
 			},
 		},
 		{
@@ -150,10 +145,9 @@ func TestIndex_Search(t *testing.T) {
 						"book_id": float64(4), "title": "Harry Potter and the Half-Blood Prince",
 					},
 				},
-				NbHits:           2,
-				Offset:           0,
-				Limit:            20,
-				ExhaustiveNbHits: false,
+				EstimatedTotalHits: 2,
+				Offset:             0,
+				Limit:              20,
 			},
 		},
 		{
@@ -176,10 +170,9 @@ func TestIndex_Search(t *testing.T) {
 						},
 					},
 				},
-				NbHits:           1,
-				Offset:           0,
-				Limit:            20,
-				ExhaustiveNbHits: false,
+				EstimatedTotalHits: 1,
+				Offset:             0,
+				Limit:              20,
 			},
 		},
 		{
@@ -203,10 +196,9 @@ func TestIndex_Search(t *testing.T) {
 						},
 					},
 				},
-				NbHits:           1,
-				Offset:           0,
-				Limit:            20,
-				ExhaustiveNbHits: false,
+				EstimatedTotalHits: 1,
+				Offset:             0,
+				Limit:              20,
 			},
 		},
 		{
@@ -229,10 +221,9 @@ func TestIndex_Search(t *testing.T) {
 						},
 					},
 				},
-				NbHits:           2,
-				Offset:           0,
-				Limit:            1,
-				ExhaustiveNbHits: false,
+				EstimatedTotalHits: 2,
+				Offset:             0,
+				Limit:              1,
 			},
 		},
 		{
@@ -257,20 +248,19 @@ func TestIndex_Search(t *testing.T) {
 						},
 					},
 				},
-				NbHits:           2,
-				Offset:           0,
-				Limit:            1,
-				ExhaustiveNbHits: false,
+				EstimatedTotalHits: 2,
+				Offset:             0,
+				Limit:              1,
 			},
 		},
 		{
-			name: "TestIndexSearchWithMatches",
+			name: "TestIndexSearchWithShowMatchesPosition",
 			args: args{
 				UID:    "indexUID",
 				client: defaultClient,
 				query:  "and",
 				request: SearchRequest{
-					Matches: true,
+					ShowMatchesPosition: true,
 				},
 			},
 			want: &SearchResponse{
@@ -288,10 +278,9 @@ func TestIndex_Search(t *testing.T) {
 						"book_id": float64(4), "title": "Harry Potter and the Half-Blood Prince",
 					},
 				},
-				NbHits:           4,
-				Offset:           0,
-				Limit:            20,
-				ExhaustiveNbHits: false,
+				EstimatedTotalHits: 4,
+				Offset:             0,
+				Limit:              20,
 			},
 		},
 		{
@@ -308,10 +297,9 @@ func TestIndex_Search(t *testing.T) {
 						"book_id": float64(4), "title": "Harry Potter and the Half-Blood Prince",
 					},
 				},
-				NbHits:           1,
-				Offset:           0,
-				Limit:            20,
-				ExhaustiveNbHits: false,
+				EstimatedTotalHits: 1,
+				Offset:             0,
+				Limit:              20,
 			},
 		},
 	}
@@ -332,12 +320,10 @@ func TestIndex_Search(t *testing.T) {
 			if tt.want.Hits[0].(map[string]interface{})["_formatted"] != nil {
 				require.Equal(t, tt.want.Hits[0].(map[string]interface{})["_formatted"], got.Hits[0].(map[string]interface{})["_formatted"])
 			}
-			require.Equal(t, tt.want.NbHits, got.NbHits)
+			require.Equal(t, tt.want.EstimatedTotalHits, got.EstimatedTotalHits)
 			require.Equal(t, tt.want.Offset, got.Offset)
 			require.Equal(t, tt.want.Limit, got.Limit)
-			require.Equal(t, tt.want.ExhaustiveNbHits, got.ExhaustiveNbHits)
-			require.Equal(t, tt.want.FacetsDistribution, got.FacetsDistribution)
-			require.Equal(t, tt.want.ExhaustiveFacetsCount, got.ExhaustiveFacetsCount)
+			require.Equal(t, tt.want.FacetDistribution, got.FacetDistribution)
 		})
 	}
 }
@@ -357,13 +343,13 @@ func TestIndex_SearchFacets(t *testing.T) {
 		want *SearchResponse
 	}{
 		{
-			name: "TestIndexSearchWithFacetsDistribution",
+			name: "TestIndexSearchWithFacets",
 			args: args{
 				UID:    "indexUID",
 				client: defaultClient,
 				query:  "prince",
 				request: SearchRequest{
-					FacetsDistribution: []string{"*"},
+					Facets: []string{"*"},
 				},
 				filterableAttributes: []string{"tag"},
 			},
@@ -376,28 +362,26 @@ func TestIndex_SearchFacets(t *testing.T) {
 						"book_id": float64(4), "title": "Harry Potter and the Half-Blood Prince",
 					},
 				},
-				NbHits:           2,
-				Offset:           0,
-				Limit:            20,
-				ExhaustiveNbHits: false,
-				FacetsDistribution: map[string]interface{}(
+				EstimatedTotalHits: 2,
+				Offset:             0,
+				Limit:              20,
+				FacetDistribution: map[string]interface{}(
 					map[string]interface{}{
 						"tag": map[string]interface{}{
 							"Epic fantasy": float64(1),
 							"Tale":         float64(1),
 						},
 					}),
-				ExhaustiveFacetsCount: interface{}(false),
 			},
 		},
 		{
-			name: "TestIndexSearchWithFacetsDistributionWithCustomClient",
+			name: "TestIndexSearchWithFacetsWithCustomClient",
 			args: args{
 				UID:    "indexUID",
 				client: customClient,
 				query:  "prince",
 				request: SearchRequest{
-					FacetsDistribution: []string{"*"},
+					Facets: []string{"*"},
 				},
 				filterableAttributes: []string{"tag"},
 			},
@@ -410,18 +394,16 @@ func TestIndex_SearchFacets(t *testing.T) {
 						"book_id": float64(4), "title": "Harry Potter and the Half-Blood Prince",
 					},
 				},
-				NbHits:           2,
-				Offset:           0,
-				Limit:            20,
-				ExhaustiveNbHits: false,
-				FacetsDistribution: map[string]interface{}(
+				EstimatedTotalHits: 2,
+				Offset:             0,
+				Limit:              20,
+				FacetDistribution: map[string]interface{}(
 					map[string]interface{}{
 						"tag": map[string]interface{}{
 							"Epic fantasy": float64(1),
 							"Tale":         float64(1),
 						},
 					}),
-				ExhaustiveFacetsCount: interface{}(false),
 			},
 		},
 	}
@@ -444,12 +426,10 @@ func TestIndex_SearchFacets(t *testing.T) {
 				require.Equal(t, tt.want.Hits[len].(map[string]interface{})["title"], got.Hits[len].(map[string]interface{})["title"])
 				require.Equal(t, tt.want.Hits[len].(map[string]interface{})["book_id"], got.Hits[len].(map[string]interface{})["book_id"])
 			}
-			require.Equal(t, tt.want.NbHits, got.NbHits)
+			require.Equal(t, tt.want.EstimatedTotalHits, got.EstimatedTotalHits)
 			require.Equal(t, tt.want.Offset, got.Offset)
 			require.Equal(t, tt.want.Limit, got.Limit)
-			require.Equal(t, tt.want.ExhaustiveNbHits, got.ExhaustiveNbHits)
-			require.Equal(t, tt.want.FacetsDistribution, got.FacetsDistribution)
-			require.Equal(t, tt.want.ExhaustiveFacetsCount, got.ExhaustiveFacetsCount)
+			require.Equal(t, tt.want.FacetDistribution, got.FacetDistribution)
 		})
 	}
 }
@@ -487,10 +467,9 @@ func TestIndex_SearchWithFilters(t *testing.T) {
 						"book_id": float64(123), "title": "Pride and Prejudice",
 					},
 				},
-				NbHits:           1,
-				Offset:           0,
-				Limit:            20,
-				ExhaustiveNbHits: false,
+				EstimatedTotalHits: 1,
+				Offset:             0,
+				Limit:              20,
 			},
 		},
 		{
@@ -512,10 +491,9 @@ func TestIndex_SearchWithFilters(t *testing.T) {
 						"book_id": float64(4), "title": "Harry Potter and the Half-Blood Prince",
 					},
 				},
-				NbHits:           1,
-				Offset:           0,
-				Limit:            20,
-				ExhaustiveNbHits: false,
+				EstimatedTotalHits: 1,
+				Offset:             0,
+				Limit:              20,
 			},
 		},
 		{
@@ -539,10 +517,9 @@ func TestIndex_SearchWithFilters(t *testing.T) {
 						"book_id": float64(4), "title": "Harry Potter and the Half-Blood Prince",
 					},
 				},
-				NbHits:           1,
-				Offset:           0,
-				Limit:            20,
-				ExhaustiveNbHits: false,
+				EstimatedTotalHits: 1,
+				Offset:             0,
+				Limit:              20,
 			},
 		},
 		{
@@ -568,10 +545,9 @@ func TestIndex_SearchWithFilters(t *testing.T) {
 						"book_id": float64(123), "title": "Pride and Prejudice",
 					},
 				},
-				NbHits:           1,
-				Offset:           0,
-				Limit:            20,
-				ExhaustiveNbHits: false,
+				EstimatedTotalHits: 1,
+				Offset:             0,
+				Limit:              20,
 			},
 		},
 		{
@@ -597,10 +573,9 @@ func TestIndex_SearchWithFilters(t *testing.T) {
 						"book_id": float64(4), "title": "Harry Potter and the Half-Blood Prince",
 					},
 				},
-				NbHits:           2,
-				Offset:           0,
-				Limit:            20,
-				ExhaustiveNbHits: false,
+				EstimatedTotalHits: 2,
+				Offset:             0,
+				Limit:              20,
 			},
 		},
 		{
@@ -628,10 +603,9 @@ func TestIndex_SearchWithFilters(t *testing.T) {
 						"book_id": float64(204), "title": "Ulysses",
 					},
 				},
-				NbHits:           3,
-				Offset:           0,
-				Limit:            20,
-				ExhaustiveNbHits: false,
+				EstimatedTotalHits: 3,
+				Offset:             0,
+				Limit:              20,
 			},
 		},
 		{
@@ -654,10 +628,9 @@ func TestIndex_SearchWithFilters(t *testing.T) {
 						"book_id": float64(1), "title": "Alice In Wonderland",
 					},
 				},
-				NbHits:           1,
-				Offset:           0,
-				Limit:            20,
-				ExhaustiveNbHits: false,
+				EstimatedTotalHits: 1,
+				Offset:             0,
+				Limit:              20,
 			},
 		},
 		{
@@ -686,10 +659,9 @@ func TestIndex_SearchWithFilters(t *testing.T) {
 						"book_id": float64(4), "title": "Harry Potter and the Half-Blood Prince",
 					},
 				},
-				NbHits:           3,
-				Offset:           0,
-				Limit:            20,
-				ExhaustiveNbHits: false,
+				EstimatedTotalHits: 3,
+				Offset:             0,
+				Limit:              20,
 			},
 		},
 		{
@@ -712,10 +684,9 @@ func TestIndex_SearchWithFilters(t *testing.T) {
 						"book_id": float64(456), "title": "Le Petit Prince",
 					},
 				},
-				NbHits:           1,
-				Offset:           0,
-				Limit:            20,
-				ExhaustiveNbHits: false,
+				EstimatedTotalHits: 1,
+				Offset:             0,
+				Limit:              20,
 			},
 		},
 		{
@@ -737,10 +708,9 @@ func TestIndex_SearchWithFilters(t *testing.T) {
 						"book_id": float64(1032), "title": "Crime and Punishment",
 					},
 				},
-				NbHits:           1,
-				Offset:           0,
-				Limit:            20,
-				ExhaustiveNbHits: false,
+				EstimatedTotalHits: 1,
+				Offset:             0,
+				Limit:              20,
 			},
 		},
 	}
@@ -763,12 +733,10 @@ func TestIndex_SearchWithFilters(t *testing.T) {
 				require.Equal(t, tt.want.Hits[len].(map[string]interface{})["title"], got.Hits[len].(map[string]interface{})["title"])
 				require.Equal(t, tt.want.Hits[len].(map[string]interface{})["book_id"], got.Hits[len].(map[string]interface{})["book_id"])
 			}
-			require.Equal(t, tt.want.NbHits, got.NbHits)
+			require.Equal(t, tt.want.EstimatedTotalHits, got.EstimatedTotalHits)
 			require.Equal(t, tt.want.Offset, got.Offset)
 			require.Equal(t, tt.want.Limit, got.Limit)
-			require.Equal(t, tt.want.ExhaustiveNbHits, got.ExhaustiveNbHits)
-			require.Equal(t, tt.want.FacetsDistribution, got.FacetsDistribution)
-			require.Equal(t, tt.want.ExhaustiveFacetsCount, got.ExhaustiveFacetsCount)
+			require.Equal(t, tt.want.FacetDistribution, got.FacetDistribution)
 		})
 	}
 }
@@ -817,10 +785,9 @@ func TestIndex_SearchWithSort(t *testing.T) {
 						"book_id": float64(4), "title": "Harry Potter and the Half-Blood Prince",
 					},
 				},
-				NbHits:           4,
-				Offset:           0,
-				Limit:            20,
-				ExhaustiveNbHits: false,
+				EstimatedTotalHits: 4,
+				Offset:             0,
+				Limit:              20,
 			},
 		},
 		{
@@ -853,10 +820,9 @@ func TestIndex_SearchWithSort(t *testing.T) {
 						"book_id": float64(4), "title": "Harry Potter and the Half-Blood Prince",
 					},
 				},
-				NbHits:           4,
-				Offset:           0,
-				Limit:            20,
-				ExhaustiveNbHits: false,
+				EstimatedTotalHits: 4,
+				Offset:             0,
+				Limit:              20,
 			},
 		},
 		{
@@ -891,10 +857,9 @@ func TestIndex_SearchWithSort(t *testing.T) {
 						"book_id": float64(4), "title": "Harry Potter and the Half-Blood Prince",
 					},
 				},
-				NbHits:           4,
-				Offset:           0,
-				Limit:            20,
-				ExhaustiveNbHits: false,
+				EstimatedTotalHits: 4,
+				Offset:             0,
+				Limit:              20,
 			},
 		},
 		{
@@ -929,10 +894,9 @@ func TestIndex_SearchWithSort(t *testing.T) {
 						"book_id": float64(4), "title": "Harry Potter and the Half-Blood Prince",
 					},
 				},
-				NbHits:           4,
-				Offset:           0,
-				Limit:            20,
-				ExhaustiveNbHits: false,
+				EstimatedTotalHits: 4,
+				Offset:             0,
+				Limit:              20,
 			},
 		},
 		{
@@ -968,10 +932,9 @@ func TestIndex_SearchWithSort(t *testing.T) {
 						"book_id": float64(7), "title": "Don Quixote",
 					},
 				},
-				NbHits:           20,
-				Offset:           0,
-				Limit:            4,
-				ExhaustiveNbHits: false,
+				EstimatedTotalHits: 20,
+				Offset:             0,
+				Limit:              4,
 			},
 		},
 	}
@@ -994,12 +957,10 @@ func TestIndex_SearchWithSort(t *testing.T) {
 				require.Equal(t, tt.want.Hits[len].(map[string]interface{})["title"], got.Hits[len].(map[string]interface{})["title"])
 				require.Equal(t, tt.want.Hits[len].(map[string]interface{})["book_id"], got.Hits[len].(map[string]interface{})["book_id"])
 			}
-			require.Equal(t, tt.want.NbHits, got.NbHits)
+			require.Equal(t, tt.want.EstimatedTotalHits, got.EstimatedTotalHits)
 			require.Equal(t, tt.want.Offset, got.Offset)
 			require.Equal(t, tt.want.Limit, got.Limit)
-			require.Equal(t, tt.want.ExhaustiveNbHits, got.ExhaustiveNbHits)
-			require.Equal(t, tt.want.FacetsDistribution, got.FacetsDistribution)
-			require.Equal(t, tt.want.ExhaustiveFacetsCount, got.ExhaustiveFacetsCount)
+			require.Equal(t, tt.want.FacetDistribution, got.FacetDistribution)
 		})
 	}
 }
@@ -1037,10 +998,9 @@ func TestIndex_SearchOnNestedFileds(t *testing.T) {
 						},
 					},
 				},
-				NbHits:           1,
-				Offset:           0,
-				Limit:            20,
-				ExhaustiveNbHits: false,
+				EstimatedTotalHits: 1,
+				Offset:             0,
+				Limit:              20,
 			},
 		},
 		{
@@ -1061,10 +1021,9 @@ func TestIndex_SearchOnNestedFileds(t *testing.T) {
 						},
 					},
 				},
-				NbHits:           1,
-				Offset:           0,
-				Limit:            20,
-				ExhaustiveNbHits: false,
+				EstimatedTotalHits: 1,
+				Offset:             0,
+				Limit:              20,
 			},
 		},
 		{
@@ -1092,10 +1051,9 @@ func TestIndex_SearchOnNestedFileds(t *testing.T) {
 						},
 					},
 				},
-				NbHits:           2,
-				Offset:           0,
-				Limit:            20,
-				ExhaustiveNbHits: false,
+				EstimatedTotalHits: 2,
+				Offset:             0,
+				Limit:              20,
 			},
 		},
 		{
@@ -1119,10 +1077,9 @@ func TestIndex_SearchOnNestedFileds(t *testing.T) {
 						},
 					},
 				},
-				NbHits:           1,
-				Offset:           0,
-				Limit:            20,
-				ExhaustiveNbHits: false,
+				EstimatedTotalHits: 1,
+				Offset:             0,
+				Limit:              20,
 			},
 		},
 		{
@@ -1153,10 +1110,9 @@ func TestIndex_SearchOnNestedFileds(t *testing.T) {
 						},
 					},
 				},
-				NbHits:           1,
-				Offset:           0,
-				Limit:            20,
-				ExhaustiveNbHits: false,
+				EstimatedTotalHits: 1,
+				Offset:             0,
+				Limit:              20,
 			},
 		},
 	}
@@ -1186,12 +1142,10 @@ func TestIndex_SearchOnNestedFileds(t *testing.T) {
 			for len := range got.Hits {
 				require.Equal(t, tt.want.Hits[len], got.Hits[len])
 			}
-			require.Equal(t, tt.want.NbHits, got.NbHits)
+			require.Equal(t, tt.want.EstimatedTotalHits, got.EstimatedTotalHits)
 			require.Equal(t, tt.want.Offset, got.Offset)
 			require.Equal(t, tt.want.Limit, got.Limit)
-			require.Equal(t, tt.want.ExhaustiveNbHits, got.ExhaustiveNbHits)
-			require.Equal(t, tt.want.FacetsDistribution, got.FacetsDistribution)
-			require.Equal(t, tt.want.ExhaustiveFacetsCount, got.ExhaustiveFacetsCount)
+			require.Equal(t, tt.want.FacetDistribution, got.FacetDistribution)
 		})
 	}
 }

--- a/types.go
+++ b/types.go
@@ -217,23 +217,21 @@ type SearchRequest struct {
 	HighlightPreTag       string
 	HighlightPostTag      string
 	Filter                interface{}
-	Matches               bool
-	FacetsDistribution    []string
+	ShowMatchesPosition   bool
+	Facets                []string
 	PlaceholderSearch     bool
 	Sort                  []string
 }
 
 // SearchResponse is the response body for search method
 type SearchResponse struct {
-	Hits                  []interface{} `json:"hits"`
-	NbHits                int64         `json:"nbHits"`
-	Offset                int64         `json:"offset"`
-	Limit                 int64         `json:"limit"`
-	ExhaustiveNbHits      bool          `json:"exhaustiveNbHits"`
-	ProcessingTimeMs      int64         `json:"processingTimeMs"`
-	Query                 string        `json:"query"`
-	FacetsDistribution    interface{}   `json:"facetsDistribution,omitempty"`
-	ExhaustiveFacetsCount interface{}   `json:"exhaustiveFacetsCount,omitempty"`
+	Hits               []interface{} `json:"hits"`
+	EstimatedTotalHits int64         `json:"estimatedTotalHits"`
+	Offset             int64         `json:"offset"`
+	Limit              int64         `json:"limit"`
+	ProcessingTimeMs   int64         `json:"processingTimeMs"`
+	Query              string        `json:"query"`
+	FacetDistribution  interface{}   `json:"facetDistribution,omitempty"`
 }
 
 // DocumentsRequest is the request body for list documents method

--- a/types_easyjson.go
+++ b/types_easyjson.go
@@ -1426,33 +1426,23 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo10(in *jlexer.Lexer,
 				}
 				in.Delim(']')
 			}
-		case "nbHits":
-			out.NbHits = int64(in.Int64())
+		case "estimatedTotalHits":
+			out.EstimatedTotalHits = int64(in.Int64())
 		case "offset":
 			out.Offset = int64(in.Int64())
 		case "limit":
 			out.Limit = int64(in.Int64())
-		case "exhaustiveNbHits":
-			out.ExhaustiveNbHits = bool(in.Bool())
 		case "processingTimeMs":
 			out.ProcessingTimeMs = int64(in.Int64())
 		case "query":
 			out.Query = string(in.String())
-		case "facetsDistribution":
-			if m, ok := out.FacetsDistribution.(easyjson.Unmarshaler); ok {
+		case "facetDistribution":
+			if m, ok := out.FacetDistribution.(easyjson.Unmarshaler); ok {
 				m.UnmarshalEasyJSON(in)
-			} else if m, ok := out.FacetsDistribution.(json.Unmarshaler); ok {
+			} else if m, ok := out.FacetDistribution.(json.Unmarshaler); ok {
 				_ = m.UnmarshalJSON(in.Raw())
 			} else {
-				out.FacetsDistribution = in.Interface()
-			}
-		case "exhaustiveFacetsCount":
-			if m, ok := out.ExhaustiveFacetsCount.(easyjson.Unmarshaler); ok {
-				m.UnmarshalEasyJSON(in)
-			} else if m, ok := out.ExhaustiveFacetsCount.(json.Unmarshaler); ok {
-				_ = m.UnmarshalJSON(in.Raw())
-			} else {
-				out.ExhaustiveFacetsCount = in.Interface()
+				out.FacetDistribution = in.Interface()
 			}
 		default:
 			in.SkipRecursive()
@@ -1491,9 +1481,9 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo10(out *jwriter.Writ
 		}
 	}
 	{
-		const prefix string = ",\"nbHits\":"
+		const prefix string = ",\"estimatedTotalHits\":"
 		out.RawString(prefix)
-		out.Int64(int64(in.NbHits))
+		out.Int64(int64(in.EstimatedTotalHits))
 	}
 	{
 		const prefix string = ",\"offset\":"
@@ -1506,11 +1496,6 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo10(out *jwriter.Writ
 		out.Int64(int64(in.Limit))
 	}
 	{
-		const prefix string = ",\"exhaustiveNbHits\":"
-		out.RawString(prefix)
-		out.Bool(bool(in.ExhaustiveNbHits))
-	}
-	{
 		const prefix string = ",\"processingTimeMs\":"
 		out.RawString(prefix)
 		out.Int64(int64(in.ProcessingTimeMs))
@@ -1520,26 +1505,15 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo10(out *jwriter.Writ
 		out.RawString(prefix)
 		out.String(string(in.Query))
 	}
-	if in.FacetsDistribution != nil {
-		const prefix string = ",\"facetsDistribution\":"
+	if in.FacetDistribution != nil {
+		const prefix string = ",\"facetDistribution\":"
 		out.RawString(prefix)
-		if m, ok := in.FacetsDistribution.(easyjson.Marshaler); ok {
+		if m, ok := in.FacetDistribution.(easyjson.Marshaler); ok {
 			m.MarshalEasyJSON(out)
-		} else if m, ok := in.FacetsDistribution.(json.Marshaler); ok {
+		} else if m, ok := in.FacetDistribution.(json.Marshaler); ok {
 			out.Raw(m.MarshalJSON())
 		} else {
-			out.Raw(json.Marshal(in.FacetsDistribution))
-		}
-	}
-	if in.ExhaustiveFacetsCount != nil {
-		const prefix string = ",\"exhaustiveFacetsCount\":"
-		out.RawString(prefix)
-		if m, ok := in.ExhaustiveFacetsCount.(easyjson.Marshaler); ok {
-			m.MarshalEasyJSON(out)
-		} else if m, ok := in.ExhaustiveFacetsCount.(json.Marshaler); ok {
-			out.Raw(m.MarshalJSON())
-		} else {
-			out.Raw(json.Marshal(in.ExhaustiveFacetsCount))
+			out.Raw(json.Marshal(in.FacetDistribution))
 		}
 	}
 	out.RawByte('}')
@@ -1676,27 +1650,27 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo11(in *jlexer.Lexer,
 			} else {
 				out.Filter = in.Interface()
 			}
-		case "Matches":
-			out.Matches = bool(in.Bool())
-		case "FacetsDistribution":
+		case "ShowMatchesPosition":
+			out.ShowMatchesPosition = bool(in.Bool())
+		case "Facets":
 			if in.IsNull() {
 				in.Skip()
-				out.FacetsDistribution = nil
+				out.Facets = nil
 			} else {
 				in.Delim('[')
-				if out.FacetsDistribution == nil {
+				if out.Facets == nil {
 					if !in.IsDelim(']') {
-						out.FacetsDistribution = make([]string, 0, 4)
+						out.Facets = make([]string, 0, 4)
 					} else {
-						out.FacetsDistribution = []string{}
+						out.Facets = []string{}
 					}
 				} else {
-					out.FacetsDistribution = (out.FacetsDistribution)[:0]
+					out.Facets = (out.Facets)[:0]
 				}
 				for !in.IsDelim(']') {
 					var v40 string
 					v40 = string(in.String())
-					out.FacetsDistribution = append(out.FacetsDistribution, v40)
+					out.Facets = append(out.Facets, v40)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1830,18 +1804,18 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo11(out *jwriter.Writ
 		}
 	}
 	{
-		const prefix string = ",\"Matches\":"
+		const prefix string = ",\"ShowMatchesPosition\":"
 		out.RawString(prefix)
-		out.Bool(bool(in.Matches))
+		out.Bool(bool(in.ShowMatchesPosition))
 	}
 	{
-		const prefix string = ",\"FacetsDistribution\":"
+		const prefix string = ",\"Facets\":"
 		out.RawString(prefix)
-		if in.FacetsDistribution == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+		if in.Facets == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v48, v49 := range in.FacetsDistribution {
+			for v48, v49 := range in.Facets {
 				if v48 > 0 {
 					out.RawByte(',')
 				}


### PR DESCRIPTION
- Rename `nbHits` response parameter to `estimatedTotalHits`.
- Delete `exhaustiveNbHits` response parameter.
- Delete `exhaustiveFacetsCount` response parameter.
- `matches` request parameter is renamed `showMatchesPosition`.
- `facetsDistribution` request parameter is renamed `facets`.
- `facetsDistribution` response parameter is renamed `facetDistribution`.