### PR TITLE
pre-alloc search post body for index_search

### DIFF
--- a/index_search.go
+++ b/index_search.go
@@ -14,7 +14,7 @@ const (
 func (i Index) Search(query string, request *SearchRequest) (*SearchResponse, error) {
 	resp := &SearchResponse{}
 
-	searchPostRequestParams := map[string]interface{}{}
+	searchPostRequestParams := make(map[string]interface{}, 14)
 
 	if request.Limit == 0 {
 		request.Limit = DefaultLimit


### PR DESCRIPTION
# Pull Request

map initialization without length map cause many allocs, adding a fixed known length to avoid.

## What does this PR do?
Fixes #<issue_number>
<!-- Please link the issue you're trying to fix with this PR, if none then please create an issue first. -->

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue?
- [X] Have you read the contributing guidelines?
- [X] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
