### PR TITLE
Create key: Add ability to specify the `Uid` and `Name` value

### DIFF
--- a/client.go
+++ b/client.go
@@ -385,7 +385,7 @@ func (c *Client) GenerateTenantToken(APIKeyUID string, SearchRules map[string]in
 // and transform the Key structure into a KeyParsed structure to send the time format
 // managed by Meilisearch
 func convertKeyToParsedKey(key Key) (resp KeyParsed) {
-	resp = KeyParsed{Description: key.Description, Actions: key.Actions, Indexes: key.Indexes}
+	resp = KeyParsed{Description: key.Description, Key: key.Key, Actions: key.Actions, Indexes: key.Indexes}
 
 	// Convert time.Time to *string to feat the exact ISO-8601
 	// format of Meilisearch

--- a/client.go
+++ b/client.go
@@ -385,7 +385,7 @@ func (c *Client) GenerateTenantToken(APIKeyUID string, SearchRules map[string]in
 // and transform the Key structure into a KeyParsed structure to send the time format
 // managed by Meilisearch
 func convertKeyToParsedKey(key Key) (resp KeyParsed) {
-	resp = KeyParsed{Description: key.Description, Key: key.Key, Actions: key.Actions, Indexes: key.Indexes}
+	resp = KeyParsed{Name: key.Name, Description: key.Description, UID: key.UID, Actions: key.Actions, Indexes: key.Indexes}
 
 	// Convert time.Time to *string to feat the exact ISO-8601
 	// format of Meilisearch

--- a/client_test.go
+++ b/client_test.go
@@ -227,11 +227,22 @@ func TestClient_CreateKey(t *testing.T) {
 			},
 		},
 		{
+			name:   "TestCreateKeyWithUID",
+			client: defaultClient,
+			key: Key{
+				Name:    "TestCreateKeyWithUID",
+				UID:     "9aec34f4-e44c-4917-86c2-9c9403abb3b6",
+				Actions: []string{"*"},
+				Indexes: []string{"*"},
+			},
+		},
+		{
 			name:   "TestCreateKeyWithAllOptions",
 			client: defaultClient,
 			key: Key{
 				Name:        "TestCreateKeyWithAllOptions",
 				Description: "TestCreateKeyWithAllOptions",
+				UID:         "9aec34f4-e44c-4917-86c2-9c9403abb3b6",
 				Actions:     []string{"documents.add", "documents.delete"},
 				Indexes:     []string{"movies", "games"},
 				ExpiresAt:   time.Now().Add(time.Hour * 10),
@@ -249,7 +260,11 @@ func TestClient_CreateKey(t *testing.T) {
 
 			gotKey, err := c.GetKey(gotResp.Key)
 			require.NoError(t, err)
+			require.Equal(t, tt.key.Name, gotKey.Name)
 			require.Equal(t, tt.key.Description, gotKey.Description)
+			if tt.key.UID != "" {
+				require.Equal(t, tt.key.UID, gotKey.UID)
+			}
 			require.Equal(t, tt.key.Actions, gotKey.Actions)
 			require.Equal(t, tt.key.Indexes, gotKey.Indexes)
 			if !tt.key.ExpiresAt.IsZero() {

--- a/types.go
+++ b/types.go
@@ -199,7 +199,7 @@ type Key struct {
 type KeyParsed struct {
 	Name        string    `json:"name"`
 	Description string    `json:"description"`
-	Key         string    `json:"key,omitempty"`
+	UID         string    `json:"uid,omitempty"`
 	Actions     []string  `json:"actions,omitempty"`
 	Indexes     []string  `json:"indexes,omitempty"`
 	CreatedAt   time.Time `json:"createdAt,omitempty"`

--- a/types_easyjson.go
+++ b/types_easyjson.go
@@ -2855,8 +2855,8 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo20(in *jlexer.Lexer,
 			out.Name = string(in.String())
 		case "description":
 			out.Description = string(in.String())
-		case "key":
-			out.Key = string(in.String())
+		case "uid":
+			out.UID = string(in.String())
 		case "actions":
 			if in.IsNull() {
 				in.Skip()
@@ -2945,10 +2945,10 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo20(out *jwriter.Writ
 		out.RawString(prefix)
 		out.String(string(in.Description))
 	}
-	if in.Key != "" {
-		const prefix string = ",\"key\":"
+	if in.UID != "" {
+		const prefix string = ",\"uid\":"
 		out.RawString(prefix)
-		out.String(string(in.Key))
+		out.String(string(in.UID))
 	}
 	if len(in.Actions) != 0 {
 		const prefix string = ",\"actions\":"


### PR DESCRIPTION
`type Key struct {}` and `type KeyParsed struct {}` both have a `Key string` field.

However, `KeyParsed`'s one is never filled and thus the server always will generate a random key, even if a value was specified in the call to `client.CreateKey(&meilisearch.Key{Key: "..."}}`.