### PR TITLE
Fix linter in github action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,13 +14,12 @@ jobs:
     name: linter
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Go
-      uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
         go-version: 1.17
-    - name: Run linter
-      uses: golangci/golangci-lint-action@v2
+    - uses: actions/checkout@v3
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
       with:
         version: v1.45.2
     - name: Run go vet


### PR DESCRIPTION
The GitHub action who run `run golangci-lint` failed with this error:
```
Running [/home/runner/golangci-lint-1.45.2-linux-amd64/golangci-lint run --out-format=github-actions] in [] ...
  level=error msg="[runner] Panic: buildir: package \"atomic\" (isInitialPkg: false, needAnalyzeSource: true): T: goroutine 7731 [running]:\nruntime/debug.Stack()\n\truntime/debug/stack.go:24 +0x65\ngithub.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyzeSafe.func1()\n\tgithub.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner_action.go:101 +0x155\npanic({0xf853e0, 0xc001fcad50})\n\truntime/panic.go:838 +0x207\nhonnef.co/go/tools/go/ir.(*Program).needMethods(0xc001bfe9a0, {0x1226ec8?, 0xc001fcad50?}, 0x0)\n\thonnef.co/go/tools@v0.2.2/go/ir/methods.go:237 +0x5b1\nhonnef.co/go/tools/go/ir.(*Program).needMethods(0xc001bfe9a0, {0x1226dd8?, 0xc001f493d0?}, 0x0)\n\thonnef.co/go/tools@v0.2.2/go/ir/methods.go:193 +0x307\nhonnef.co/go/tools/go/ir.(*Program).needMethods(0xc001bfe9a0, {0x1226ea0?, 0xc001f27908?}, 0x0)\n\thonnef.co/go/tools@v0.2.2/go/ir/methods.go:233 +0x708\nhonnef.co/go/tools/go/ir.(*Program).needMethods(0xc001bfe9a0, {0x1226dd8?, 0xc002072a10?}, 0x0)\n\thonnef.co/go/tools@v0.2.2/go/ir/methods.go:181 +0x1af\nhonnef.co/go/tools/go/ir.(*Program).needMethods(0xc001bfe9a0, {0x1226d60?, 0xc001d0f810?}, 0x0)\n\thonnef.co/go/tools@v0.2.2/go/ir/methods.go:215 +0x55f\nhonnef.co/go/tools/go/ir.(*Program).needMethodsOf(0xc001bfe9a0, {0x1226d60?, 0xc001d0f810?})\n\thonnef.co/go/tools@v0.2.2/go/ir/methods.go:145 +0x70\nhonnef.co/go/tools/go/ir.(*Package).build(0xc001bbae10)\n\thonnef.co/go/tools@v0.2.2/go/ir/builder.go:23[75](https://github.com/meilisearch/meilisearch-go/runs/7741763442?check_suite_focus=true#step:4:77) +0x111\nsync.(*Once).doSlow(0xc001bfe9a0?, 0xc001f39ef0?)\n\tsync/once.go:68 +0xc2\nsync.(*Once).Do(...)\n\tsync/once.go:59\nhonnef.co/go/tools/go/ir.(*Package).Build(...)\n\thonnef.co/go/tools@v0.2.2/go/ir/builder.go:2363\nhonnef.co/go/tools/internal/passes/buildir.run(0xc00205e340)\n\thonnef.co/go/tools@v0.2.2/internal/passes/buildir/buildir.go:86 +0x368\ngithub.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyze(0xc0063dd050)\n\tgithub.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner_action.go:187 +0x9c4\ngithub.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyzeSafe.func2()\n\tgithub.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner_action.go:105 +0x1d\ngithub.com/golangci/golangci-lint/pkg/timeutils.(*Stopwatch).TrackStage(0xc0033e3db0, {0xfe42b6, 0x7}, 0xc0004f3748)\n\tgithub.com/golangci/golangci-lint/pkg/timeutils/stopwatch.go:111 +0x4a\ngithub.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyzeSafe(0xc00232bbc0?)\n\tgithub.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner_action.go:104 +0x85\ngithub.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*loadingPackage).analyze.func2(0xc0063dd050)\n\tgithub.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner_loadingpackage.go:80 +0xb4\ncreated by github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*loadingPackage).analyze\n\tgithub.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner_loadingpackage.go:75 +0x1eb\n"
  level=warning msg="[runner] Can't run linter goanalysis_metalinter: goanalysis_metalinter: buildir: package \"atomic\" (isInitialPkg: false, needAnalyzeSource: true): T"
  level=error msg="Running error: 1 error occurred:\n\t* can't run linter goanalysis_metalinter: goanalysis_metalinter: buildir: package \"atomic\" (isInitialPkg: false, needAnalyzeSource: true): T\n\n"
  
  Error: golangci-lint exit with code 3
  Ran golangci-lint in 19059ms
```