### PR TITLE
Apply keys changes

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -70,7 +70,7 @@ get_all_tasks_by_index_1: |-
 get_one_key_1: |-
   client.GetKey("d0552b41536279a0ad88bd595327b96f01176a60c2243e906c52ac02375f9bc4")
 get_keys_1: |-
-  client.GetKeys()
+  client.GetKeys(nil)
 create_a_key_1: |-
   client.CreateKey(&meilisearch.Key{
     Description: "Add documents: Products API key",
@@ -710,7 +710,7 @@ security_guide_list_keys_1: |-
     Host: "http://127.0.0.1:7700",
     APIKey: "masterKey",
   })
-  client.GetKeys();
+  client.GetKeys(nil);
 security_guide_delete_key_1: |-
   client := meilisearch.NewClient(meilisearch.ClientConfig{
     Host: "http://127.0.0.1:7700",
@@ -722,7 +722,7 @@ authorization_header_1: |-
     Host: "http://127.0.0.1:7700",
     APIKey: "masterKey",
   })
-  client.GetKeys();
+  client.GetKeys(nil);
 tenant_token_guide_generate_sdk_1: |-
   searchRules := map[string]interface{}{
     "patient_medical_records": map[string]string{

--- a/client.go
+++ b/client.go
@@ -41,9 +41,9 @@ type ClientInterface interface {
 	DeleteIndex(uid string) (resp *Task, err error)
 	CreateKey(request *Key) (resp *Key, err error)
 	GetKey(identifier string) (resp *Key, err error)
-	GetKeys() (resp *ResultKey, err error)
-	UpdateKey(identifier string, request *Key) (resp *Key, err error)
-	DeleteKey(identifier string) (resp bool, err error)
+	GetKeys(param *KeysQuery) (resp *KeysResults, err error)
+	UpdateKey(keyOrUID string, request *Key) (resp *Key, err error)
+	DeleteKey(keyOrUID string) (resp bool, err error)
 	GetAllStats() (resp *Stats, err error)
 	CreateDump() (resp *Dump, err error)
 	GetDumpStatus(dumpUID string) (resp *Dump, err error)
@@ -152,15 +152,22 @@ func (c *Client) GetKey(identifier string) (resp *Key, err error) {
 	return resp, nil
 }
 
-func (c *Client) GetKeys() (resp *ResultKey, err error) {
-	resp = &ResultKey{}
+func (c *Client) GetKeys(param *KeysQuery) (resp *KeysResults, err error) {
+	resp = &KeysResults{}
 	req := internalRequest{
 		endpoint:            "/keys",
 		method:              http.MethodGet,
 		withRequest:         nil,
 		withResponse:        resp,
+		withQueryParams:     map[string]string{},
 		acceptedStatusCodes: []int{http.StatusOK},
 		functionName:        "GetKeys",
+	}
+	if param != nil && param.Limit != 0 {
+		req.withQueryParams["limit"] = strconv.FormatInt(param.Limit, 10)
+	}
+	if param != nil && param.Offset != 0 {
+		req.withQueryParams["offset"] = strconv.FormatInt(param.Offset, 10)
 	}
 	if err := c.executeRequest(req); err != nil {
 		return nil, err
@@ -168,11 +175,11 @@ func (c *Client) GetKeys() (resp *ResultKey, err error) {
 	return resp, nil
 }
 
-func (c *Client) UpdateKey(identifier string, request *Key) (resp *Key, err error) {
-	parsedRequest := convertKeyToParsedKey(*request)
+func (c *Client) UpdateKey(keyOrUID string, request *Key) (resp *Key, err error) {
+	parsedRequest := KeyUpdate{Name: request.Name, Description: request.Description}
 	resp = &Key{}
 	req := internalRequest{
-		endpoint:            "/keys/" + identifier,
+		endpoint:            "/keys/" + keyOrUID,
 		method:              http.MethodPatch,
 		contentType:         contentTypeJSON,
 		withRequest:         &parsedRequest,
@@ -186,9 +193,9 @@ func (c *Client) UpdateKey(identifier string, request *Key) (resp *Key, err erro
 	return resp, nil
 }
 
-func (c *Client) DeleteKey(identifier string) (resp bool, err error) {
+func (c *Client) DeleteKey(keyOrUID string) (resp bool, err error) {
 	req := internalRequest{
-		endpoint:            "/keys/" + identifier,
+		endpoint:            "/keys/" + keyOrUID,
 		method:              http.MethodDelete,
 		withRequest:         nil,
 		withResponse:        nil,

--- a/main_test.go
+++ b/main_test.go
@@ -41,7 +41,7 @@ func deleteAllIndexes(client ClientInterface) (ok bool, err error) {
 }
 
 func deleteAllKeys(client ClientInterface) (ok bool, err error) {
-	list, err := client.GetKeys()
+	list, err := client.GetKeys(nil)
 	if err != nil {
 		return false, err
 	}
@@ -78,12 +78,12 @@ func testWaitForBatchTask(t *testing.T, i *Index, u []Task) {
 }
 
 func GetPrivateKey() (key string) {
-	list, err := defaultClient.GetKeys()
+	list, err := defaultClient.GetKeys(nil)
 	if err != nil {
 		return ""
 	}
 	for _, key := range list.Results {
-		if strings.Contains(key.Description, "Admin API Key") || (key.Description == "") {
+		if strings.Contains(key.Name, "Default Admin API Key") || (key.Description == "") {
 			return key.Key
 		}
 	}

--- a/types.go
+++ b/types.go
@@ -129,8 +129,10 @@ type ResultTask struct {
 //
 // Documentation: https://docs.meilisearch.com/learn/advanced/security.html#protecting-a-meilisearch-instance
 type Key struct {
+	Name        string    `json:"name"`
 	Description string    `json:"description"`
 	Key         string    `json:"key,omitempty"`
+	UID         string    `json:"uid,omitempty"`
 	Actions     []string  `json:"actions,omitempty"`
 	Indexes     []string  `json:"indexes,omitempty"`
 	CreatedAt   time.Time `json:"createdAt,omitempty"`
@@ -140,6 +142,7 @@ type Key struct {
 
 // This structure is used to send the exact ISO-8601 time format managed by Meilisearch
 type KeyParsed struct {
+	Name        string    `json:"name"`
 	Description string    `json:"description"`
 	Key         string    `json:"key,omitempty"`
 	Actions     []string  `json:"actions,omitempty"`
@@ -149,8 +152,23 @@ type KeyParsed struct {
 	ExpiresAt   *string   `json:"expiresAt"`
 }
 
-type ResultKey struct {
+// This structure is used to update a Key
+type KeyUpdate struct {
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+// Return of multiple keys is wrap in a KeysResults
+type KeysResults struct {
 	Results []Key `json:"results"`
+	Offset  int64 `json:"offset"`
+	Limit   int64 `json:"limit"`
+	Total   int64 `json:"total"`
+}
+
+type KeysQuery struct {
+	Limit  int64 `json:"limit,omitempty"`
+	Offset int64 `json:"offset,omitempty"`
 }
 
 // Information to create a tenant token


### PR DESCRIPTION
# Pull Request

Related to: https://github.com/meilisearch/integration-guides/issues/205

## What does this PR do?

Breaking because enforces the users to use Meilisearch v0.28.0

### Changes

- `PATCH /keys/:uid_or_key` can update **only** `name` and `description` fields.
- [x] Add test for new `:name` attributes