### PR TITLE
Remove references to github.com/pkg/errors

### DIFF
--- a/client_request.go
+++ b/client_request.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/pkg/errors"
 	"github.com/valyala/fasthttp"
 
 	"encoding/json"
@@ -75,7 +74,7 @@ func (c *Client) sendRequest(req *internalRequest, internalError *Error, respons
 	// Setup URL
 	requestURL, err := url.Parse(c.config.Host + req.endpoint)
 	if err != nil {
-		return errors.Wrap(err, "unable to parse url")
+		return fmt.Errorf("unable to parse url: %w", err)
 	}
 
 	// Build query parameters

--- a/error.go
+++ b/error.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // ErrCode are all possible errors found during requests
@@ -118,7 +116,7 @@ func (e Error) Error() string {
 		"link":               e.MeilisearchApiError.Link,
 	})
 	if e.OriginError != nil {
-		return errors.Wrap(e.OriginError, message).Error()
+		return fmt.Sprintf("%s: %s", message, e.OriginError.Error())
 	}
 
 	return message

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.4.2
 	github.com/klauspost/compress v1.15.6 // indirect
 	github.com/mailru/easyjson v0.7.7
-	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.1
 	github.com/valyala/fasthttp v1.37.1-0.20220607072126-8a320890c08d
 )

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,6 @@ github.com/klauspost/compress v1.15.6 h1:6D9PcO8QWu0JyaQ2zUMmu16T1T+zjjEpP91guRs
 github.com/klauspost/compress v1.15.6/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/index_documents.go
+++ b/index_documents.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/csv"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"math"
@@ -11,8 +12,6 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 func (i Index) GetDocument(identifier string, request *DocumentQuery, documentPtr interface{}) error {
@@ -135,7 +134,7 @@ func (i Index) AddDocumentsCsvFromReader(documents io.Reader, primaryKey ...stri
 	// read content to memory anyway because of problems with streamed bodies
 	data, err := ioutil.ReadAll(documents)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not read documents")
+		return nil, fmt.Errorf("could not read documents: %w", err)
 	}
 	return i.addDocuments(data, contentTypeCSV, primaryKey...)
 }
@@ -166,7 +165,7 @@ func (i Index) AddDocumentsCsvFromReaderInBatches(documents io.Reader, batchSize
 		w.UseCRLF = true // Keep output RFC 4180 compliant
 		err := w.WriteAll(records)
 		if err != nil {
-			return nil, errors.Wrap(err, "could not write CSV records")
+			return nil, fmt.Errorf("could not write CSV records: %w", err)
 		}
 
 		resp, err := i.AddDocumentsCsv(b.Bytes(), primaryKey...)
@@ -184,7 +183,7 @@ func (i Index) AddDocumentsCsvFromReaderInBatches(documents io.Reader, batchSize
 			break
 		}
 		if err != nil {
-			return nil, errors.Wrap(err, "could not read CSV record")
+			return nil, fmt.Errorf("could not read CSV record: %w", err)
 		}
 
 		// Store first record as header
@@ -233,7 +232,7 @@ func (i Index) AddDocumentsNdjsonFromReader(documents io.Reader, primaryKey ...s
 	// read content to memory anyway because of problems with streamed bodies
 	data, err := ioutil.ReadAll(documents)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not read documents")
+		return nil, fmt.Errorf("could not read documents: %w", err)
 	}
 	return i.addDocuments(data, contentTypeNDJSON, primaryKey...)
 }
@@ -255,11 +254,11 @@ func (i Index) AddDocumentsNdjsonFromReaderInBatches(documents io.Reader, batchS
 		for _, line := range lines {
 			_, err := b.WriteString(line)
 			if err != nil {
-				return nil, errors.Wrap(err, "could not write NDJSON line")
+				return nil, fmt.Errorf("could not write NDJSON line: %w", err)
 			}
 			err = b.WriteByte('\n')
 			if err != nil {
-				return nil, errors.Wrap(err, "could not write NDJSON line")
+				return nil, fmt.Errorf("could not write NDJSON line: %w", err)
 			}
 		}
 
@@ -296,7 +295,7 @@ func (i Index) AddDocumentsNdjsonFromReaderInBatches(documents io.Reader, batchS
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		return nil, errors.Wrap(err, "could not read NDJSON")
+		return nil, fmt.Errorf("could not read NDJSON: %w", err)
 	}
 
 	// Send remaining records as the last batch if there is any


### PR DESCRIPTION
Package github.com/pkg/errors has been marked deprecated.

# Pull Request

## Related issue
Fixes #378

## What does this PR do?
- Remove references to github.com/pkg/errors

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
