### PR TITLE
Add tests to custom search with matching_strategy param

### DIFF
--- a/index_search.go
+++ b/index_search.go
@@ -47,6 +47,9 @@ func (i Index) Search(query string, request *SearchRequest) (*SearchResponse, er
 	if request.HighlightPostTag != "" {
 		searchPostRequestParams["highlightPostTag"] = request.HighlightPostTag
 	}
+	if request.MatchingStrategy != "" {
+		searchPostRequestParams["matchingStrategy"] = request.MatchingStrategy
+	}
 	if len(request.AttributesToRetrieve) != 0 {
 		searchPostRequestParams["attributesToRetrieve"] = request.AttributesToRetrieve
 	}

--- a/index_search_test.go
+++ b/index_search_test.go
@@ -302,6 +302,55 @@ func TestIndex_Search(t *testing.T) {
 				Limit:              20,
 			},
 		},
+		{
+			name: "TestIndexSearchWithCustomMatchingStrategyAll",
+			args: args{
+				UID:    "indexUID",
+				client: defaultClient,
+				query:  "le prince",
+				request: SearchRequest{
+					Limit:                 10,
+					AttributesToRetrieve: []string{"book_id","title"},
+					MatchingStrategy:      "all",
+				},
+			},
+			want: &SearchResponse{
+				Hits: []interface{}{
+					map[string]interface{}{
+						"book_id": float64(456), "title": "Le Petit Prince",
+					},
+				},
+				EstimatedTotalHits: 1,
+				Offset:             0,
+				Limit:              10,
+			},
+		},
+		{
+			name: "TestIndexSearchWithCustomMatchingStrategyLast",
+			args: args{
+				UID:    "indexUID",
+				client: defaultClient,
+				query:  "prince",
+				request: SearchRequest{
+					Limit:                 10,
+					AttributesToRetrieve: []string{"book_id","title"},
+					MatchingStrategy:      "last",
+				},
+			},
+			want: &SearchResponse{
+				Hits: []interface{}{
+					map[string]interface{}{
+						"book_id": float64(456), "title": "Le Petit Prince",
+					},
+					map[string]interface{}{
+						"book_id": float64(4), "title": "Harry Potter and the Half-Blood Prince",
+					},
+				},
+				EstimatedTotalHits: 2,
+				Offset:             0,
+				Limit:              10,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/types.go
+++ b/types.go
@@ -267,6 +267,7 @@ type SearchRequest struct {
 	AttributesToHighlight []string
 	HighlightPreTag       string
 	HighlightPostTag      string
+	MatchingStrategy      string
 	Filter                interface{}
 	ShowMatchesPosition   bool
 	Facets                []string


### PR DESCRIPTION
Ensure the support of `MatchingStrategy` query parameter.