### PR TITLE
Release v0.21.0

### DIFF
--- a/version.go
+++ b/version.go
@@ -2,7 +2,7 @@ package meilisearch
 
 import "fmt"
 
-const VERSION = "0.20.1"
+const VERSION = "0.21.0"
 
 func GetQualifiedVersion() (qualifiedVersion string) {
 	return getQualifiedVersion(VERSION)


### PR DESCRIPTION
This version makes this package compatible with Meilisearch v0.29.0 :tada:
Check out the changelog of [Meilisearch v0.29.0](https://github.com/meilisearch/meilisearch/releases/tag/v0.29.0) for more information on the changes.

## 🚀 Enhancements

- Ensure support to the new search query parameter `MatchingStrategy` (#348) @brunoocasali 
- Ensure support to keys with wildcarded actions.
  - `actions` field during key creation now accepts wildcards on actions. For example, `indexes.*` provides rights to `indexes.create`, `indexes.get`,`indexes.delete`, `indexes.delete`, and `indexes.update`. (#349) @brunoocasali 
  
## ⚠️ Breaking Changes

This breaking change *__may not affect you__*, but in any case, you should check your search queries if you want to keep the same behavior from `v0.28`.

- The `NOT` filter keyword does not have an implicitly `EXIST` operator anymore. Check out for more information: https://github.com/meilisearch/meilisearch/issues/2486