### PR TITLE
add code samples for matching strategy

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -340,6 +340,14 @@ search_parameter_guide_show_matches_position_1: |-
   resp, err := client.Index("movies").Search("winter feast", &meilisearch.SearchRequest{
     ShowMatchesPosition:    true,
   })
+search_parameter_guide_matching_strategy_1: |-
+  resp, err := client.Index("movies").Search("big fat liar", &meilisearch.SearchRequest{
+    MatchingStrategy:    "last",
+  })
+search_parameter_guide_matching_strategy_2: |-
+  resp, err := client.Index("movies").Search("big fat liar", &meilisearch.SearchRequest{
+    MatchingStrategy:    "all",
+  })
 settings_guide_synonyms_1: |-
   settings := meilisearch.Settings{
     Synonyms: map[string][]string{


### PR DESCRIPTION
This commit adds code samples for the MatchingStrategy field of a SearchRequest.

Closes #368

# Pull Request

## Related issue
Fixes #368

## What does this PR do?
- adds code samples for using "last" and "all" as `MatchingStrategy` in a `SearchRequest`

## PR checklist
Please check if your PR fulfills the following requirements:
- [X] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [X] Have you read the contributing guidelines?
- [X] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
