### PR TITLE
Apply documents changes

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -23,7 +23,7 @@ get_one_document_1: |-
   client.Index("movies").GetDocument("25684", &a)
 get_documents_1: |-
   var a []interface{}
-  client.Index("movies").GetDocuments(&meilisearch.DocumentsRequest{
+  client.Index("movies").GetDocuments(nil, &meilisearch.DocumentsRequest{
     Limit: 2,
   }, &a)
 add_or_replace_documents_1: |-

--- a/index.go
+++ b/index.go
@@ -32,7 +32,7 @@ type IndexInterface interface {
 	AddDocumentsNdjsonInBatches(documents []byte, batchSize int, primaryKey ...string) (resp []Task, err error)
 	UpdateDocuments(documentsPtr interface{}, primaryKey ...string) (resp *Task, err error)
 	GetDocument(uid string, documentPtr interface{}) error
-	GetDocuments(request *DocumentsRequest, resp interface{}) error
+	GetDocuments(param *DocumentsQuery, resp *DocumentsResult) error
 	DeleteDocument(uid string) (resp *Task, err error)
 	DeleteDocuments(uid []string) (resp *Task, err error)
 	DeleteAllDocuments() (resp *Task, err error)

--- a/index_documents.go
+++ b/index_documents.go
@@ -30,7 +30,7 @@ func (i Index) GetDocument(identifier string, documentPtr interface{}) error {
 	return nil
 }
 
-func (i Index) GetDocuments(request *DocumentsRequest, resp interface{}) error {
+func (i Index) GetDocuments(request *DocumentsQuery, resp *DocumentsResult) error {
 	req := internalRequest{
 		endpoint:            "/indexes/" + i.UID + "/documents",
 		method:              http.MethodGet,
@@ -40,14 +40,14 @@ func (i Index) GetDocuments(request *DocumentsRequest, resp interface{}) error {
 		acceptedStatusCodes: []int{http.StatusOK},
 		functionName:        "GetDocuments",
 	}
-	if request.Limit != 0 {
+	if request != nil && request.Limit != 0 {
 		req.withQueryParams["limit"] = strconv.FormatInt(request.Limit, 10)
 	}
-	if request.Offset != 0 {
+	if request != nil && request.Offset != 0 {
 		req.withQueryParams["offset"] = strconv.FormatInt(request.Offset, 10)
 	}
-	if len(request.AttributesToRetrieve) != 0 {
-		req.withQueryParams["attributesToRetrieve"] = strings.Join(request.AttributesToRetrieve, ",")
+	if request != nil && len(request.Fields) != 0 {
+		req.withQueryParams["fields"] = strings.Join(request.Fields, ",")
 	}
 	if err := i.client.executeRequest(req); err != nil {
 		return err

--- a/index_documents.go
+++ b/index_documents.go
@@ -40,14 +40,16 @@ func (i Index) GetDocuments(request *DocumentsQuery, resp *DocumentsResult) erro
 		acceptedStatusCodes: []int{http.StatusOK},
 		functionName:        "GetDocuments",
 	}
-	if request != nil && request.Limit != 0 {
-		req.withQueryParams["limit"] = strconv.FormatInt(request.Limit, 10)
-	}
-	if request != nil && request.Offset != 0 {
-		req.withQueryParams["offset"] = strconv.FormatInt(request.Offset, 10)
-	}
-	if request != nil && len(request.Fields) != 0 {
-		req.withQueryParams["fields"] = strings.Join(request.Fields, ",")
+	if request != nil {
+		if request.Limit != 0 {
+			req.withQueryParams["limit"] = strconv.FormatInt(request.Limit, 10)
+		}
+		if request.Offset != 0 {
+			req.withQueryParams["offset"] = strconv.FormatInt(request.Offset, 10)
+		}
+		if len(request.Fields) != 0 {
+			req.withQueryParams["fields"] = strings.Join(request.Fields, ",")
+		}
 	}
 	if err := i.client.executeRequest(req); err != nil {
 		return err

--- a/types.go
+++ b/types.go
@@ -234,11 +234,18 @@ type SearchResponse struct {
 	FacetDistribution  interface{}   `json:"facetDistribution,omitempty"`
 }
 
-// DocumentsRequest is the request body for list documents method
-type DocumentsRequest struct {
-	Offset               int64    `json:"offset,omitempty"`
-	Limit                int64    `json:"limit,omitempty"`
-	AttributesToRetrieve []string `json:"attributesToRetrieve,omitempty"`
+// DocumentsQuery is the request body for list documents method
+type DocumentsQuery struct {
+	Offset int64    `json:"offset,omitempty"`
+	Limit  int64    `json:"limit,omitempty"`
+	Fields []string `json:"fields,omitempty"`
+}
+
+type DocumentsResult struct {
+	Results []map[string]interface{} `json:"results"`
+	Limit   int64                    `json:"limit"`
+	Offset  int64                    `json:"offset"`
+	Total   int64                    `json:"total"`
 }
 
 // RawType is an alias for raw byte[]


### PR DESCRIPTION
# Pull Request

Related to: https://github.com/meilisearch/integration-guides/issues/205

## What does this PR do?

Breaking because enforces the users to use Meilisearch v0.28.0

- `GET /documents/:uid`, `GET /documents` Add the possibility to reduce the body payload by using a query parameter called `fields` (previously called `attributesToRetrieve`), check the issue and the spec for the entire behavior.
- The documents objects in now return wrap in a `results`
- [x] Adapt DocumentsQuery naming following all the routes
- [x] Fix tests