### PR TITLE
Apply dumps changes

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -591,8 +591,6 @@ faceted_search_walkthrough_filter_1: |-
   })
 post_dump_1: |-
   resp, err := client.CreateDump()
-get_dump_status_1: |-
-  resp, err := client.GetDumpStatus("dump-uid")
 phrase_search_1: |-
   resp, err := client.Index("movies").Search("\"african american\" horror", &meilisearch.SearchRequest{})
 sorting_guide_update_sortable_attributes_1: |-

--- a/client.go
+++ b/client.go
@@ -45,8 +45,7 @@ type ClientInterface interface {
 	UpdateKey(identifier string, request *Key) (resp *Key, err error)
 	DeleteKey(identifier string) (resp bool, err error)
 	GetAllStats() (resp *Stats, err error)
-	CreateDump() (resp *Dump, err error)
-	GetDumpStatus(dumpUID string) (resp *Dump, err error)
+	CreateDump() (resp *Task, err error)
 	Version() (*Version, error)
 	GetVersion() (resp *Version, err error)
 	Health() (*Health, error)
@@ -224,8 +223,8 @@ func (c *Client) IsHealthy() bool {
 	return true
 }
 
-func (c *Client) CreateDump() (resp *Dump, err error) {
-	resp = &Dump{}
+func (c *Client) CreateDump() (resp *Task, err error) {
+	resp = &Task{}
 	req := internalRequest{
 		endpoint:            "/dumps",
 		method:              http.MethodPost,

--- a/client_test.go
+++ b/client_test.go
@@ -532,13 +532,13 @@ func TestClient_CreateDump(t *testing.T) {
 	tests := []struct {
 		name     string
 		client   *Client
-		wantResp *Dump
+		wantResp *Task
 	}{
 		{
 			name:   "TestCreateDump",
 			client: defaultClient,
-			wantResp: &Dump{
-				Status: "in_progress",
+			wantResp: &Task{
+				Status: "enqueued",
 			},
 		},
 	}
@@ -554,40 +554,11 @@ func TestClient_CreateDump(t *testing.T) {
 
 			// Waiting for CreateDump() to finished
 			for {
-				gotResp, _ := c.GetDumpStatus(gotResp.UID)
-				if gotResp.Status == "done" {
+				gotResp, _ := c.GetTask(gotResp.TaskUID)
+				if gotResp.Status == "succeeded" {
 					break
 				}
 			}
-		})
-	}
-}
-
-func TestClient_GetDumpStatus(t *testing.T) {
-	tests := []struct {
-		name     string
-		client   *Client
-		wantResp []DumpStatus
-		wantErr  bool
-	}{
-		{
-			name:     "TestGetDumpStatus",
-			client:   defaultClient,
-			wantResp: []DumpStatus{DumpStatusInProgress, DumpStatusFailed, DumpStatusDone},
-			wantErr:  false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c := tt.client
-
-			dump, err := c.CreateDump()
-			require.NoError(t, err, "CreateDump() in TestGetDumpStatus error should be nil")
-
-			gotResp, err := c.GetDumpStatus(dump.UID)
-			require.NoError(t, err)
-			require.Contains(t, tt.wantResp, gotResp.Status, "GetDumpStatus() got response status %v", gotResp.Status)
-			require.NotEqual(t, "failed", gotResp.Status, "GetDumpStatus() response status should not be failed")
 		})
 	}
 }


### PR DESCRIPTION
# Pull Request

Related to: https://github.com/meilisearch/integration-guides/issues/205

## What does this PR do?

Breaking because enforces the users to use Meilisearch v0.28.0

### Changes

- [x] Remove code sample get_dump_status_1
- [x] Remove method `GetDumpStatus` and `WaitForDumpCreation`