### PR TITLE
Add tests to wildcarded action keys

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -227,6 +227,16 @@ func TestClient_CreateKey(t *testing.T) {
 			},
 		},
 		{
+			name:   "TestCreateKeyWithWildcardedAction",
+			client: defaultClient,
+			key: Key{
+				Name:        "TestCreateKeyWithWildcardedAction",
+				Description: "TestCreateKeyWithWildcardedAction",
+				Actions:     []string{"documents.*"},
+				Indexes:     []string{"movies", "games"},
+			},
+		},
+		{
 			name:   "TestCreateKeyWithUID",
 			client: defaultClient,
 			key: Key{


### PR DESCRIPTION
Ensure support to keys with wildcarded actions.

- `actions` field during key creation now accepts wildcards on actions. For example, `indexes.*` provides rights to `indexes.create`, `indexes.get`,`indexes.delete`, `indexes.delete`, and `indexes.update`.