### PR TITLE
Apply tenant changes

### DIFF
--- a/client.go
+++ b/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"regexp"
 	"strconv"
 	"time"
 
@@ -54,7 +55,7 @@ type ClientInterface interface {
 	GetTask(taskID int64) (resp *Task, err error)
 	GetTasks() (resp *ResultTask, err error)
 	WaitForTask(task *Task, options ...WaitParams) (*Task, error)
-	GenerateTenantToken(searchRules map[string]interface{}, options *TenantTokenOptions) (resp string, err error)
+	GenerateTenantToken(APIKeyUID string, searchRules map[string]interface{}, options *TenantTokenOptions) (resp string, err error)
 }
 
 var _ ClientInterface = &Client{}
@@ -327,13 +328,16 @@ func (c *Client) WaitForTask(task *Task, options ...WaitParams) (*Task, error) {
 // accessible indexes for the signing API Key.
 // ExpiresAt options is a time.Time when the key will expire. Note that if an ExpiresAt value is included it should be in UTC time.
 // ApiKey options is the API key parent of the token. If you leave it empty the client API Key will be used.
-func (c *Client) GenerateTenantToken(SearchRules map[string]interface{}, Options *TenantTokenOptions) (resp string, err error) {
+func (c *Client) GenerateTenantToken(APIKeyUID string, SearchRules map[string]interface{}, Options *TenantTokenOptions) (resp string, err error) {
 	// Validate the arguments
 	if SearchRules == nil {
 		return "", fmt.Errorf("GenerateTenantToken: The search rules added in the token generation must be of type array or object")
 	}
 	if (Options == nil || Options.APIKey == "") && c.config.APIKey == "" {
 		return "", fmt.Errorf("GenerateTenantToken: The API key used for the token generation must exist and be a valid Meilisearch key")
+	}
+	if APIKeyUID == "" || !IsValidUUID(APIKeyUID) {
+		return "", fmt.Errorf("GenerateTenantToken: The uid used for the token generation must exist and comply to uuid4 format")
 	}
 	if Options != nil && !Options.ExpiresAt.IsZero() && Options.ExpiresAt.Before(time.Now()) {
 		return "", fmt.Errorf("GenerateTenantToken: When the expiresAt field in the token generation has a value, it must be a date set in the future")
@@ -356,7 +360,7 @@ func (c *Client) GenerateTenantToken(SearchRules map[string]interface{}, Options
 			ExpiresAt: Options.ExpiresAt.Unix(),
 		}
 	}
-	claims.APIKeyPrefix = secret[:8]
+	claims.APIKeyUID = APIKeyUID
 	claims.SearchRules = SearchRules
 
 	// Create a new token object, specifying signing method and the claims
@@ -382,4 +386,9 @@ func convertKeyToParsedKey(key Key) (resp KeyParsed) {
 		resp.ExpiresAt = &timeParsedToString
 	}
 	return resp
+}
+
+func IsValidUUID(uuid string) bool {
+	r := regexp.MustCompile("^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-4[a-fA-F0-9]{3}-[8|9|aA|bB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$")
+	return r.MatchString(uuid)
 }

--- a/client_test.go
+++ b/client_test.go
@@ -917,8 +917,9 @@ func TestClient_ConnectionCloseByServer(t *testing.T) {
 
 func TestClient_GenerateTenantToken(t *testing.T) {
 	type args struct {
-		UID         string
+		IndexUID    string
 		client      *Client
+		APIKeyUID   string
 		searchRules map[string]interface{}
 		options     *TenantTokenOptions
 		filter      []string
@@ -932,8 +933,9 @@ func TestClient_GenerateTenantToken(t *testing.T) {
 		{
 			name: "TestDefaultGenerateTenantToken",
 			args: args{
-				UID:    "TestDefaultGenerateTenantToken",
-				client: privateClient,
+				IndexUID:  "TestDefaultGenerateTenantToken",
+				client:    privateClient,
+				APIKeyUID: GetPrivateUIDKey(),
 				searchRules: map[string]interface{}{
 					"*": map[string]string{},
 				},
@@ -946,8 +948,9 @@ func TestClient_GenerateTenantToken(t *testing.T) {
 		{
 			name: "TestGenerateTenantTokenWithApiKey",
 			args: args{
-				UID:    "TestGenerateTenantTokenWithApiKey",
-				client: defaultClient,
+				IndexUID:  "TestGenerateTenantTokenWithApiKey",
+				client:    defaultClient,
+				APIKeyUID: GetPrivateUIDKey(),
 				searchRules: map[string]interface{}{
 					"*": map[string]string{},
 				},
@@ -962,8 +965,9 @@ func TestClient_GenerateTenantToken(t *testing.T) {
 		{
 			name: "TestGenerateTenantTokenWithOnlyExpiresAt",
 			args: args{
-				UID:    "TestGenerateTenantTokenWithOnlyExpiresAt",
-				client: privateClient,
+				IndexUID:  "TestGenerateTenantTokenWithOnlyExpiresAt",
+				client:    privateClient,
+				APIKeyUID: GetPrivateUIDKey(),
 				searchRules: map[string]interface{}{
 					"*": map[string]string{},
 				},
@@ -978,8 +982,9 @@ func TestClient_GenerateTenantToken(t *testing.T) {
 		{
 			name: "TestGenerateTenantTokenWithApiKeyAndExpiresAt",
 			args: args{
-				UID:    "TestGenerateTenantTokenWithApiKeyAndExpiresAt",
-				client: defaultClient,
+				IndexUID:  "TestGenerateTenantTokenWithApiKeyAndExpiresAt",
+				client:    defaultClient,
+				APIKeyUID: GetPrivateUIDKey(),
 				searchRules: map[string]interface{}{
 					"*": map[string]string{},
 				},
@@ -995,8 +1000,9 @@ func TestClient_GenerateTenantToken(t *testing.T) {
 		{
 			name: "TestGenerateTenantTokenWithFilters",
 			args: args{
-				UID:    "indexUID",
-				client: privateClient,
+				IndexUID:  "indexUID",
+				client:    privateClient,
+				APIKeyUID: GetPrivateUIDKey(),
 				searchRules: map[string]interface{}{
 					"*": map[string]string{
 						"filter": "book_id > 1000",
@@ -1013,8 +1019,9 @@ func TestClient_GenerateTenantToken(t *testing.T) {
 		{
 			name: "TestGenerateTenantTokenWithFilterOnOneINdex",
 			args: args{
-				UID:    "indexUID",
-				client: privateClient,
+				IndexUID:  "indexUID",
+				client:    privateClient,
+				APIKeyUID: GetPrivateUIDKey(),
 				searchRules: map[string]interface{}{
 					"indexUID": map[string]string{
 						"filter": "year > 2000",
@@ -1031,8 +1038,9 @@ func TestClient_GenerateTenantToken(t *testing.T) {
 		{
 			name: "TestGenerateTenantTokenWithoutSearchRules",
 			args: args{
-				UID:         "TestGenerateTenantTokenWithoutSearchRules",
+				IndexUID:    "TestGenerateTenantTokenWithoutSearchRules",
 				client:      privateClient,
+				APIKeyUID:   GetPrivateUIDKey(),
 				searchRules: nil,
 				options:     nil,
 				filter:      nil,
@@ -1043,11 +1051,12 @@ func TestClient_GenerateTenantToken(t *testing.T) {
 		{
 			name: "TestGenerateTenantTokenWithoutApiKey",
 			args: args{
-				UID: "TestGenerateTenantTokenWithoutApiKey",
+				IndexUID: "TestGenerateTenantTokenWithoutApiKey",
 				client: NewClient(ClientConfig{
 					Host:   "http://localhost:7700",
 					APIKey: "",
 				}),
+				APIKeyUID: GetPrivateUIDKey(),
 				searchRules: map[string]interface{}{
 					"*": map[string]string{},
 				},
@@ -1060,8 +1069,9 @@ func TestClient_GenerateTenantToken(t *testing.T) {
 		{
 			name: "TestGenerateTenantTokenWithBadExpiresAt",
 			args: args{
-				UID:    "TestGenerateTenantTokenWithBadExpiresAt",
-				client: defaultClient,
+				IndexUID:  "TestGenerateTenantTokenWithBadExpiresAt",
+				client:    defaultClient,
+				APIKeyUID: GetPrivateUIDKey(),
 				searchRules: map[string]interface{}{
 					"*": map[string]string{},
 				},
@@ -1073,13 +1083,43 @@ func TestClient_GenerateTenantToken(t *testing.T) {
 			wantErr:    true,
 			wantFilter: false,
 		},
+		{
+			name: "TestGenerateTenantTokenWithBadAPIKeyUID",
+			args: args{
+				IndexUID:  "TestGenerateTenantTokenWithBadAPIKeyUID",
+				client:    defaultClient,
+				APIKeyUID: GetPrivateUIDKey() + "1234",
+				searchRules: map[string]interface{}{
+					"*": map[string]string{},
+				},
+				options: nil,
+				filter:  nil,
+			},
+			wantErr:    true,
+			wantFilter: false,
+		},
+		{
+			name: "TestGenerateTenantTokenWithEmptyAPIKeyUID",
+			args: args{
+				IndexUID:  "TestGenerateTenantTokenWithEmptyAPIKeyUID",
+				client:    defaultClient,
+				APIKeyUID: "",
+				searchRules: map[string]interface{}{
+					"*": map[string]string{},
+				},
+				options: nil,
+				filter:  nil,
+			},
+			wantErr:    true,
+			wantFilter: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := tt.args.client
 			t.Cleanup(cleanup(c))
 
-			token, err := c.GenerateTenantToken(tt.args.searchRules, tt.args.options)
+			token, err := c.GenerateTenantToken(tt.args.APIKeyUID, tt.args.searchRules, tt.args.options)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -1087,11 +1127,11 @@ func TestClient_GenerateTenantToken(t *testing.T) {
 				require.NoError(t, err)
 
 				if tt.wantFilter {
-					gotTask, err := c.Index(tt.args.UID).UpdateFilterableAttributes(&tt.args.filter)
+					gotTask, err := c.Index(tt.args.IndexUID).UpdateFilterableAttributes(&tt.args.filter)
 					require.NoError(t, err, "UpdateFilterableAttributes() in TestGenerateTenantToken error should be nil")
-					testWaitForTask(t, c.Index(tt.args.UID), gotTask)
+					testWaitForTask(t, c.Index(tt.args.IndexUID), gotTask)
 				} else {
-					_, err := SetUpEmptyIndex(&IndexConfig{Uid: tt.args.UID})
+					_, err := SetUpEmptyIndex(&IndexConfig{Uid: tt.args.IndexUID})
 					require.NoError(t, err, "CreateIndex() in TestGenerateTenantToken error should be nil")
 				}
 
@@ -1100,7 +1140,7 @@ func TestClient_GenerateTenantToken(t *testing.T) {
 					APIKey: token,
 				})
 
-				_, err = client.Index(tt.args.UID).Search("", &SearchRequest{})
+				_, err = client.Index(tt.args.IndexUID).Search("", &SearchRequest{})
 
 				require.NoError(t, err)
 			}

--- a/main_test.go
+++ b/main_test.go
@@ -90,6 +90,19 @@ func GetPrivateKey() (key string) {
 	return ""
 }
 
+func GetPrivateUIDKey() (key string) {
+	list, err := defaultClient.GetKeys(nil)
+	if err != nil {
+		return ""
+	}
+	for _, key := range list.Results {
+		if strings.Contains(key.Name, "Default Admin API Key") || (key.Description == "") {
+			return key.UID
+		}
+	}
+	return ""
+}
+
 func SetUpEmptyIndex(index *IndexConfig) (resp *Index, err error) {
 	client := NewClient(ClientConfig{
 		Host:   "http://localhost:7700",

--- a/types.go
+++ b/types.go
@@ -165,8 +165,8 @@ type TenantTokenOptions struct {
 
 // Custom Claims structure to create a Tenant Token
 type TenantTokenClaims struct {
-	APIKeyPrefix string      `json:"apiKeyPrefix"`
-	SearchRules  interface{} `json:"searchRules"`
+	APIKeyUID   string      `json:"apiKeyUid"`
+	SearchRules interface{} `json:"searchRules"`
 	jwt.StandardClaims
 }
 


### PR DESCRIPTION
as per the [spec](https://github.com/meilisearch/specifications/pull/148/files#diff-7b1a49daa5acb02c131aff3eb5fabb81c7e7c3d1b95adb60c4bf70cadcb488d4)


- [x] apiKeyPrefix claim is now named apiKeyUid and expects the uid of the signing API key as a value.
