### PR TITLE
Remove references to io/ioutil

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -449,10 +449,10 @@ typo_tolerance_guide_4: |-
 add_movies_json_1: |-
   import (
     "encoding/json"
-    "io/ioutil"
+    "os"
   )
 
-  file, _ := ioutil.ReadFile("movies.json")
+  file, _ := os.ReadFile("movies.json")
 
   var movies interface{}
   json.Unmarshal([]byte(file), &movies)
@@ -494,7 +494,7 @@ getting_started_add_documents_md: |-
   import (
     "os"
     "encoding/json"
-    "io/ioutil"
+    "io"
 
     "github.com/meilisearch/meilisearch-go"
   )
@@ -507,7 +507,7 @@ getting_started_add_documents_md: |-
     jsonFile, _ := os.Open("movies.json")
     defer jsonFile.Close()
 
-    byteValue, _ := ioutil.ReadAll(jsonFile)
+    byteValue, _ := io.ReadAll(jsonFile)
     var movies []map[string]interface{}
     json.Unmarshal(byteValue, &movies)
 
@@ -534,7 +534,7 @@ getting_started_add_meteorites: |-
     jsonFile, _ := os.Open("meteorites.json")
     defer jsonFile.Close()
 
-    byteValue, _ := ioutil.ReadAll(jsonFile)
+    byteValue, _ := io.ReadAll(jsonFile)
     var meteorites []map[string]interface{}
     json.Unmarshal(byteValue, &meteorites)
 

--- a/index_documents.go
+++ b/index_documents.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"encoding/csv"
 	"io"
-	"io/ioutil"
 	"math"
 	"net/http"
 	"reflect"
@@ -133,7 +132,7 @@ func (i Index) AddDocumentsCsv(documents []byte, primaryKey ...string) (resp *Ta
 func (i Index) AddDocumentsCsvFromReader(documents io.Reader, primaryKey ...string) (resp *TaskInfo, err error) {
 	// Using io.Reader would avoid JSON conversion in Client.sendRequest(), but
 	// read content to memory anyway because of problems with streamed bodies
-	data, err := ioutil.ReadAll(documents)
+	data, err := io.ReadAll(documents)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not read documents")
 	}
@@ -231,7 +230,7 @@ func (i Index) AddDocumentsNdjson(documents []byte, primaryKey ...string) (resp 
 func (i Index) AddDocumentsNdjsonFromReader(documents io.Reader, primaryKey ...string) (resp *TaskInfo, err error) {
 	// Using io.Reader would avoid JSON conversion in Client.sendRequest(), but
 	// read content to memory anyway because of problems with streamed bodies
-	data, err := ioutil.ReadAll(documents)
+	data, err := io.ReadAll(documents)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not read documents")
 	}


### PR DESCRIPTION
Package io/ioutil has been marked deprecated in Go 1.16.

# Pull Request

## Related issue
Fixes #380 

## What does this PR do?
- Removes references to io/ioutil

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
