### PR TITLE
docs: fix code samples for typo tolerance

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -413,26 +413,26 @@ settings_guide_faceting_1: |-
     MaxValuesPerFacet: 5,
   })
 settings_guide_typo_tolerance_1: |-
-  client.index("movies").UpdateTypoTolerance({
+  client.Index("movies").UpdateTypoTolerance(&meilisearch.TypoTolerance{
     MinWordSizeForTypos: meilisearch.MinWordSizeForTypos{
       TwoTypos: 12,
     },
     DisableOnAttributes: []string{"title"},
   })
 typo_tolerance_guide_1: |-
-  client.index("movies").UpdateTypoTolerance({
+  client.Index("movies").UpdateTypoTolerance(&meilisearch.TypoTolerance{
     Enabled: false,
   })
 typo_tolerance_guide_2: |-
-  client.index("movies").UpdateTypoTolerance({
+  client.Index("movies").UpdateTypoTolerance(&meilisearch.TypoTolerance{
     DisableOnAttributes: []string{"title"},
   })
 typo_tolerance_guide_3: |-
-  client.index("movies").UpdateTypoTolerance({
+  client.Index("movies").UpdateTypoTolerance(&meilisearch.TypoTolerance{
     DisableOnWords: []string{"shrek"},
   })
 typo_tolerance_guide_4: |-
-  client.index("movies").UpdateTypoTolerance({
+  client.Index("movies").UpdateTypoTolerance(&meilisearch.TypoTolerance{
     MinWordSizeForTypos: meilisearch.MinWordSizeForTypos{
       OneTypo: 4,
       TwoTypos: 10,


### PR DESCRIPTION
I added the TypoTolerance struct type to options brackets and capitalized the I in the Index function. A detailed description is in the issue.

# Pull Request

## What does this PR do?
Fixes https://github.com/meilisearch/meilisearch-go/issues/344
<!-- Please link the issue you're trying to fix with this PR, if none then please create an issue first. -->

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?
