### PR TITLE
Add tasks filters for v0.30

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -791,7 +791,7 @@ get_all_tasks_filtering_1: |-
   client.Index("movies").GetTasks(nil);
   // OR
   client.GetTasks(&TasksQuery{
-    IndexUID: []string{"movies"},
+    IndexUIDs: []string{"movies"},
   });
 get_all_tasks_filtering_2: |-
   client.GetTasks(&meilisearch.TasksQuery{

--- a/client.go
+++ b/client.go
@@ -283,14 +283,14 @@ func (c *Client) GetTasks(param *TasksQuery) (resp *TaskResult, err error) {
 		if param.From != 0 {
 			req.withQueryParams["from"] = strconv.FormatInt(param.From, 10)
 		}
-		if len(param.Status) != 0 {
-			req.withQueryParams["status"] = strings.Join(param.Status, ",")
+		if len(param.Statuses) != 0 {
+			req.withQueryParams["statuses"] = strings.Join(param.Statuses, ",")
 		}
-		if len(param.Type) != 0 {
-			req.withQueryParams["type"] = strings.Join(param.Type, ",")
+		if len(param.Types) != 0 {
+			req.withQueryParams["types"] = strings.Join(param.Types, ",")
 		}
-		if len(param.IndexUID) != 0 {
-			req.withQueryParams["indexUid"] = strings.Join(param.IndexUID, ",")
+		if len(param.IndexUIDs) != 0 {
+			req.withQueryParams["indexUids"] = strings.Join(param.IndexUIDs, ",")
 		}
 	}
 	if err := c.executeRequest(req); err != nil {

--- a/client.go
+++ b/client.go
@@ -285,7 +285,6 @@ func (c *Client) GetTasks(param *TasksQuery) (resp *TaskResult, err error) {
 	return resp, nil
 }
 
-
 // WaitForTask waits for a task to be processed
 //
 // The function will check by regular interval provided in parameter interval
@@ -400,11 +399,11 @@ func encodeTasksQuery(param *TasksQuery, req *internalRequest) {
 	if len(param.Types) != 0 {
 		req.withQueryParams["types"] = strings.Join(param.Types, ",")
 	}
-	if len(param.IndexUIDs) != 0 {
-		req.withQueryParams["indexUids"] = strings.Join(param.IndexUIDs, ",")
+	if len(param.IndexUIDS) != 0 {
+		req.withQueryParams["indexUids"] = strings.Join(param.IndexUIDS, ",")
 	}
-	if len(param.UIDs) != 0 {
-		req.withQueryParams["uids"] = strings.Trim(strings.Join(strings.Fields(fmt.Sprint(param.UIDs)), ","), "[]")
+	if len(param.UIDS) != 0 {
+		req.withQueryParams["uids"] = strings.Trim(strings.Join(strings.Fields(fmt.Sprint(param.UIDS)), ","), "[]")
 	}
 	if len(param.CanceledBy) != 0 {
 		req.withQueryParams["canceledBy"] = strings.Trim(strings.Join(strings.Fields(fmt.Sprint(param.CanceledBy)), ","), "[]")

--- a/client_test.go
+++ b/client_test.go
@@ -749,7 +749,7 @@ func TestClient_GetTasks(t *testing.T) {
 				query: &TasksQuery{
 					Limit:     1,
 					From:      0,
-					IndexUIDs: []string{"indexUID"},
+					IndexUIDS: []string{"indexUID"},
 				},
 			},
 		},
@@ -763,7 +763,7 @@ func TestClient_GetTasks(t *testing.T) {
 				},
 				query: &TasksQuery{
 					Limit: 1,
-					UIDs:  []int64{1},
+					UIDS:  []int64{1},
 				},
 			},
 		},
@@ -1021,7 +1021,7 @@ func TestClient_ConnectionCloseByServer(t *testing.T) {
 
 func TestClient_GenerateTenantToken(t *testing.T) {
 	type args struct {
-		IndexUIDs   string
+		IndexUIDS   string
 		client      *Client
 		APIKeyUID   string
 		searchRules map[string]interface{}
@@ -1037,7 +1037,7 @@ func TestClient_GenerateTenantToken(t *testing.T) {
 		{
 			name: "TestDefaultGenerateTenantToken",
 			args: args{
-				IndexUIDs: "TestDefaultGenerateTenantToken",
+				IndexUIDS: "TestDefaultGenerateTenantToken",
 				client:    privateClient,
 				APIKeyUID: GetPrivateUIDKey(),
 				searchRules: map[string]interface{}{
@@ -1052,7 +1052,7 @@ func TestClient_GenerateTenantToken(t *testing.T) {
 		{
 			name: "TestGenerateTenantTokenWithApiKey",
 			args: args{
-				IndexUIDs: "TestGenerateTenantTokenWithApiKey",
+				IndexUIDS: "TestGenerateTenantTokenWithApiKey",
 				client:    defaultClient,
 				APIKeyUID: GetPrivateUIDKey(),
 				searchRules: map[string]interface{}{
@@ -1069,7 +1069,7 @@ func TestClient_GenerateTenantToken(t *testing.T) {
 		{
 			name: "TestGenerateTenantTokenWithOnlyExpiresAt",
 			args: args{
-				IndexUIDs: "TestGenerateTenantTokenWithOnlyExpiresAt",
+				IndexUIDS: "TestGenerateTenantTokenWithOnlyExpiresAt",
 				client:    privateClient,
 				APIKeyUID: GetPrivateUIDKey(),
 				searchRules: map[string]interface{}{
@@ -1086,7 +1086,7 @@ func TestClient_GenerateTenantToken(t *testing.T) {
 		{
 			name: "TestGenerateTenantTokenWithApiKeyAndExpiresAt",
 			args: args{
-				IndexUIDs: "TestGenerateTenantTokenWithApiKeyAndExpiresAt",
+				IndexUIDS: "TestGenerateTenantTokenWithApiKeyAndExpiresAt",
 				client:    defaultClient,
 				APIKeyUID: GetPrivateUIDKey(),
 				searchRules: map[string]interface{}{
@@ -1104,7 +1104,7 @@ func TestClient_GenerateTenantToken(t *testing.T) {
 		{
 			name: "TestGenerateTenantTokenWithFilters",
 			args: args{
-				IndexUIDs: "indexUID",
+				IndexUIDS: "indexUID",
 				client:    privateClient,
 				APIKeyUID: GetPrivateUIDKey(),
 				searchRules: map[string]interface{}{
@@ -1123,7 +1123,7 @@ func TestClient_GenerateTenantToken(t *testing.T) {
 		{
 			name: "TestGenerateTenantTokenWithFilterOnOneINdex",
 			args: args{
-				IndexUIDs: "indexUID",
+				IndexUIDS: "indexUID",
 				client:    privateClient,
 				APIKeyUID: GetPrivateUIDKey(),
 				searchRules: map[string]interface{}{
@@ -1142,7 +1142,7 @@ func TestClient_GenerateTenantToken(t *testing.T) {
 		{
 			name: "TestGenerateTenantTokenWithoutSearchRules",
 			args: args{
-				IndexUIDs:   "TestGenerateTenantTokenWithoutSearchRules",
+				IndexUIDS:   "TestGenerateTenantTokenWithoutSearchRules",
 				client:      privateClient,
 				APIKeyUID:   GetPrivateUIDKey(),
 				searchRules: nil,
@@ -1155,7 +1155,7 @@ func TestClient_GenerateTenantToken(t *testing.T) {
 		{
 			name: "TestGenerateTenantTokenWithoutApiKey",
 			args: args{
-				IndexUIDs: "TestGenerateTenantTokenWithoutApiKey",
+				IndexUIDS: "TestGenerateTenantTokenWithoutApiKey",
 				client: NewClient(ClientConfig{
 					Host:   getenv("MEILISEARCH_URL", "http://localhost:7700"),
 					APIKey: "",
@@ -1173,7 +1173,7 @@ func TestClient_GenerateTenantToken(t *testing.T) {
 		{
 			name: "TestGenerateTenantTokenWithBadExpiresAt",
 			args: args{
-				IndexUIDs: "TestGenerateTenantTokenWithBadExpiresAt",
+				IndexUIDS: "TestGenerateTenantTokenWithBadExpiresAt",
 				client:    defaultClient,
 				APIKeyUID: GetPrivateUIDKey(),
 				searchRules: map[string]interface{}{
@@ -1190,7 +1190,7 @@ func TestClient_GenerateTenantToken(t *testing.T) {
 		{
 			name: "TestGenerateTenantTokenWithBadAPIKeyUID",
 			args: args{
-				IndexUIDs: "TestGenerateTenantTokenWithBadAPIKeyUID",
+				IndexUIDS: "TestGenerateTenantTokenWithBadAPIKeyUID",
 				client:    defaultClient,
 				APIKeyUID: GetPrivateUIDKey() + "1234",
 				searchRules: map[string]interface{}{
@@ -1205,7 +1205,7 @@ func TestClient_GenerateTenantToken(t *testing.T) {
 		{
 			name: "TestGenerateTenantTokenWithEmptyAPIKeyUID",
 			args: args{
-				IndexUIDs: "TestGenerateTenantTokenWithEmptyAPIKeyUID",
+				IndexUIDS: "TestGenerateTenantTokenWithEmptyAPIKeyUID",
 				client:    defaultClient,
 				APIKeyUID: "",
 				searchRules: map[string]interface{}{
@@ -1231,11 +1231,11 @@ func TestClient_GenerateTenantToken(t *testing.T) {
 				require.NoError(t, err)
 
 				if tt.wantFilter {
-					gotTask, err := c.Index(tt.args.IndexUIDs).UpdateFilterableAttributes(&tt.args.filter)
+					gotTask, err := c.Index(tt.args.IndexUIDS).UpdateFilterableAttributes(&tt.args.filter)
 					require.NoError(t, err, "UpdateFilterableAttributes() in TestGenerateTenantToken error should be nil")
-					testWaitForTask(t, c.Index(tt.args.IndexUIDs), gotTask)
+					testWaitForTask(t, c.Index(tt.args.IndexUIDS), gotTask)
 				} else {
-					_, err := SetUpEmptyIndex(&IndexConfig{Uid: tt.args.IndexUIDs})
+					_, err := SetUpEmptyIndex(&IndexConfig{Uid: tt.args.IndexUIDS})
 					require.NoError(t, err, "CreateIndex() in TestGenerateTenantToken error should be nil")
 				}
 
@@ -1244,7 +1244,7 @@ func TestClient_GenerateTenantToken(t *testing.T) {
 					APIKey: token,
 				})
 
-				_, err = client.Index(tt.args.IndexUIDs).Search("", &SearchRequest{})
+				_, err = client.Index(tt.args.IndexUIDS).Search("", &SearchRequest{})
 
 				require.NoError(t, err)
 			}

--- a/client_test.go
+++ b/client_test.go
@@ -747,9 +747,51 @@ func TestClient_GetTasks(t *testing.T) {
 					{ID: "123", Name: "Pride and Prejudice"},
 				},
 				query: &TasksQuery{
-					Limit:    1,
-					From:     0,
-					IndexUID: []string{"indexUID"},
+					Limit:     1,
+					From:      0,
+					IndexUIDs: []string{"indexUID"},
+				},
+			},
+		},
+		{
+			name: "TestGetTasksWithUidFilter",
+			args: args{
+				UID:    "indexUID",
+				client: defaultClient,
+				document: []docTest{
+					{ID: "123", Name: "Pride and Prejudice"},
+				},
+				query: &TasksQuery{
+					Limit:     1,
+					UIDs: []string{"1"},
+				},
+			},
+		},
+		{
+			name: "TestGetTasksWithDateFilter",
+			args: args{
+				UID:    "indexUID",
+				client: defaultClient,
+				document: []docTest{
+					{ID: "123", Name: "Pride and Prejudice"},
+				},
+				query: &TasksQuery{
+					Limit:     1,
+					BeforeEnqueuedAt: time.Now(),
+				},
+			},
+		},
+		{
+			name: "TestGetTasksWithCanceledByFilter",
+			args: args{
+				UID:    "indexUID",
+				client: defaultClient,
+				document: []docTest{
+					{ID: "123", Name: "Pride and Prejudice"},
+				},
+				query: &TasksQuery{
+					Limit:     1,
+					CanceledBy: 1,
 				},
 			},
 		},
@@ -979,7 +1021,7 @@ func TestClient_ConnectionCloseByServer(t *testing.T) {
 
 func TestClient_GenerateTenantToken(t *testing.T) {
 	type args struct {
-		IndexUID    string
+		IndexUIDs   string
 		client      *Client
 		APIKeyUID   string
 		searchRules map[string]interface{}
@@ -995,7 +1037,7 @@ func TestClient_GenerateTenantToken(t *testing.T) {
 		{
 			name: "TestDefaultGenerateTenantToken",
 			args: args{
-				IndexUID:  "TestDefaultGenerateTenantToken",
+				IndexUIDs: "TestDefaultGenerateTenantToken",
 				client:    privateClient,
 				APIKeyUID: GetPrivateUIDKey(),
 				searchRules: map[string]interface{}{
@@ -1010,7 +1052,7 @@ func TestClient_GenerateTenantToken(t *testing.T) {
 		{
 			name: "TestGenerateTenantTokenWithApiKey",
 			args: args{
-				IndexUID:  "TestGenerateTenantTokenWithApiKey",
+				IndexUIDs: "TestGenerateTenantTokenWithApiKey",
 				client:    defaultClient,
 				APIKeyUID: GetPrivateUIDKey(),
 				searchRules: map[string]interface{}{
@@ -1027,7 +1069,7 @@ func TestClient_GenerateTenantToken(t *testing.T) {
 		{
 			name: "TestGenerateTenantTokenWithOnlyExpiresAt",
 			args: args{
-				IndexUID:  "TestGenerateTenantTokenWithOnlyExpiresAt",
+				IndexUIDs: "TestGenerateTenantTokenWithOnlyExpiresAt",
 				client:    privateClient,
 				APIKeyUID: GetPrivateUIDKey(),
 				searchRules: map[string]interface{}{
@@ -1044,7 +1086,7 @@ func TestClient_GenerateTenantToken(t *testing.T) {
 		{
 			name: "TestGenerateTenantTokenWithApiKeyAndExpiresAt",
 			args: args{
-				IndexUID:  "TestGenerateTenantTokenWithApiKeyAndExpiresAt",
+				IndexUIDs: "TestGenerateTenantTokenWithApiKeyAndExpiresAt",
 				client:    defaultClient,
 				APIKeyUID: GetPrivateUIDKey(),
 				searchRules: map[string]interface{}{
@@ -1062,7 +1104,7 @@ func TestClient_GenerateTenantToken(t *testing.T) {
 		{
 			name: "TestGenerateTenantTokenWithFilters",
 			args: args{
-				IndexUID:  "indexUID",
+				IndexUIDs: "indexUID",
 				client:    privateClient,
 				APIKeyUID: GetPrivateUIDKey(),
 				searchRules: map[string]interface{}{
@@ -1081,7 +1123,7 @@ func TestClient_GenerateTenantToken(t *testing.T) {
 		{
 			name: "TestGenerateTenantTokenWithFilterOnOneINdex",
 			args: args{
-				IndexUID:  "indexUID",
+				IndexUIDs: "indexUID",
 				client:    privateClient,
 				APIKeyUID: GetPrivateUIDKey(),
 				searchRules: map[string]interface{}{
@@ -1100,7 +1142,7 @@ func TestClient_GenerateTenantToken(t *testing.T) {
 		{
 			name: "TestGenerateTenantTokenWithoutSearchRules",
 			args: args{
-				IndexUID:    "TestGenerateTenantTokenWithoutSearchRules",
+				IndexUIDs:   "TestGenerateTenantTokenWithoutSearchRules",
 				client:      privateClient,
 				APIKeyUID:   GetPrivateUIDKey(),
 				searchRules: nil,
@@ -1113,7 +1155,7 @@ func TestClient_GenerateTenantToken(t *testing.T) {
 		{
 			name: "TestGenerateTenantTokenWithoutApiKey",
 			args: args{
-				IndexUID: "TestGenerateTenantTokenWithoutApiKey",
+				IndexUIDs: "TestGenerateTenantTokenWithoutApiKey",
 				client: NewClient(ClientConfig{
 					Host:   getenv("MEILISEARCH_URL", "http://localhost:7700"),
 					APIKey: "",
@@ -1131,7 +1173,7 @@ func TestClient_GenerateTenantToken(t *testing.T) {
 		{
 			name: "TestGenerateTenantTokenWithBadExpiresAt",
 			args: args{
-				IndexUID:  "TestGenerateTenantTokenWithBadExpiresAt",
+				IndexUIDs: "TestGenerateTenantTokenWithBadExpiresAt",
 				client:    defaultClient,
 				APIKeyUID: GetPrivateUIDKey(),
 				searchRules: map[string]interface{}{
@@ -1148,7 +1190,7 @@ func TestClient_GenerateTenantToken(t *testing.T) {
 		{
 			name: "TestGenerateTenantTokenWithBadAPIKeyUID",
 			args: args{
-				IndexUID:  "TestGenerateTenantTokenWithBadAPIKeyUID",
+				IndexUIDs: "TestGenerateTenantTokenWithBadAPIKeyUID",
 				client:    defaultClient,
 				APIKeyUID: GetPrivateUIDKey() + "1234",
 				searchRules: map[string]interface{}{
@@ -1163,7 +1205,7 @@ func TestClient_GenerateTenantToken(t *testing.T) {
 		{
 			name: "TestGenerateTenantTokenWithEmptyAPIKeyUID",
 			args: args{
-				IndexUID:  "TestGenerateTenantTokenWithEmptyAPIKeyUID",
+				IndexUIDs: "TestGenerateTenantTokenWithEmptyAPIKeyUID",
 				client:    defaultClient,
 				APIKeyUID: "",
 				searchRules: map[string]interface{}{
@@ -1189,11 +1231,11 @@ func TestClient_GenerateTenantToken(t *testing.T) {
 				require.NoError(t, err)
 
 				if tt.wantFilter {
-					gotTask, err := c.Index(tt.args.IndexUID).UpdateFilterableAttributes(&tt.args.filter)
+					gotTask, err := c.Index(tt.args.IndexUIDs).UpdateFilterableAttributes(&tt.args.filter)
 					require.NoError(t, err, "UpdateFilterableAttributes() in TestGenerateTenantToken error should be nil")
-					testWaitForTask(t, c.Index(tt.args.IndexUID), gotTask)
+					testWaitForTask(t, c.Index(tt.args.IndexUIDs), gotTask)
 				} else {
-					_, err := SetUpEmptyIndex(&IndexConfig{Uid: tt.args.IndexUID})
+					_, err := SetUpEmptyIndex(&IndexConfig{Uid: tt.args.IndexUIDs})
 					require.NoError(t, err, "CreateIndex() in TestGenerateTenantToken error should be nil")
 				}
 
@@ -1202,7 +1244,7 @@ func TestClient_GenerateTenantToken(t *testing.T) {
 					APIKey: token,
 				})
 
-				_, err = client.Index(tt.args.IndexUID).Search("", &SearchRequest{})
+				_, err = client.Index(tt.args.IndexUIDs).Search("", &SearchRequest{})
 
 				require.NoError(t, err)
 			}

--- a/client_test.go
+++ b/client_test.go
@@ -762,8 +762,8 @@ func TestClient_GetTasks(t *testing.T) {
 					{ID: "123", Name: "Pride and Prejudice"},
 				},
 				query: &TasksQuery{
-					Limit:     1,
-					UIDs: []string{"1"},
+					Limit: 1,
+					UIDs:  []int64{1},
 				},
 			},
 		},
@@ -776,7 +776,7 @@ func TestClient_GetTasks(t *testing.T) {
 					{ID: "123", Name: "Pride and Prejudice"},
 				},
 				query: &TasksQuery{
-					Limit:     1,
+					Limit:            1,
 					BeforeEnqueuedAt: time.Now(),
 				},
 			},
@@ -790,8 +790,8 @@ func TestClient_GetTasks(t *testing.T) {
 					{ID: "123", Name: "Pride and Prejudice"},
 				},
 				query: &TasksQuery{
-					Limit:     1,
-					CanceledBy: 1,
+					Limit:      1,
+					CanceledBy: []int64{1},
 				},
 			},
 		},

--- a/index.go
+++ b/index.go
@@ -189,9 +189,9 @@ func (i Index) GetTasks(param *TasksQuery) (resp *TaskResult, err error) {
 		if len(param.Types) != 0 {
 			req.withQueryParams["types"] = strings.Join(param.Types, ",")
 		}
-		if len(param.IndexUIDs) != 0 {
-			param.IndexUIDs = append(param.IndexUIDs, i.UID)
-			req.withQueryParams["indexUids"] = strings.Join(param.IndexUIDs, ",")
+		if len(param.IndexUIDS) != 0 {
+			param.IndexUIDS = append(param.IndexUIDS, i.UID)
+			req.withQueryParams["indexUids"] = strings.Join(param.IndexUIDS, ",")
 		} else {
 			req.withQueryParams["indexUids"] = i.UID
 		}

--- a/index.go
+++ b/index.go
@@ -183,17 +183,17 @@ func (i Index) GetTasks(param *TasksQuery) (resp *TaskResult, err error) {
 		if param.From != 0 {
 			req.withQueryParams["from"] = strconv.FormatInt(param.From, 10)
 		}
-		if len(param.Status) != 0 {
-			req.withQueryParams["status"] = strings.Join(param.Status, ",")
+		if len(param.Statuses) != 0 {
+			req.withQueryParams["statuses"] = strings.Join(param.Statuses, ",")
 		}
-		if len(param.Type) != 0 {
-			req.withQueryParams["type"] = strings.Join(param.Type, ",")
+		if len(param.Types) != 0 {
+			req.withQueryParams["types"] = strings.Join(param.Types, ",")
 		}
-		if len(param.IndexUID) != 0 {
-			param.IndexUID = append(param.IndexUID, i.UID)
-			req.withQueryParams["indexUid"] = strings.Join(param.IndexUID, ",")
+		if len(param.IndexUIDs) != 0 {
+			param.IndexUIDs = append(param.IndexUIDs, i.UID)
+			req.withQueryParams["indexUids"] = strings.Join(param.IndexUIDs, ",")
 		} else {
-			req.withQueryParams["indexUid"] = i.UID
+			req.withQueryParams["indexUids"] = i.UID
 		}
 	}
 	if err := i.client.executeRequest(req); err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -275,14 +275,14 @@ func TestMain(m *testing.M) {
 }
 
 func Test_deleteAllIndexes(t *testing.T) {
-	indexUIDs := []string{
+	indexUIDS := []string{
 		"Test_deleteAllIndexes",
 		"Test_deleteAllIndexes2",
 		"Test_deleteAllIndexes3",
 	}
 	_, _ = deleteAllIndexes(defaultClient)
 
-	for _, uid := range indexUIDs {
+	for _, uid := range indexUIDS {
 		task, err := defaultClient.CreateIndex(&IndexConfig{
 			Uid: uid,
 		})
@@ -297,7 +297,7 @@ func Test_deleteAllIndexes(t *testing.T) {
 
 	_, _ = deleteAllIndexes(defaultClient)
 
-	for _, uid := range indexUIDs {
+	for _, uid := range indexUIDS {
 		resp, err := defaultClient.GetIndex(uid)
 		if resp != nil {
 			t.Fatal(resp)

--- a/types.go
+++ b/types.go
@@ -130,31 +130,35 @@ type Task struct {
 	StartedAt  time.Time           `json:"startedAt,omitempty"`
 	FinishedAt time.Time           `json:"finishedAt,omitempty"`
 	Details    Details             `json:"details,omitempty"`
+	CanceledBy int64               `json:"canceledBy,omitempty"`
 }
 
 // TaskInfo indicates information regarding a task returned by an asynchronous method
 //
 // Documentation: https://docs.meilisearch.com/reference/api/tasks.html#tasks
 type TaskInfo struct {
-	Status     TaskStatus          `json:"status"`
-	TaskUID    int64               `json:"taskUid,omitempty"`
-	IndexUID   string              `json:"indexUid"`
-	Type       string              `json:"type"`
-	Error      meilisearchApiError `json:"error,omitempty"`
-	Duration   string              `json:"duration,omitempty"`
-	EnqueuedAt time.Time           `json:"enqueuedAt"`
-	StartedAt  time.Time           `json:"startedAt,omitempty"`
-	FinishedAt time.Time           `json:"finishedAt,omitempty"`
-	Details    Details             `json:"details,omitempty"`
+	Status     TaskStatus `json:"status"`
+	TaskUID    int64      `json:"taskUid,omitempty"`
+	IndexUID   string     `json:"indexUid"`
+	Type       string     `json:"type"`
+	EnqueuedAt time.Time  `json:"enqueuedAt"`
 }
 
 // TasksQuery is the request body for list documents method
 type TasksQuery struct {
-	Limit    int64    `json:"limit,omitempty"`
-	From     int64    `json:"from,omitempty"`
-	IndexUID []string `json:"indexUid,omitempty"`
-	Status   []string `json:"status,omitempty"`
-	Type     []string `json:"type,omitempty"`
+	UIDs             []string  `json:"uids,omitempty"`
+	Limit            int64     `json:"limit,omitempty"`
+	From             int64     `json:"from,omitempty"`
+	IndexUIDs        []string  `json:"indexUids,omitempty"`
+	Statuses         []string  `json:"statuses,omitempty"`
+	Types            []string  `json:"types,omitempty"`
+	CanceledBy       int64     `json:"canceledBy,omitempty"`
+	BeforeEnqueuedAt time.Time `json:"beforeEnqueuedAt,omitempty"`
+	AfterEnqueuedAt  time.Time `json:"afterEnqueuedAt,omitempty"`
+	BeforeStartedAt  time.Time `json:"beforeStartedAt,omitempty"`
+	AfterStartedAt   time.Time `json:"afterStartedAt,omitempty"`
+	BeforeFinishedAt time.Time `json:"beforeFinishedAt,omitempty"`
+	AfterFinishedAt  time.Time `json:"afterFinishedAt,omitempty"`
 }
 
 type Details struct {

--- a/types.go
+++ b/types.go
@@ -150,10 +150,10 @@ type TaskInfo struct {
 
 // TasksQuery is the request body for list documents method
 type TasksQuery struct {
-	UIDs             []int64
+	UIDS             []int64
 	Limit            int64
 	From             int64
-	IndexUIDs        []string
+	IndexUIDS        []string
 	Statuses         []string
 	Types            []string
 	CanceledBy       []int64

--- a/types.go
+++ b/types.go
@@ -35,8 +35,8 @@ type IndexesResults struct {
 }
 
 type IndexesQuery struct {
-	Limit  int64 `json:"limit,omitempty"`
-	Offset int64 `json:"offset,omitempty"`
+	Limit  int64
+	Offset int64
 }
 
 // Settings is the type that represents the settings in Meilisearch
@@ -130,35 +130,39 @@ type Task struct {
 	StartedAt  time.Time           `json:"startedAt,omitempty"`
 	FinishedAt time.Time           `json:"finishedAt,omitempty"`
 	Details    Details             `json:"details,omitempty"`
-	CanceledBy int64               `json:"canceledBy,omitempty"`
 }
 
 // TaskInfo indicates information regarding a task returned by an asynchronous method
 //
 // Documentation: https://docs.meilisearch.com/reference/api/tasks.html#tasks
 type TaskInfo struct {
-	Status     TaskStatus `json:"status"`
-	TaskUID    int64      `json:"taskUid,omitempty"`
-	IndexUID   string     `json:"indexUid"`
-	Type       string     `json:"type"`
-	EnqueuedAt time.Time  `json:"enqueuedAt"`
+	Status     TaskStatus          `json:"status"`
+	TaskUID    int64               `json:"taskUid,omitempty"`
+	IndexUID   string              `json:"indexUid"`
+	Type       string              `json:"type"`
+	Error      meilisearchApiError `json:"error,omitempty"`
+	Duration   string              `json:"duration,omitempty"`
+	EnqueuedAt time.Time           `json:"enqueuedAt"`
+	StartedAt  time.Time           `json:"startedAt,omitempty"`
+	FinishedAt time.Time           `json:"finishedAt,omitempty"`
+	Details    Details             `json:"details,omitempty"`
 }
 
 // TasksQuery is the request body for list documents method
 type TasksQuery struct {
-	UIDs             []string  `json:"uids,omitempty"`
-	Limit            int64     `json:"limit,omitempty"`
-	From             int64     `json:"from,omitempty"`
-	IndexUIDs        []string  `json:"indexUids,omitempty"`
-	Statuses         []string  `json:"statuses,omitempty"`
-	Types            []string  `json:"types,omitempty"`
-	CanceledBy       int64     `json:"canceledBy,omitempty"`
-	BeforeEnqueuedAt time.Time `json:"beforeEnqueuedAt,omitempty"`
-	AfterEnqueuedAt  time.Time `json:"afterEnqueuedAt,omitempty"`
-	BeforeStartedAt  time.Time `json:"beforeStartedAt,omitempty"`
-	AfterStartedAt   time.Time `json:"afterStartedAt,omitempty"`
-	BeforeFinishedAt time.Time `json:"beforeFinishedAt,omitempty"`
-	AfterFinishedAt  time.Time `json:"afterFinishedAt,omitempty"`
+	UIDs             []int64
+	Limit            int64
+	From             int64
+	IndexUIDs        []string
+	Statuses         []string
+	Types            []string
+	CanceledBy       []int64
+	BeforeEnqueuedAt time.Time
+	AfterEnqueuedAt  time.Time
+	BeforeStartedAt  time.Time
+	AfterStartedAt   time.Time
+	BeforeFinishedAt time.Time
+	AfterFinishedAt  time.Time
 }
 
 type Details struct {
@@ -168,9 +172,6 @@ type Details struct {
 	PrimaryKey           string              `json:"primaryKey,omitempty"`
 	RankingRules         []string            `json:"rankingRules,omitempty"`
 	DistinctAttribute    *string             `json:"distinctAttribute,omitempty"`
-	SearchableAttributes []string            `json:"searchableAttributes,omitempty"`
-	DisplayedAttributes  []string            `json:"displayedAttributes,omitempty"`
-	StopWords            []string            `json:"stopWords,omitempty"`
 	Synonyms             map[string][]string `json:"synonyms,omitempty"`
 	FilterableAttributes []string            `json:"filterableAttributes,omitempty"`
 	SortableAttributes   []string            `json:"sortableAttributes,omitempty"`
@@ -226,8 +227,8 @@ type KeysResults struct {
 }
 
 type KeysQuery struct {
-	Limit  int64 `json:"limit,omitempty"`
-	Offset int64 `json:"offset,omitempty"`
+	Limit  int64
+	Offset int64
 }
 
 // Information to create a tenant token

--- a/types_easyjson.go
+++ b/types_easyjson.go
@@ -587,7 +587,7 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo5(in *jlexer.Lexer, 
 			continue
 		}
 		switch key {
-		case "uids":
+		case "UIDs":
 			if in.IsNull() {
 				in.Skip()
 				out.UIDs = nil
@@ -595,26 +595,26 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo5(in *jlexer.Lexer, 
 				in.Delim('[')
 				if out.UIDs == nil {
 					if !in.IsDelim(']') {
-						out.UIDs = make([]string, 0, 4)
+						out.UIDs = make([]int64, 0, 8)
 					} else {
-						out.UIDs = []string{}
+						out.UIDs = []int64{}
 					}
 				} else {
 					out.UIDs = (out.UIDs)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v7 string
-					v7 = string(in.String())
+					var v7 int64
+					v7 = int64(in.Int64())
 					out.UIDs = append(out.UIDs, v7)
 					in.WantComma()
 				}
 				in.Delim(']')
 			}
-		case "limit":
+		case "Limit":
 			out.Limit = int64(in.Int64())
-		case "from":
+		case "From":
 			out.From = int64(in.Int64())
-		case "indexUids":
+		case "IndexUIDs":
 			if in.IsNull() {
 				in.Skip()
 				out.IndexUIDs = nil
@@ -637,7 +637,7 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo5(in *jlexer.Lexer, 
 				}
 				in.Delim(']')
 			}
-		case "statuses":
+		case "Statuses":
 			if in.IsNull() {
 				in.Skip()
 				out.Statuses = nil
@@ -660,7 +660,7 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo5(in *jlexer.Lexer, 
 				}
 				in.Delim(']')
 			}
-		case "types":
+		case "Types":
 			if in.IsNull() {
 				in.Skip()
 				out.Types = nil
@@ -683,29 +683,50 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo5(in *jlexer.Lexer, 
 				}
 				in.Delim(']')
 			}
-		case "canceledBy":
-			out.CanceledBy = int64(in.Int64())
-		case "beforeEnqueuedAt":
+		case "CanceledBy":
+			if in.IsNull() {
+				in.Skip()
+				out.CanceledBy = nil
+			} else {
+				in.Delim('[')
+				if out.CanceledBy == nil {
+					if !in.IsDelim(']') {
+						out.CanceledBy = make([]int64, 0, 8)
+					} else {
+						out.CanceledBy = []int64{}
+					}
+				} else {
+					out.CanceledBy = (out.CanceledBy)[:0]
+				}
+				for !in.IsDelim(']') {
+					var v11 int64
+					v11 = int64(in.Int64())
+					out.CanceledBy = append(out.CanceledBy, v11)
+					in.WantComma()
+				}
+				in.Delim(']')
+			}
+		case "BeforeEnqueuedAt":
 			if data := in.Raw(); in.Ok() {
 				in.AddError((out.BeforeEnqueuedAt).UnmarshalJSON(data))
 			}
-		case "afterEnqueuedAt":
+		case "AfterEnqueuedAt":
 			if data := in.Raw(); in.Ok() {
 				in.AddError((out.AfterEnqueuedAt).UnmarshalJSON(data))
 			}
-		case "beforeStartedAt":
+		case "BeforeStartedAt":
 			if data := in.Raw(); in.Ok() {
 				in.AddError((out.BeforeStartedAt).UnmarshalJSON(data))
 			}
-		case "afterStartedAt":
+		case "AfterStartedAt":
 			if data := in.Raw(); in.Ok() {
 				in.AddError((out.AfterStartedAt).UnmarshalJSON(data))
 			}
-		case "beforeFinishedAt":
+		case "BeforeFinishedAt":
 			if data := in.Raw(); in.Ok() {
 				in.AddError((out.BeforeFinishedAt).UnmarshalJSON(data))
 			}
-		case "afterFinishedAt":
+		case "AfterFinishedAt":
 			if data := in.Raw(); in.Ok() {
 				in.AddError((out.AfterFinishedAt).UnmarshalJSON(data))
 			}
@@ -723,166 +744,124 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo5(out *jwriter.Write
 	out.RawByte('{')
 	first := true
 	_ = first
-	if len(in.UIDs) != 0 {
-		const prefix string = ",\"uids\":"
-		first = false
+	{
+		const prefix string = ",\"UIDs\":"
 		out.RawString(prefix[1:])
-		{
+		if in.UIDs == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+			out.RawString("null")
+		} else {
 			out.RawByte('[')
-			for v11, v12 := range in.UIDs {
-				if v11 > 0 {
+			for v12, v13 := range in.UIDs {
+				if v12 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v12))
+				out.Int64(int64(v13))
 			}
 			out.RawByte(']')
 		}
 	}
-	if in.Limit != 0 {
-		const prefix string = ",\"limit\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
+	{
+		const prefix string = ",\"Limit\":"
+		out.RawString(prefix)
 		out.Int64(int64(in.Limit))
 	}
-	if in.From != 0 {
-		const prefix string = ",\"from\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
+	{
+		const prefix string = ",\"From\":"
+		out.RawString(prefix)
 		out.Int64(int64(in.From))
 	}
-	if len(in.IndexUIDs) != 0 {
-		const prefix string = ",\"indexUids\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
+	{
+		const prefix string = ",\"IndexUIDs\":"
+		out.RawString(prefix)
+		if in.IndexUIDs == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+			out.RawString("null")
 		} else {
-			out.RawString(prefix)
-		}
-		{
 			out.RawByte('[')
-			for v13, v14 := range in.IndexUIDs {
-				if v13 > 0 {
+			for v14, v15 := range in.IndexUIDs {
+				if v14 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v14))
+				out.String(string(v15))
 			}
 			out.RawByte(']')
 		}
 	}
-	if len(in.Statuses) != 0 {
-		const prefix string = ",\"statuses\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
+	{
+		const prefix string = ",\"Statuses\":"
+		out.RawString(prefix)
+		if in.Statuses == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+			out.RawString("null")
 		} else {
-			out.RawString(prefix)
-		}
-		{
 			out.RawByte('[')
-			for v15, v16 := range in.Statuses {
-				if v15 > 0 {
+			for v16, v17 := range in.Statuses {
+				if v16 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v16))
+				out.String(string(v17))
 			}
 			out.RawByte(']')
 		}
 	}
-	if len(in.Types) != 0 {
-		const prefix string = ",\"types\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
+	{
+		const prefix string = ",\"Types\":"
+		out.RawString(prefix)
+		if in.Types == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+			out.RawString("null")
 		} else {
-			out.RawString(prefix)
-		}
-		{
 			out.RawByte('[')
-			for v17, v18 := range in.Types {
-				if v17 > 0 {
+			for v18, v19 := range in.Types {
+				if v18 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v18))
+				out.String(string(v19))
 			}
 			out.RawByte(']')
 		}
 	}
-	if in.CanceledBy != 0 {
-		const prefix string = ",\"canceledBy\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
+	{
+		const prefix string = ",\"CanceledBy\":"
+		out.RawString(prefix)
+		if in.CanceledBy == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+			out.RawString("null")
 		} else {
-			out.RawString(prefix)
+			out.RawByte('[')
+			for v20, v21 := range in.CanceledBy {
+				if v20 > 0 {
+					out.RawByte(',')
+				}
+				out.Int64(int64(v21))
+			}
+			out.RawByte(']')
 		}
-		out.Int64(int64(in.CanceledBy))
 	}
-	if true {
-		const prefix string = ",\"beforeEnqueuedAt\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
+	{
+		const prefix string = ",\"BeforeEnqueuedAt\":"
+		out.RawString(prefix)
 		out.Raw((in.BeforeEnqueuedAt).MarshalJSON())
 	}
-	if true {
-		const prefix string = ",\"afterEnqueuedAt\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
+	{
+		const prefix string = ",\"AfterEnqueuedAt\":"
+		out.RawString(prefix)
 		out.Raw((in.AfterEnqueuedAt).MarshalJSON())
 	}
-	if true {
-		const prefix string = ",\"beforeStartedAt\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
+	{
+		const prefix string = ",\"BeforeStartedAt\":"
+		out.RawString(prefix)
 		out.Raw((in.BeforeStartedAt).MarshalJSON())
 	}
-	if true {
-		const prefix string = ",\"afterStartedAt\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
+	{
+		const prefix string = ",\"AfterStartedAt\":"
+		out.RawString(prefix)
 		out.Raw((in.AfterStartedAt).MarshalJSON())
 	}
-	if true {
-		const prefix string = ",\"beforeFinishedAt\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
+	{
+		const prefix string = ",\"BeforeFinishedAt\":"
+		out.RawString(prefix)
 		out.Raw((in.BeforeFinishedAt).MarshalJSON())
 	}
-	if true {
-		const prefix string = ",\"afterFinishedAt\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
+	{
+		const prefix string = ",\"AfterFinishedAt\":"
+		out.RawString(prefix)
 		out.Raw((in.AfterFinishedAt).MarshalJSON())
 	}
 	out.RawByte('}')
@@ -946,9 +925,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo6(in *jlexer.Lexer, 
 					out.Results = (out.Results)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v19 Task
-					(v19).UnmarshalEasyJSON(in)
-					out.Results = append(out.Results, v19)
+					var v22 Task
+					(v22).UnmarshalEasyJSON(in)
+					out.Results = append(out.Results, v22)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -980,11 +959,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo6(out *jwriter.Write
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v20, v21 := range in.Results {
-				if v20 > 0 {
+			for v23, v24 := range in.Results {
+				if v23 > 0 {
 					out.RawByte(',')
 				}
-				(v21).MarshalEasyJSON(out)
+				(v24).MarshalEasyJSON(out)
 			}
 			out.RawByte(']')
 		}
@@ -1057,10 +1036,24 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo7(in *jlexer.Lexer, 
 			out.IndexUID = string(in.String())
 		case "type":
 			out.Type = string(in.String())
+		case "error":
+			easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo8(in, &out.Error)
+		case "duration":
+			out.Duration = string(in.String())
 		case "enqueuedAt":
 			if data := in.Raw(); in.Ok() {
 				in.AddError((out.EnqueuedAt).UnmarshalJSON(data))
 			}
+		case "startedAt":
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.StartedAt).UnmarshalJSON(data))
+			}
+		case "finishedAt":
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.FinishedAt).UnmarshalJSON(data))
+			}
+		case "details":
+			(out.Details).UnmarshalEasyJSON(in)
 		default:
 			in.SkipRecursive()
 		}
@@ -1095,10 +1088,35 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo7(out *jwriter.Write
 		out.RawString(prefix)
 		out.String(string(in.Type))
 	}
+	if true {
+		const prefix string = ",\"error\":"
+		out.RawString(prefix)
+		easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo8(out, in.Error)
+	}
+	if in.Duration != "" {
+		const prefix string = ",\"duration\":"
+		out.RawString(prefix)
+		out.String(string(in.Duration))
+	}
 	{
 		const prefix string = ",\"enqueuedAt\":"
 		out.RawString(prefix)
 		out.Raw((in.EnqueuedAt).MarshalJSON())
+	}
+	if true {
+		const prefix string = ",\"startedAt\":"
+		out.RawString(prefix)
+		out.Raw((in.StartedAt).MarshalJSON())
+	}
+	if true {
+		const prefix string = ",\"finishedAt\":"
+		out.RawString(prefix)
+		out.Raw((in.FinishedAt).MarshalJSON())
+	}
+	if true {
+		const prefix string = ",\"details\":"
+		out.RawString(prefix)
+		(in.Details).MarshalEasyJSON(out)
 	}
 	out.RawByte('}')
 }
@@ -1126,156 +1144,7 @@ func (v *TaskInfo) UnmarshalJSON(data []byte) error {
 func (v *TaskInfo) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo7(l, v)
 }
-func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo8(in *jlexer.Lexer, out *Task) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "status":
-			out.Status = TaskStatus(in.String())
-		case "uid":
-			out.UID = int64(in.Int64())
-		case "taskUid":
-			out.TaskUID = int64(in.Int64())
-		case "indexUid":
-			out.IndexUID = string(in.String())
-		case "type":
-			out.Type = string(in.String())
-		case "error":
-			easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo9(in, &out.Error)
-		case "duration":
-			out.Duration = string(in.String())
-		case "enqueuedAt":
-			if data := in.Raw(); in.Ok() {
-				in.AddError((out.EnqueuedAt).UnmarshalJSON(data))
-			}
-		case "startedAt":
-			if data := in.Raw(); in.Ok() {
-				in.AddError((out.StartedAt).UnmarshalJSON(data))
-			}
-		case "finishedAt":
-			if data := in.Raw(); in.Ok() {
-				in.AddError((out.FinishedAt).UnmarshalJSON(data))
-			}
-		case "details":
-			(out.Details).UnmarshalEasyJSON(in)
-		case "canceledBy":
-			out.CanceledBy = int64(in.Int64())
-		default:
-			in.SkipRecursive()
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo8(out *jwriter.Writer, in Task) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	{
-		const prefix string = ",\"status\":"
-		out.RawString(prefix[1:])
-		out.String(string(in.Status))
-	}
-	if in.UID != 0 {
-		const prefix string = ",\"uid\":"
-		out.RawString(prefix)
-		out.Int64(int64(in.UID))
-	}
-	if in.TaskUID != 0 {
-		const prefix string = ",\"taskUid\":"
-		out.RawString(prefix)
-		out.Int64(int64(in.TaskUID))
-	}
-	{
-		const prefix string = ",\"indexUid\":"
-		out.RawString(prefix)
-		out.String(string(in.IndexUID))
-	}
-	{
-		const prefix string = ",\"type\":"
-		out.RawString(prefix)
-		out.String(string(in.Type))
-	}
-	if true {
-		const prefix string = ",\"error\":"
-		out.RawString(prefix)
-		easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo9(out, in.Error)
-	}
-	if in.Duration != "" {
-		const prefix string = ",\"duration\":"
-		out.RawString(prefix)
-		out.String(string(in.Duration))
-	}
-	{
-		const prefix string = ",\"enqueuedAt\":"
-		out.RawString(prefix)
-		out.Raw((in.EnqueuedAt).MarshalJSON())
-	}
-	if true {
-		const prefix string = ",\"startedAt\":"
-		out.RawString(prefix)
-		out.Raw((in.StartedAt).MarshalJSON())
-	}
-	if true {
-		const prefix string = ",\"finishedAt\":"
-		out.RawString(prefix)
-		out.Raw((in.FinishedAt).MarshalJSON())
-	}
-	if true {
-		const prefix string = ",\"details\":"
-		out.RawString(prefix)
-		(in.Details).MarshalEasyJSON(out)
-	}
-	if in.CanceledBy != 0 {
-		const prefix string = ",\"canceledBy\":"
-		out.RawString(prefix)
-		out.Int64(int64(in.CanceledBy))
-	}
-	out.RawByte('}')
-}
-
-// MarshalJSON supports json.Marshaler interface
-func (v Task) MarshalJSON() ([]byte, error) {
-	w := jwriter.Writer{}
-	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo8(&w, v)
-	return w.Buffer.BuildBytes(), w.Error
-}
-
-// MarshalEasyJSON supports easyjson.Marshaler interface
-func (v Task) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo8(w, v)
-}
-
-// UnmarshalJSON supports json.Unmarshaler interface
-func (v *Task) UnmarshalJSON(data []byte) error {
-	r := jlexer.Lexer{Data: data}
-	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo8(&r, v)
-	return r.Error()
-}
-
-// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *Task) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo8(l, v)
-}
-func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo9(in *jlexer.Lexer, out *meilisearchApiError) {
+func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo8(in *jlexer.Lexer, out *meilisearchApiError) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -1312,7 +1181,7 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo9(in *jlexer.Lexer, 
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo9(out *jwriter.Writer, in meilisearchApiError) {
+func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo8(out *jwriter.Writer, in meilisearchApiError) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1337,6 +1206,148 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo9(out *jwriter.Write
 		out.String(string(in.Link))
 	}
 	out.RawByte('}')
+}
+func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo9(in *jlexer.Lexer, out *Task) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "status":
+			out.Status = TaskStatus(in.String())
+		case "uid":
+			out.UID = int64(in.Int64())
+		case "taskUid":
+			out.TaskUID = int64(in.Int64())
+		case "indexUid":
+			out.IndexUID = string(in.String())
+		case "type":
+			out.Type = string(in.String())
+		case "error":
+			easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo8(in, &out.Error)
+		case "duration":
+			out.Duration = string(in.String())
+		case "enqueuedAt":
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.EnqueuedAt).UnmarshalJSON(data))
+			}
+		case "startedAt":
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.StartedAt).UnmarshalJSON(data))
+			}
+		case "finishedAt":
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.FinishedAt).UnmarshalJSON(data))
+			}
+		case "details":
+			(out.Details).UnmarshalEasyJSON(in)
+		default:
+			in.SkipRecursive()
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo9(out *jwriter.Writer, in Task) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	{
+		const prefix string = ",\"status\":"
+		out.RawString(prefix[1:])
+		out.String(string(in.Status))
+	}
+	if in.UID != 0 {
+		const prefix string = ",\"uid\":"
+		out.RawString(prefix)
+		out.Int64(int64(in.UID))
+	}
+	if in.TaskUID != 0 {
+		const prefix string = ",\"taskUid\":"
+		out.RawString(prefix)
+		out.Int64(int64(in.TaskUID))
+	}
+	{
+		const prefix string = ",\"indexUid\":"
+		out.RawString(prefix)
+		out.String(string(in.IndexUID))
+	}
+	{
+		const prefix string = ",\"type\":"
+		out.RawString(prefix)
+		out.String(string(in.Type))
+	}
+	if true {
+		const prefix string = ",\"error\":"
+		out.RawString(prefix)
+		easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo8(out, in.Error)
+	}
+	if in.Duration != "" {
+		const prefix string = ",\"duration\":"
+		out.RawString(prefix)
+		out.String(string(in.Duration))
+	}
+	{
+		const prefix string = ",\"enqueuedAt\":"
+		out.RawString(prefix)
+		out.Raw((in.EnqueuedAt).MarshalJSON())
+	}
+	if true {
+		const prefix string = ",\"startedAt\":"
+		out.RawString(prefix)
+		out.Raw((in.StartedAt).MarshalJSON())
+	}
+	if true {
+		const prefix string = ",\"finishedAt\":"
+		out.RawString(prefix)
+		out.Raw((in.FinishedAt).MarshalJSON())
+	}
+	if true {
+		const prefix string = ",\"details\":"
+		out.RawString(prefix)
+		(in.Details).MarshalEasyJSON(out)
+	}
+	out.RawByte('}')
+}
+
+// MarshalJSON supports json.Marshaler interface
+func (v Task) MarshalJSON() ([]byte, error) {
+	w := jwriter.Writer{}
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo9(&w, v)
+	return w.Buffer.BuildBytes(), w.Error
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v Task) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo9(w, v)
+}
+
+// UnmarshalJSON supports json.Unmarshaler interface
+func (v *Task) UnmarshalJSON(data []byte) error {
+	r := jlexer.Lexer{Data: data}
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo9(&r, v)
+	return r.Error()
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *Task) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo9(l, v)
 }
 func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo10(in *jlexer.Lexer, out *StatsIndex) {
 	isTopLevel := in.IsStart()
@@ -1370,9 +1381,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo10(in *jlexer.Lexer,
 				for !in.IsDelim('}') {
 					key := string(in.String())
 					in.WantColon()
-					var v22 int64
-					v22 = int64(in.Int64())
-					(out.FieldDistribution)[key] = v22
+					var v25 int64
+					v25 = int64(in.Int64())
+					(out.FieldDistribution)[key] = v25
 					in.WantComma()
 				}
 				in.Delim('}')
@@ -1408,16 +1419,16 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo10(out *jwriter.Writ
 			out.RawString(`null`)
 		} else {
 			out.RawByte('{')
-			v23First := true
-			for v23Name, v23Value := range in.FieldDistribution {
-				if v23First {
-					v23First = false
+			v26First := true
+			for v26Name, v26Value := range in.FieldDistribution {
+				if v26First {
+					v26First = false
 				} else {
 					out.RawByte(',')
 				}
-				out.String(string(v23Name))
+				out.String(string(v26Name))
 				out.RawByte(':')
-				out.Int64(int64(v23Value))
+				out.Int64(int64(v26Value))
 			}
 			out.RawByte('}')
 		}
@@ -1482,9 +1493,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo11(in *jlexer.Lexer,
 				for !in.IsDelim('}') {
 					key := string(in.String())
 					in.WantColon()
-					var v24 StatsIndex
-					(v24).UnmarshalEasyJSON(in)
-					(out.Indexes)[key] = v24
+					var v27 StatsIndex
+					(v27).UnmarshalEasyJSON(in)
+					(out.Indexes)[key] = v27
 					in.WantComma()
 				}
 				in.Delim('}')
@@ -1520,16 +1531,16 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo11(out *jwriter.Writ
 			out.RawString(`null`)
 		} else {
 			out.RawByte('{')
-			v25First := true
-			for v25Name, v25Value := range in.Indexes {
-				if v25First {
-					v25First = false
+			v28First := true
+			for v28Name, v28Value := range in.Indexes {
+				if v28First {
+					v28First = false
 				} else {
 					out.RawByte(',')
 				}
-				out.String(string(v25Name))
+				out.String(string(v28Name))
 				out.RawByte(':')
-				(v25Value).MarshalEasyJSON(out)
+				(v28Value).MarshalEasyJSON(out)
 			}
 			out.RawByte('}')
 		}
@@ -1595,9 +1606,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo12(in *jlexer.Lexer,
 					out.RankingRules = (out.RankingRules)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v26 string
-					v26 = string(in.String())
-					out.RankingRules = append(out.RankingRules, v26)
+					var v29 string
+					v29 = string(in.String())
+					out.RankingRules = append(out.RankingRules, v29)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1628,9 +1639,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo12(in *jlexer.Lexer,
 					out.SearchableAttributes = (out.SearchableAttributes)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v27 string
-					v27 = string(in.String())
-					out.SearchableAttributes = append(out.SearchableAttributes, v27)
+					var v30 string
+					v30 = string(in.String())
+					out.SearchableAttributes = append(out.SearchableAttributes, v30)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1651,9 +1662,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo12(in *jlexer.Lexer,
 					out.DisplayedAttributes = (out.DisplayedAttributes)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v28 string
-					v28 = string(in.String())
-					out.DisplayedAttributes = append(out.DisplayedAttributes, v28)
+					var v31 string
+					v31 = string(in.String())
+					out.DisplayedAttributes = append(out.DisplayedAttributes, v31)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1674,9 +1685,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo12(in *jlexer.Lexer,
 					out.StopWords = (out.StopWords)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v29 string
-					v29 = string(in.String())
-					out.StopWords = append(out.StopWords, v29)
+					var v32 string
+					v32 = string(in.String())
+					out.StopWords = append(out.StopWords, v32)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1694,30 +1705,30 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo12(in *jlexer.Lexer,
 				for !in.IsDelim('}') {
 					key := string(in.String())
 					in.WantColon()
-					var v30 []string
+					var v33 []string
 					if in.IsNull() {
 						in.Skip()
-						v30 = nil
+						v33 = nil
 					} else {
 						in.Delim('[')
-						if v30 == nil {
+						if v33 == nil {
 							if !in.IsDelim(']') {
-								v30 = make([]string, 0, 4)
+								v33 = make([]string, 0, 4)
 							} else {
-								v30 = []string{}
+								v33 = []string{}
 							}
 						} else {
-							v30 = (v30)[:0]
+							v33 = (v33)[:0]
 						}
 						for !in.IsDelim(']') {
-							var v31 string
-							v31 = string(in.String())
-							v30 = append(v30, v31)
+							var v34 string
+							v34 = string(in.String())
+							v33 = append(v33, v34)
 							in.WantComma()
 						}
 						in.Delim(']')
 					}
-					(out.Synonyms)[key] = v30
+					(out.Synonyms)[key] = v33
 					in.WantComma()
 				}
 				in.Delim('}')
@@ -1738,9 +1749,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo12(in *jlexer.Lexer,
 					out.FilterableAttributes = (out.FilterableAttributes)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v32 string
-					v32 = string(in.String())
-					out.FilterableAttributes = append(out.FilterableAttributes, v32)
+					var v35 string
+					v35 = string(in.String())
+					out.FilterableAttributes = append(out.FilterableAttributes, v35)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1761,9 +1772,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo12(in *jlexer.Lexer,
 					out.SortableAttributes = (out.SortableAttributes)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v33 string
-					v33 = string(in.String())
-					out.SortableAttributes = append(out.SortableAttributes, v33)
+					var v36 string
+					v36 = string(in.String())
+					out.SortableAttributes = append(out.SortableAttributes, v36)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1818,11 +1829,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo12(out *jwriter.Writ
 		out.RawString(prefix[1:])
 		{
 			out.RawByte('[')
-			for v34, v35 := range in.RankingRules {
-				if v34 > 0 {
+			for v37, v38 := range in.RankingRules {
+				if v37 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v35))
+				out.String(string(v38))
 			}
 			out.RawByte(']')
 		}
@@ -1847,11 +1858,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo12(out *jwriter.Writ
 		}
 		{
 			out.RawByte('[')
-			for v36, v37 := range in.SearchableAttributes {
-				if v36 > 0 {
+			for v39, v40 := range in.SearchableAttributes {
+				if v39 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v37))
+				out.String(string(v40))
 			}
 			out.RawByte(']')
 		}
@@ -1866,11 +1877,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo12(out *jwriter.Writ
 		}
 		{
 			out.RawByte('[')
-			for v38, v39 := range in.DisplayedAttributes {
-				if v38 > 0 {
+			for v41, v42 := range in.DisplayedAttributes {
+				if v41 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v39))
+				out.String(string(v42))
 			}
 			out.RawByte(']')
 		}
@@ -1885,11 +1896,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo12(out *jwriter.Writ
 		}
 		{
 			out.RawByte('[')
-			for v40, v41 := range in.StopWords {
-				if v40 > 0 {
+			for v43, v44 := range in.StopWords {
+				if v43 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v41))
+				out.String(string(v44))
 			}
 			out.RawByte(']')
 		}
@@ -1904,24 +1915,24 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo12(out *jwriter.Writ
 		}
 		{
 			out.RawByte('{')
-			v42First := true
-			for v42Name, v42Value := range in.Synonyms {
-				if v42First {
-					v42First = false
+			v45First := true
+			for v45Name, v45Value := range in.Synonyms {
+				if v45First {
+					v45First = false
 				} else {
 					out.RawByte(',')
 				}
-				out.String(string(v42Name))
+				out.String(string(v45Name))
 				out.RawByte(':')
-				if v42Value == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+				if v45Value == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
 					out.RawString("null")
 				} else {
 					out.RawByte('[')
-					for v43, v44 := range v42Value {
-						if v43 > 0 {
+					for v46, v47 := range v45Value {
+						if v46 > 0 {
 							out.RawByte(',')
 						}
-						out.String(string(v44))
+						out.String(string(v47))
 					}
 					out.RawByte(']')
 				}
@@ -1939,11 +1950,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo12(out *jwriter.Writ
 		}
 		{
 			out.RawByte('[')
-			for v45, v46 := range in.FilterableAttributes {
-				if v45 > 0 {
+			for v48, v49 := range in.FilterableAttributes {
+				if v48 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v46))
+				out.String(string(v49))
 			}
 			out.RawByte(']')
 		}
@@ -1958,11 +1969,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo12(out *jwriter.Writ
 		}
 		{
 			out.RawByte('[')
-			for v47, v48 := range in.SortableAttributes {
-				if v47 > 0 {
+			for v50, v51 := range in.SortableAttributes {
+				if v50 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v48))
+				out.String(string(v51))
 			}
 			out.RawByte(']')
 		}
@@ -2058,15 +2069,15 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo13(in *jlexer.Lexer,
 					out.Hits = (out.Hits)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v49 interface{}
-					if m, ok := v49.(easyjson.Unmarshaler); ok {
+					var v52 interface{}
+					if m, ok := v52.(easyjson.Unmarshaler); ok {
 						m.UnmarshalEasyJSON(in)
-					} else if m, ok := v49.(json.Unmarshaler); ok {
+					} else if m, ok := v52.(json.Unmarshaler); ok {
 						_ = m.UnmarshalJSON(in.Raw())
 					} else {
-						v49 = in.Interface()
+						v52 = in.Interface()
 					}
-					out.Hits = append(out.Hits, v49)
+					out.Hits = append(out.Hits, v52)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -2110,16 +2121,16 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo13(out *jwriter.Writ
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v50, v51 := range in.Hits {
-				if v50 > 0 {
+			for v53, v54 := range in.Hits {
+				if v53 > 0 {
 					out.RawByte(',')
 				}
-				if m, ok := v51.(easyjson.Marshaler); ok {
+				if m, ok := v54.(easyjson.Marshaler); ok {
 					m.MarshalEasyJSON(out)
-				} else if m, ok := v51.(json.Marshaler); ok {
+				} else if m, ok := v54.(json.Marshaler); ok {
 					out.Raw(m.MarshalJSON())
 				} else {
-					out.Raw(json.Marshal(v51))
+					out.Raw(json.Marshal(v54))
 				}
 			}
 			out.RawByte(']')
@@ -2226,9 +2237,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo14(in *jlexer.Lexer,
 					out.AttributesToRetrieve = (out.AttributesToRetrieve)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v52 string
-					v52 = string(in.String())
-					out.AttributesToRetrieve = append(out.AttributesToRetrieve, v52)
+					var v55 string
+					v55 = string(in.String())
+					out.AttributesToRetrieve = append(out.AttributesToRetrieve, v55)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -2249,9 +2260,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo14(in *jlexer.Lexer,
 					out.AttributesToCrop = (out.AttributesToCrop)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v53 string
-					v53 = string(in.String())
-					out.AttributesToCrop = append(out.AttributesToCrop, v53)
+					var v56 string
+					v56 = string(in.String())
+					out.AttributesToCrop = append(out.AttributesToCrop, v56)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -2276,9 +2287,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo14(in *jlexer.Lexer,
 					out.AttributesToHighlight = (out.AttributesToHighlight)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v54 string
-					v54 = string(in.String())
-					out.AttributesToHighlight = append(out.AttributesToHighlight, v54)
+					var v57 string
+					v57 = string(in.String())
+					out.AttributesToHighlight = append(out.AttributesToHighlight, v57)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -2315,9 +2326,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo14(in *jlexer.Lexer,
 					out.Facets = (out.Facets)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v55 string
-					v55 = string(in.String())
-					out.Facets = append(out.Facets, v55)
+					var v58 string
+					v58 = string(in.String())
+					out.Facets = append(out.Facets, v58)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -2340,9 +2351,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo14(in *jlexer.Lexer,
 					out.Sort = (out.Sort)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v56 string
-					v56 = string(in.String())
-					out.Sort = append(out.Sort, v56)
+					var v59 string
+					v59 = string(in.String())
+					out.Sort = append(out.Sort, v59)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -2378,11 +2389,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo14(out *jwriter.Writ
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v57, v58 := range in.AttributesToRetrieve {
-				if v57 > 0 {
+			for v60, v61 := range in.AttributesToRetrieve {
+				if v60 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v58))
+				out.String(string(v61))
 			}
 			out.RawByte(']')
 		}
@@ -2394,11 +2405,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo14(out *jwriter.Writ
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v59, v60 := range in.AttributesToCrop {
-				if v59 > 0 {
+			for v62, v63 := range in.AttributesToCrop {
+				if v62 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v60))
+				out.String(string(v63))
 			}
 			out.RawByte(']')
 		}
@@ -2420,11 +2431,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo14(out *jwriter.Writ
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v61, v62 := range in.AttributesToHighlight {
-				if v61 > 0 {
+			for v64, v65 := range in.AttributesToHighlight {
+				if v64 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v62))
+				out.String(string(v65))
 			}
 			out.RawByte(']')
 		}
@@ -2467,11 +2478,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo14(out *jwriter.Writ
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v63, v64 := range in.Facets {
-				if v63 > 0 {
+			for v66, v67 := range in.Facets {
+				if v66 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v64))
+				out.String(string(v67))
 			}
 			out.RawByte(']')
 		}
@@ -2488,11 +2499,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo14(out *jwriter.Writ
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v65, v66 := range in.Sort {
-				if v65 > 0 {
+			for v68, v69 := range in.Sort {
+				if v68 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v66))
+				out.String(string(v69))
 			}
 			out.RawByte(']')
 		}
@@ -2703,9 +2714,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo17(in *jlexer.Lexer,
 					out.Results = (out.Results)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v67 Key
-					(v67).UnmarshalEasyJSON(in)
-					out.Results = append(out.Results, v67)
+					var v70 Key
+					(v70).UnmarshalEasyJSON(in)
+					out.Results = append(out.Results, v70)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -2737,11 +2748,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo17(out *jwriter.Writ
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v68, v69 := range in.Results {
-				if v68 > 0 {
+			for v71, v72 := range in.Results {
+				if v71 > 0 {
 					out.RawByte(',')
 				}
-				(v69).MarshalEasyJSON(out)
+				(v72).MarshalEasyJSON(out)
 			}
 			out.RawByte(']')
 		}
@@ -2806,9 +2817,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo18(in *jlexer.Lexer,
 			continue
 		}
 		switch key {
-		case "limit":
+		case "Limit":
 			out.Limit = int64(in.Int64())
-		case "offset":
+		case "Offset":
 			out.Offset = int64(in.Int64())
 		default:
 			in.SkipRecursive()
@@ -2824,20 +2835,14 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo18(out *jwriter.Writ
 	out.RawByte('{')
 	first := true
 	_ = first
-	if in.Limit != 0 {
-		const prefix string = ",\"limit\":"
-		first = false
+	{
+		const prefix string = ",\"Limit\":"
 		out.RawString(prefix[1:])
 		out.Int64(int64(in.Limit))
 	}
-	if in.Offset != 0 {
-		const prefix string = ",\"offset\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
+	{
+		const prefix string = ",\"Offset\":"
+		out.RawString(prefix)
 		out.Int64(int64(in.Offset))
 	}
 	out.RawByte('}')
@@ -2986,9 +2991,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo20(in *jlexer.Lexer,
 					out.Actions = (out.Actions)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v70 string
-					v70 = string(in.String())
-					out.Actions = append(out.Actions, v70)
+					var v73 string
+					v73 = string(in.String())
+					out.Actions = append(out.Actions, v73)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -3009,9 +3014,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo20(in *jlexer.Lexer,
 					out.Indexes = (out.Indexes)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v71 string
-					v71 = string(in.String())
-					out.Indexes = append(out.Indexes, v71)
+					var v74 string
+					v74 = string(in.String())
+					out.Indexes = append(out.Indexes, v74)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -3068,11 +3073,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo20(out *jwriter.Writ
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v72, v73 := range in.Actions {
-				if v72 > 0 {
+			for v75, v76 := range in.Actions {
+				if v75 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v73))
+				out.String(string(v76))
 			}
 			out.RawByte(']')
 		}
@@ -3082,11 +3087,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo20(out *jwriter.Writ
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v74, v75 := range in.Indexes {
-				if v74 > 0 {
+			for v77, v78 := range in.Indexes {
+				if v77 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v75))
+				out.String(string(v78))
 			}
 			out.RawByte(']')
 		}
@@ -3179,9 +3184,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo21(in *jlexer.Lexer,
 					out.Actions = (out.Actions)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v76 string
-					v76 = string(in.String())
-					out.Actions = append(out.Actions, v76)
+					var v79 string
+					v79 = string(in.String())
+					out.Actions = append(out.Actions, v79)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -3202,9 +3207,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo21(in *jlexer.Lexer,
 					out.Indexes = (out.Indexes)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v77 string
-					v77 = string(in.String())
-					out.Indexes = append(out.Indexes, v77)
+					var v80 string
+					v80 = string(in.String())
+					out.Indexes = append(out.Indexes, v80)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -3260,11 +3265,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo21(out *jwriter.Writ
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v78, v79 := range in.Actions {
-				if v78 > 0 {
+			for v81, v82 := range in.Actions {
+				if v81 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v79))
+				out.String(string(v82))
 			}
 			out.RawByte(']')
 		}
@@ -3274,11 +3279,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo21(out *jwriter.Writ
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v80, v81 := range in.Indexes {
-				if v80 > 0 {
+			for v83, v84 := range in.Indexes {
+				if v83 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v81))
+				out.String(string(v84))
 			}
 			out.RawByte(']')
 		}
@@ -3359,9 +3364,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo22(in *jlexer.Lexer,
 					out.Results = (out.Results)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v82 Index
-					(v82).UnmarshalEasyJSON(in)
-					out.Results = append(out.Results, v82)
+					var v85 Index
+					(v85).UnmarshalEasyJSON(in)
+					out.Results = append(out.Results, v85)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -3393,11 +3398,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo22(out *jwriter.Writ
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v83, v84 := range in.Results {
-				if v83 > 0 {
+			for v86, v87 := range in.Results {
+				if v86 > 0 {
 					out.RawByte(',')
 				}
-				(v84).MarshalEasyJSON(out)
+				(v87).MarshalEasyJSON(out)
 			}
 			out.RawByte(']')
 		}
@@ -3462,9 +3467,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo23(in *jlexer.Lexer,
 			continue
 		}
 		switch key {
-		case "limit":
+		case "Limit":
 			out.Limit = int64(in.Int64())
-		case "offset":
+		case "Offset":
 			out.Offset = int64(in.Int64())
 		default:
 			in.SkipRecursive()
@@ -3480,20 +3485,14 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo23(out *jwriter.Writ
 	out.RawByte('{')
 	first := true
 	_ = first
-	if in.Limit != 0 {
-		const prefix string = ",\"limit\":"
-		first = false
+	{
+		const prefix string = ",\"Limit\":"
 		out.RawString(prefix[1:])
 		out.Int64(int64(in.Limit))
 	}
-	if in.Offset != 0 {
-		const prefix string = ",\"offset\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
+	{
+		const prefix string = ",\"Offset\":"
+		out.RawString(prefix)
 		out.Int64(int64(in.Offset))
 	}
 	out.RawByte('}')
@@ -3780,29 +3779,29 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo27(in *jlexer.Lexer,
 					out.Results = (out.Results)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v85 map[string]interface{}
+					var v88 map[string]interface{}
 					if in.IsNull() {
 						in.Skip()
 					} else {
 						in.Delim('{')
-						v85 = make(map[string]interface{})
+						v88 = make(map[string]interface{})
 						for !in.IsDelim('}') {
 							key := string(in.String())
 							in.WantColon()
-							var v86 interface{}
-							if m, ok := v86.(easyjson.Unmarshaler); ok {
+							var v89 interface{}
+							if m, ok := v89.(easyjson.Unmarshaler); ok {
 								m.UnmarshalEasyJSON(in)
-							} else if m, ok := v86.(json.Unmarshaler); ok {
+							} else if m, ok := v89.(json.Unmarshaler); ok {
 								_ = m.UnmarshalJSON(in.Raw())
 							} else {
-								v86 = in.Interface()
+								v89 = in.Interface()
 							}
-							(v85)[key] = v86
+							(v88)[key] = v89
 							in.WantComma()
 						}
 						in.Delim('}')
 					}
-					out.Results = append(out.Results, v85)
+					out.Results = append(out.Results, v88)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -3834,29 +3833,29 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo27(out *jwriter.Writ
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v87, v88 := range in.Results {
-				if v87 > 0 {
+			for v90, v91 := range in.Results {
+				if v90 > 0 {
 					out.RawByte(',')
 				}
-				if v88 == nil && (out.Flags&jwriter.NilMapAsEmpty) == 0 {
+				if v91 == nil && (out.Flags&jwriter.NilMapAsEmpty) == 0 {
 					out.RawString(`null`)
 				} else {
 					out.RawByte('{')
-					v89First := true
-					for v89Name, v89Value := range v88 {
-						if v89First {
-							v89First = false
+					v92First := true
+					for v92Name, v92Value := range v91 {
+						if v92First {
+							v92First = false
 						} else {
 							out.RawByte(',')
 						}
-						out.String(string(v89Name))
+						out.String(string(v92Name))
 						out.RawByte(':')
-						if m, ok := v89Value.(easyjson.Marshaler); ok {
+						if m, ok := v92Value.(easyjson.Marshaler); ok {
 							m.MarshalEasyJSON(out)
-						} else if m, ok := v89Value.(json.Marshaler); ok {
+						} else if m, ok := v92Value.(json.Marshaler); ok {
 							out.Raw(m.MarshalJSON())
 						} else {
-							out.Raw(json.Marshal(v89Value))
+							out.Raw(json.Marshal(v92Value))
 						}
 					}
 					out.RawByte('}')
@@ -3945,9 +3944,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo28(in *jlexer.Lexer,
 					out.Fields = (out.Fields)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v90 string
-					v90 = string(in.String())
-					out.Fields = append(out.Fields, v90)
+					var v93 string
+					v93 = string(in.String())
+					out.Fields = append(out.Fields, v93)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -3992,11 +3991,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo28(out *jwriter.Writ
 		}
 		{
 			out.RawByte('[')
-			for v91, v92 := range in.Fields {
-				if v91 > 0 {
+			for v94, v95 := range in.Fields {
+				if v94 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v92))
+				out.String(string(v95))
 			}
 			out.RawByte(']')
 		}
@@ -4062,9 +4061,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo29(in *jlexer.Lexer,
 					out.Fields = (out.Fields)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v93 string
-					v93 = string(in.String())
-					out.Fields = append(out.Fields, v93)
+					var v96 string
+					v96 = string(in.String())
+					out.Fields = append(out.Fields, v96)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -4089,11 +4088,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo29(out *jwriter.Writ
 		out.RawString(prefix[1:])
 		{
 			out.RawByte('[')
-			for v94, v95 := range in.Fields {
-				if v94 > 0 {
+			for v97, v98 := range in.Fields {
+				if v97 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v95))
+				out.String(string(v98))
 			}
 			out.RawByte(']')
 		}
@@ -4167,9 +4166,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo30(in *jlexer.Lexer,
 					out.RankingRules = (out.RankingRules)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v96 string
-					v96 = string(in.String())
-					out.RankingRules = append(out.RankingRules, v96)
+					var v99 string
+					v99 = string(in.String())
+					out.RankingRules = append(out.RankingRules, v99)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -4183,75 +4182,6 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo30(in *jlexer.Lexer,
 					out.DistinctAttribute = new(string)
 				}
 				*out.DistinctAttribute = string(in.String())
-			}
-		case "searchableAttributes":
-			if in.IsNull() {
-				in.Skip()
-				out.SearchableAttributes = nil
-			} else {
-				in.Delim('[')
-				if out.SearchableAttributes == nil {
-					if !in.IsDelim(']') {
-						out.SearchableAttributes = make([]string, 0, 4)
-					} else {
-						out.SearchableAttributes = []string{}
-					}
-				} else {
-					out.SearchableAttributes = (out.SearchableAttributes)[:0]
-				}
-				for !in.IsDelim(']') {
-					var v97 string
-					v97 = string(in.String())
-					out.SearchableAttributes = append(out.SearchableAttributes, v97)
-					in.WantComma()
-				}
-				in.Delim(']')
-			}
-		case "displayedAttributes":
-			if in.IsNull() {
-				in.Skip()
-				out.DisplayedAttributes = nil
-			} else {
-				in.Delim('[')
-				if out.DisplayedAttributes == nil {
-					if !in.IsDelim(']') {
-						out.DisplayedAttributes = make([]string, 0, 4)
-					} else {
-						out.DisplayedAttributes = []string{}
-					}
-				} else {
-					out.DisplayedAttributes = (out.DisplayedAttributes)[:0]
-				}
-				for !in.IsDelim(']') {
-					var v98 string
-					v98 = string(in.String())
-					out.DisplayedAttributes = append(out.DisplayedAttributes, v98)
-					in.WantComma()
-				}
-				in.Delim(']')
-			}
-		case "stopWords":
-			if in.IsNull() {
-				in.Skip()
-				out.StopWords = nil
-			} else {
-				in.Delim('[')
-				if out.StopWords == nil {
-					if !in.IsDelim(']') {
-						out.StopWords = make([]string, 0, 4)
-					} else {
-						out.StopWords = []string{}
-					}
-				} else {
-					out.StopWords = (out.StopWords)[:0]
-				}
-				for !in.IsDelim(']') {
-					var v99 string
-					v99 = string(in.String())
-					out.StopWords = append(out.StopWords, v99)
-					in.WantComma()
-				}
-				in.Delim(']')
 			}
 		case "synonyms":
 			if in.IsNull() {
@@ -4419,63 +4349,6 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo30(out *jwriter.Writ
 		}
 		out.String(string(*in.DistinctAttribute))
 	}
-	if len(in.SearchableAttributes) != 0 {
-		const prefix string = ",\"searchableAttributes\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		{
-			out.RawByte('[')
-			for v106, v107 := range in.SearchableAttributes {
-				if v106 > 0 {
-					out.RawByte(',')
-				}
-				out.String(string(v107))
-			}
-			out.RawByte(']')
-		}
-	}
-	if len(in.DisplayedAttributes) != 0 {
-		const prefix string = ",\"displayedAttributes\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		{
-			out.RawByte('[')
-			for v108, v109 := range in.DisplayedAttributes {
-				if v108 > 0 {
-					out.RawByte(',')
-				}
-				out.String(string(v109))
-			}
-			out.RawByte(']')
-		}
-	}
-	if len(in.StopWords) != 0 {
-		const prefix string = ",\"stopWords\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		{
-			out.RawByte('[')
-			for v110, v111 := range in.StopWords {
-				if v110 > 0 {
-					out.RawByte(',')
-				}
-				out.String(string(v111))
-			}
-			out.RawByte(']')
-		}
-	}
 	if len(in.Synonyms) != 0 {
 		const prefix string = ",\"synonyms\":"
 		if first {
@@ -4486,24 +4359,24 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo30(out *jwriter.Writ
 		}
 		{
 			out.RawByte('{')
-			v112First := true
-			for v112Name, v112Value := range in.Synonyms {
-				if v112First {
-					v112First = false
+			v106First := true
+			for v106Name, v106Value := range in.Synonyms {
+				if v106First {
+					v106First = false
 				} else {
 					out.RawByte(',')
 				}
-				out.String(string(v112Name))
+				out.String(string(v106Name))
 				out.RawByte(':')
-				if v112Value == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+				if v106Value == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
 					out.RawString("null")
 				} else {
 					out.RawByte('[')
-					for v113, v114 := range v112Value {
-						if v113 > 0 {
+					for v107, v108 := range v106Value {
+						if v107 > 0 {
 							out.RawByte(',')
 						}
-						out.String(string(v114))
+						out.String(string(v108))
 					}
 					out.RawByte(']')
 				}
@@ -4521,11 +4394,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo30(out *jwriter.Writ
 		}
 		{
 			out.RawByte('[')
-			for v115, v116 := range in.FilterableAttributes {
-				if v115 > 0 {
+			for v109, v110 := range in.FilterableAttributes {
+				if v109 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v116))
+				out.String(string(v110))
 			}
 			out.RawByte(']')
 		}
@@ -4540,11 +4413,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo30(out *jwriter.Writ
 		}
 		{
 			out.RawByte('[')
-			for v117, v118 := range in.SortableAttributes {
-				if v117 > 0 {
+			for v111, v112 := range in.SortableAttributes {
+				if v111 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v118))
+				out.String(string(v112))
 			}
 			out.RawByte(']')
 		}

--- a/types_easyjson.go
+++ b/types_easyjson.go
@@ -587,25 +587,25 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo5(in *jlexer.Lexer, 
 			continue
 		}
 		switch key {
-		case "UIDs":
+		case "UIDS":
 			if in.IsNull() {
 				in.Skip()
-				out.UIDs = nil
+				out.UIDS = nil
 			} else {
 				in.Delim('[')
-				if out.UIDs == nil {
+				if out.UIDS == nil {
 					if !in.IsDelim(']') {
-						out.UIDs = make([]int64, 0, 8)
+						out.UIDS = make([]int64, 0, 8)
 					} else {
-						out.UIDs = []int64{}
+						out.UIDS = []int64{}
 					}
 				} else {
-					out.UIDs = (out.UIDs)[:0]
+					out.UIDS = (out.UIDS)[:0]
 				}
 				for !in.IsDelim(']') {
 					var v7 int64
 					v7 = int64(in.Int64())
-					out.UIDs = append(out.UIDs, v7)
+					out.UIDS = append(out.UIDS, v7)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -614,25 +614,25 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo5(in *jlexer.Lexer, 
 			out.Limit = int64(in.Int64())
 		case "From":
 			out.From = int64(in.Int64())
-		case "IndexUIDs":
+		case "IndexUIDS":
 			if in.IsNull() {
 				in.Skip()
-				out.IndexUIDs = nil
+				out.IndexUIDS = nil
 			} else {
 				in.Delim('[')
-				if out.IndexUIDs == nil {
+				if out.IndexUIDS == nil {
 					if !in.IsDelim(']') {
-						out.IndexUIDs = make([]string, 0, 4)
+						out.IndexUIDS = make([]string, 0, 4)
 					} else {
-						out.IndexUIDs = []string{}
+						out.IndexUIDS = []string{}
 					}
 				} else {
-					out.IndexUIDs = (out.IndexUIDs)[:0]
+					out.IndexUIDS = (out.IndexUIDS)[:0]
 				}
 				for !in.IsDelim(']') {
 					var v8 string
 					v8 = string(in.String())
-					out.IndexUIDs = append(out.IndexUIDs, v8)
+					out.IndexUIDS = append(out.IndexUIDS, v8)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -745,13 +745,13 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo5(out *jwriter.Write
 	first := true
 	_ = first
 	{
-		const prefix string = ",\"UIDs\":"
+		const prefix string = ",\"UIDS\":"
 		out.RawString(prefix[1:])
-		if in.UIDs == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+		if in.UIDS == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v12, v13 := range in.UIDs {
+			for v12, v13 := range in.UIDS {
 				if v12 > 0 {
 					out.RawByte(',')
 				}
@@ -771,13 +771,13 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo5(out *jwriter.Write
 		out.Int64(int64(in.From))
 	}
 	{
-		const prefix string = ",\"IndexUIDs\":"
+		const prefix string = ",\"IndexUIDS\":"
 		out.RawString(prefix)
-		if in.IndexUIDs == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+		if in.IndexUIDS == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v14, v15 := range in.IndexUIDs {
+			for v14, v15 := range in.IndexUIDS {
 				if v14 > 0 {
 					out.RawByte(',')
 				}

--- a/types_easyjson.go
+++ b/types_easyjson.go
@@ -587,78 +587,127 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo5(in *jlexer.Lexer, 
 			continue
 		}
 		switch key {
-		case "limit":
-			out.Limit = int64(in.Int64())
-		case "from":
-			out.From = int64(in.Int64())
-		case "indexUid":
+		case "uids":
 			if in.IsNull() {
 				in.Skip()
-				out.IndexUID = nil
+				out.UIDs = nil
 			} else {
 				in.Delim('[')
-				if out.IndexUID == nil {
+				if out.UIDs == nil {
 					if !in.IsDelim(']') {
-						out.IndexUID = make([]string, 0, 4)
+						out.UIDs = make([]string, 0, 4)
 					} else {
-						out.IndexUID = []string{}
+						out.UIDs = []string{}
 					}
 				} else {
-					out.IndexUID = (out.IndexUID)[:0]
+					out.UIDs = (out.UIDs)[:0]
 				}
 				for !in.IsDelim(']') {
 					var v7 string
 					v7 = string(in.String())
-					out.IndexUID = append(out.IndexUID, v7)
+					out.UIDs = append(out.UIDs, v7)
 					in.WantComma()
 				}
 				in.Delim(']')
 			}
-		case "status":
+		case "limit":
+			out.Limit = int64(in.Int64())
+		case "from":
+			out.From = int64(in.Int64())
+		case "indexUids":
 			if in.IsNull() {
 				in.Skip()
-				out.Status = nil
+				out.IndexUIDs = nil
 			} else {
 				in.Delim('[')
-				if out.Status == nil {
+				if out.IndexUIDs == nil {
 					if !in.IsDelim(']') {
-						out.Status = make([]string, 0, 4)
+						out.IndexUIDs = make([]string, 0, 4)
 					} else {
-						out.Status = []string{}
+						out.IndexUIDs = []string{}
 					}
 				} else {
-					out.Status = (out.Status)[:0]
+					out.IndexUIDs = (out.IndexUIDs)[:0]
 				}
 				for !in.IsDelim(']') {
 					var v8 string
 					v8 = string(in.String())
-					out.Status = append(out.Status, v8)
+					out.IndexUIDs = append(out.IndexUIDs, v8)
 					in.WantComma()
 				}
 				in.Delim(']')
 			}
-		case "type":
+		case "statuses":
 			if in.IsNull() {
 				in.Skip()
-				out.Type = nil
+				out.Statuses = nil
 			} else {
 				in.Delim('[')
-				if out.Type == nil {
+				if out.Statuses == nil {
 					if !in.IsDelim(']') {
-						out.Type = make([]string, 0, 4)
+						out.Statuses = make([]string, 0, 4)
 					} else {
-						out.Type = []string{}
+						out.Statuses = []string{}
 					}
 				} else {
-					out.Type = (out.Type)[:0]
+					out.Statuses = (out.Statuses)[:0]
 				}
 				for !in.IsDelim(']') {
 					var v9 string
 					v9 = string(in.String())
-					out.Type = append(out.Type, v9)
+					out.Statuses = append(out.Statuses, v9)
 					in.WantComma()
 				}
 				in.Delim(']')
+			}
+		case "types":
+			if in.IsNull() {
+				in.Skip()
+				out.Types = nil
+			} else {
+				in.Delim('[')
+				if out.Types == nil {
+					if !in.IsDelim(']') {
+						out.Types = make([]string, 0, 4)
+					} else {
+						out.Types = []string{}
+					}
+				} else {
+					out.Types = (out.Types)[:0]
+				}
+				for !in.IsDelim(']') {
+					var v10 string
+					v10 = string(in.String())
+					out.Types = append(out.Types, v10)
+					in.WantComma()
+				}
+				in.Delim(']')
+			}
+		case "canceledBy":
+			out.CanceledBy = int64(in.Int64())
+		case "beforeEnqueuedAt":
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.BeforeEnqueuedAt).UnmarshalJSON(data))
+			}
+		case "afterEnqueuedAt":
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.AfterEnqueuedAt).UnmarshalJSON(data))
+			}
+		case "beforeStartedAt":
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.BeforeStartedAt).UnmarshalJSON(data))
+			}
+		case "afterStartedAt":
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.AfterStartedAt).UnmarshalJSON(data))
+			}
+		case "beforeFinishedAt":
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.BeforeFinishedAt).UnmarshalJSON(data))
+			}
+		case "afterFinishedAt":
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.AfterFinishedAt).UnmarshalJSON(data))
 			}
 		default:
 			in.SkipRecursive()
@@ -674,10 +723,29 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo5(out *jwriter.Write
 	out.RawByte('{')
 	first := true
 	_ = first
-	if in.Limit != 0 {
-		const prefix string = ",\"limit\":"
+	if len(in.UIDs) != 0 {
+		const prefix string = ",\"uids\":"
 		first = false
 		out.RawString(prefix[1:])
+		{
+			out.RawByte('[')
+			for v11, v12 := range in.UIDs {
+				if v11 > 0 {
+					out.RawByte(',')
+				}
+				out.String(string(v12))
+			}
+			out.RawByte(']')
+		}
+	}
+	if in.Limit != 0 {
+		const prefix string = ",\"limit\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
 		out.Int64(int64(in.Limit))
 	}
 	if in.From != 0 {
@@ -690,8 +758,8 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo5(out *jwriter.Write
 		}
 		out.Int64(int64(in.From))
 	}
-	if len(in.IndexUID) != 0 {
-		const prefix string = ",\"indexUid\":"
+	if len(in.IndexUIDs) != 0 {
+		const prefix string = ",\"indexUids\":"
 		if first {
 			first = false
 			out.RawString(prefix[1:])
@@ -700,17 +768,17 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo5(out *jwriter.Write
 		}
 		{
 			out.RawByte('[')
-			for v10, v11 := range in.IndexUID {
-				if v10 > 0 {
+			for v13, v14 := range in.IndexUIDs {
+				if v13 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v11))
+				out.String(string(v14))
 			}
 			out.RawByte(']')
 		}
 	}
-	if len(in.Status) != 0 {
-		const prefix string = ",\"status\":"
+	if len(in.Statuses) != 0 {
+		const prefix string = ",\"statuses\":"
 		if first {
 			first = false
 			out.RawString(prefix[1:])
@@ -719,17 +787,17 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo5(out *jwriter.Write
 		}
 		{
 			out.RawByte('[')
-			for v12, v13 := range in.Status {
-				if v12 > 0 {
+			for v15, v16 := range in.Statuses {
+				if v15 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v13))
+				out.String(string(v16))
 			}
 			out.RawByte(']')
 		}
 	}
-	if len(in.Type) != 0 {
-		const prefix string = ",\"type\":"
+	if len(in.Types) != 0 {
+		const prefix string = ",\"types\":"
 		if first {
 			first = false
 			out.RawString(prefix[1:])
@@ -738,14 +806,84 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo5(out *jwriter.Write
 		}
 		{
 			out.RawByte('[')
-			for v14, v15 := range in.Type {
-				if v14 > 0 {
+			for v17, v18 := range in.Types {
+				if v17 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v15))
+				out.String(string(v18))
 			}
 			out.RawByte(']')
 		}
+	}
+	if in.CanceledBy != 0 {
+		const prefix string = ",\"canceledBy\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.Int64(int64(in.CanceledBy))
+	}
+	if true {
+		const prefix string = ",\"beforeEnqueuedAt\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.Raw((in.BeforeEnqueuedAt).MarshalJSON())
+	}
+	if true {
+		const prefix string = ",\"afterEnqueuedAt\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.Raw((in.AfterEnqueuedAt).MarshalJSON())
+	}
+	if true {
+		const prefix string = ",\"beforeStartedAt\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.Raw((in.BeforeStartedAt).MarshalJSON())
+	}
+	if true {
+		const prefix string = ",\"afterStartedAt\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.Raw((in.AfterStartedAt).MarshalJSON())
+	}
+	if true {
+		const prefix string = ",\"beforeFinishedAt\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.Raw((in.BeforeFinishedAt).MarshalJSON())
+	}
+	if true {
+		const prefix string = ",\"afterFinishedAt\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.Raw((in.AfterFinishedAt).MarshalJSON())
 	}
 	out.RawByte('}')
 }
@@ -808,9 +946,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo6(in *jlexer.Lexer, 
 					out.Results = (out.Results)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v16 Task
-					(v16).UnmarshalEasyJSON(in)
-					out.Results = append(out.Results, v16)
+					var v19 Task
+					(v19).UnmarshalEasyJSON(in)
+					out.Results = append(out.Results, v19)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -842,11 +980,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo6(out *jwriter.Write
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v17, v18 := range in.Results {
-				if v17 > 0 {
+			for v20, v21 := range in.Results {
+				if v20 > 0 {
 					out.RawByte(',')
 				}
-				(v18).MarshalEasyJSON(out)
+				(v21).MarshalEasyJSON(out)
 			}
 			out.RawByte(']')
 		}
@@ -919,24 +1057,10 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo7(in *jlexer.Lexer, 
 			out.IndexUID = string(in.String())
 		case "type":
 			out.Type = string(in.String())
-		case "error":
-			easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo8(in, &out.Error)
-		case "duration":
-			out.Duration = string(in.String())
 		case "enqueuedAt":
 			if data := in.Raw(); in.Ok() {
 				in.AddError((out.EnqueuedAt).UnmarshalJSON(data))
 			}
-		case "startedAt":
-			if data := in.Raw(); in.Ok() {
-				in.AddError((out.StartedAt).UnmarshalJSON(data))
-			}
-		case "finishedAt":
-			if data := in.Raw(); in.Ok() {
-				in.AddError((out.FinishedAt).UnmarshalJSON(data))
-			}
-		case "details":
-			(out.Details).UnmarshalEasyJSON(in)
 		default:
 			in.SkipRecursive()
 		}
@@ -971,35 +1095,10 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo7(out *jwriter.Write
 		out.RawString(prefix)
 		out.String(string(in.Type))
 	}
-	if true {
-		const prefix string = ",\"error\":"
-		out.RawString(prefix)
-		easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo8(out, in.Error)
-	}
-	if in.Duration != "" {
-		const prefix string = ",\"duration\":"
-		out.RawString(prefix)
-		out.String(string(in.Duration))
-	}
 	{
 		const prefix string = ",\"enqueuedAt\":"
 		out.RawString(prefix)
 		out.Raw((in.EnqueuedAt).MarshalJSON())
-	}
-	if true {
-		const prefix string = ",\"startedAt\":"
-		out.RawString(prefix)
-		out.Raw((in.StartedAt).MarshalJSON())
-	}
-	if true {
-		const prefix string = ",\"finishedAt\":"
-		out.RawString(prefix)
-		out.Raw((in.FinishedAt).MarshalJSON())
-	}
-	if true {
-		const prefix string = ",\"details\":"
-		out.RawString(prefix)
-		(in.Details).MarshalEasyJSON(out)
 	}
 	out.RawByte('}')
 }
@@ -1027,7 +1126,156 @@ func (v *TaskInfo) UnmarshalJSON(data []byte) error {
 func (v *TaskInfo) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo7(l, v)
 }
-func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo8(in *jlexer.Lexer, out *meilisearchApiError) {
+func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo8(in *jlexer.Lexer, out *Task) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "status":
+			out.Status = TaskStatus(in.String())
+		case "uid":
+			out.UID = int64(in.Int64())
+		case "taskUid":
+			out.TaskUID = int64(in.Int64())
+		case "indexUid":
+			out.IndexUID = string(in.String())
+		case "type":
+			out.Type = string(in.String())
+		case "error":
+			easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo9(in, &out.Error)
+		case "duration":
+			out.Duration = string(in.String())
+		case "enqueuedAt":
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.EnqueuedAt).UnmarshalJSON(data))
+			}
+		case "startedAt":
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.StartedAt).UnmarshalJSON(data))
+			}
+		case "finishedAt":
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.FinishedAt).UnmarshalJSON(data))
+			}
+		case "details":
+			(out.Details).UnmarshalEasyJSON(in)
+		case "canceledBy":
+			out.CanceledBy = int64(in.Int64())
+		default:
+			in.SkipRecursive()
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo8(out *jwriter.Writer, in Task) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	{
+		const prefix string = ",\"status\":"
+		out.RawString(prefix[1:])
+		out.String(string(in.Status))
+	}
+	if in.UID != 0 {
+		const prefix string = ",\"uid\":"
+		out.RawString(prefix)
+		out.Int64(int64(in.UID))
+	}
+	if in.TaskUID != 0 {
+		const prefix string = ",\"taskUid\":"
+		out.RawString(prefix)
+		out.Int64(int64(in.TaskUID))
+	}
+	{
+		const prefix string = ",\"indexUid\":"
+		out.RawString(prefix)
+		out.String(string(in.IndexUID))
+	}
+	{
+		const prefix string = ",\"type\":"
+		out.RawString(prefix)
+		out.String(string(in.Type))
+	}
+	if true {
+		const prefix string = ",\"error\":"
+		out.RawString(prefix)
+		easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo9(out, in.Error)
+	}
+	if in.Duration != "" {
+		const prefix string = ",\"duration\":"
+		out.RawString(prefix)
+		out.String(string(in.Duration))
+	}
+	{
+		const prefix string = ",\"enqueuedAt\":"
+		out.RawString(prefix)
+		out.Raw((in.EnqueuedAt).MarshalJSON())
+	}
+	if true {
+		const prefix string = ",\"startedAt\":"
+		out.RawString(prefix)
+		out.Raw((in.StartedAt).MarshalJSON())
+	}
+	if true {
+		const prefix string = ",\"finishedAt\":"
+		out.RawString(prefix)
+		out.Raw((in.FinishedAt).MarshalJSON())
+	}
+	if true {
+		const prefix string = ",\"details\":"
+		out.RawString(prefix)
+		(in.Details).MarshalEasyJSON(out)
+	}
+	if in.CanceledBy != 0 {
+		const prefix string = ",\"canceledBy\":"
+		out.RawString(prefix)
+		out.Int64(int64(in.CanceledBy))
+	}
+	out.RawByte('}')
+}
+
+// MarshalJSON supports json.Marshaler interface
+func (v Task) MarshalJSON() ([]byte, error) {
+	w := jwriter.Writer{}
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo8(&w, v)
+	return w.Buffer.BuildBytes(), w.Error
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v Task) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo8(w, v)
+}
+
+// UnmarshalJSON supports json.Unmarshaler interface
+func (v *Task) UnmarshalJSON(data []byte) error {
+	r := jlexer.Lexer{Data: data}
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo8(&r, v)
+	return r.Error()
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *Task) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo8(l, v)
+}
+func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo9(in *jlexer.Lexer, out *meilisearchApiError) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -1064,7 +1312,7 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo8(in *jlexer.Lexer, 
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo8(out *jwriter.Writer, in meilisearchApiError) {
+func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo9(out *jwriter.Writer, in meilisearchApiError) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1089,148 +1337,6 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo8(out *jwriter.Write
 		out.String(string(in.Link))
 	}
 	out.RawByte('}')
-}
-func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo9(in *jlexer.Lexer, out *Task) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "status":
-			out.Status = TaskStatus(in.String())
-		case "uid":
-			out.UID = int64(in.Int64())
-		case "taskUid":
-			out.TaskUID = int64(in.Int64())
-		case "indexUid":
-			out.IndexUID = string(in.String())
-		case "type":
-			out.Type = string(in.String())
-		case "error":
-			easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo8(in, &out.Error)
-		case "duration":
-			out.Duration = string(in.String())
-		case "enqueuedAt":
-			if data := in.Raw(); in.Ok() {
-				in.AddError((out.EnqueuedAt).UnmarshalJSON(data))
-			}
-		case "startedAt":
-			if data := in.Raw(); in.Ok() {
-				in.AddError((out.StartedAt).UnmarshalJSON(data))
-			}
-		case "finishedAt":
-			if data := in.Raw(); in.Ok() {
-				in.AddError((out.FinishedAt).UnmarshalJSON(data))
-			}
-		case "details":
-			(out.Details).UnmarshalEasyJSON(in)
-		default:
-			in.SkipRecursive()
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo9(out *jwriter.Writer, in Task) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	{
-		const prefix string = ",\"status\":"
-		out.RawString(prefix[1:])
-		out.String(string(in.Status))
-	}
-	if in.UID != 0 {
-		const prefix string = ",\"uid\":"
-		out.RawString(prefix)
-		out.Int64(int64(in.UID))
-	}
-	if in.TaskUID != 0 {
-		const prefix string = ",\"taskUid\":"
-		out.RawString(prefix)
-		out.Int64(int64(in.TaskUID))
-	}
-	{
-		const prefix string = ",\"indexUid\":"
-		out.RawString(prefix)
-		out.String(string(in.IndexUID))
-	}
-	{
-		const prefix string = ",\"type\":"
-		out.RawString(prefix)
-		out.String(string(in.Type))
-	}
-	if true {
-		const prefix string = ",\"error\":"
-		out.RawString(prefix)
-		easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo8(out, in.Error)
-	}
-	if in.Duration != "" {
-		const prefix string = ",\"duration\":"
-		out.RawString(prefix)
-		out.String(string(in.Duration))
-	}
-	{
-		const prefix string = ",\"enqueuedAt\":"
-		out.RawString(prefix)
-		out.Raw((in.EnqueuedAt).MarshalJSON())
-	}
-	if true {
-		const prefix string = ",\"startedAt\":"
-		out.RawString(prefix)
-		out.Raw((in.StartedAt).MarshalJSON())
-	}
-	if true {
-		const prefix string = ",\"finishedAt\":"
-		out.RawString(prefix)
-		out.Raw((in.FinishedAt).MarshalJSON())
-	}
-	if true {
-		const prefix string = ",\"details\":"
-		out.RawString(prefix)
-		(in.Details).MarshalEasyJSON(out)
-	}
-	out.RawByte('}')
-}
-
-// MarshalJSON supports json.Marshaler interface
-func (v Task) MarshalJSON() ([]byte, error) {
-	w := jwriter.Writer{}
-	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo9(&w, v)
-	return w.Buffer.BuildBytes(), w.Error
-}
-
-// MarshalEasyJSON supports easyjson.Marshaler interface
-func (v Task) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo9(w, v)
-}
-
-// UnmarshalJSON supports json.Unmarshaler interface
-func (v *Task) UnmarshalJSON(data []byte) error {
-	r := jlexer.Lexer{Data: data}
-	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo9(&r, v)
-	return r.Error()
-}
-
-// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *Task) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo9(l, v)
 }
 func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo10(in *jlexer.Lexer, out *StatsIndex) {
 	isTopLevel := in.IsStart()
@@ -1264,9 +1370,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo10(in *jlexer.Lexer,
 				for !in.IsDelim('}') {
 					key := string(in.String())
 					in.WantColon()
-					var v19 int64
-					v19 = int64(in.Int64())
-					(out.FieldDistribution)[key] = v19
+					var v22 int64
+					v22 = int64(in.Int64())
+					(out.FieldDistribution)[key] = v22
 					in.WantComma()
 				}
 				in.Delim('}')
@@ -1302,16 +1408,16 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo10(out *jwriter.Writ
 			out.RawString(`null`)
 		} else {
 			out.RawByte('{')
-			v20First := true
-			for v20Name, v20Value := range in.FieldDistribution {
-				if v20First {
-					v20First = false
+			v23First := true
+			for v23Name, v23Value := range in.FieldDistribution {
+				if v23First {
+					v23First = false
 				} else {
 					out.RawByte(',')
 				}
-				out.String(string(v20Name))
+				out.String(string(v23Name))
 				out.RawByte(':')
-				out.Int64(int64(v20Value))
+				out.Int64(int64(v23Value))
 			}
 			out.RawByte('}')
 		}
@@ -1376,9 +1482,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo11(in *jlexer.Lexer,
 				for !in.IsDelim('}') {
 					key := string(in.String())
 					in.WantColon()
-					var v21 StatsIndex
-					(v21).UnmarshalEasyJSON(in)
-					(out.Indexes)[key] = v21
+					var v24 StatsIndex
+					(v24).UnmarshalEasyJSON(in)
+					(out.Indexes)[key] = v24
 					in.WantComma()
 				}
 				in.Delim('}')
@@ -1414,16 +1520,16 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo11(out *jwriter.Writ
 			out.RawString(`null`)
 		} else {
 			out.RawByte('{')
-			v22First := true
-			for v22Name, v22Value := range in.Indexes {
-				if v22First {
-					v22First = false
+			v25First := true
+			for v25Name, v25Value := range in.Indexes {
+				if v25First {
+					v25First = false
 				} else {
 					out.RawByte(',')
 				}
-				out.String(string(v22Name))
+				out.String(string(v25Name))
 				out.RawByte(':')
-				(v22Value).MarshalEasyJSON(out)
+				(v25Value).MarshalEasyJSON(out)
 			}
 			out.RawByte('}')
 		}
@@ -1489,9 +1595,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo12(in *jlexer.Lexer,
 					out.RankingRules = (out.RankingRules)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v23 string
-					v23 = string(in.String())
-					out.RankingRules = append(out.RankingRules, v23)
+					var v26 string
+					v26 = string(in.String())
+					out.RankingRules = append(out.RankingRules, v26)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1522,9 +1628,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo12(in *jlexer.Lexer,
 					out.SearchableAttributes = (out.SearchableAttributes)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v24 string
-					v24 = string(in.String())
-					out.SearchableAttributes = append(out.SearchableAttributes, v24)
+					var v27 string
+					v27 = string(in.String())
+					out.SearchableAttributes = append(out.SearchableAttributes, v27)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1545,9 +1651,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo12(in *jlexer.Lexer,
 					out.DisplayedAttributes = (out.DisplayedAttributes)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v25 string
-					v25 = string(in.String())
-					out.DisplayedAttributes = append(out.DisplayedAttributes, v25)
+					var v28 string
+					v28 = string(in.String())
+					out.DisplayedAttributes = append(out.DisplayedAttributes, v28)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1568,9 +1674,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo12(in *jlexer.Lexer,
 					out.StopWords = (out.StopWords)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v26 string
-					v26 = string(in.String())
-					out.StopWords = append(out.StopWords, v26)
+					var v29 string
+					v29 = string(in.String())
+					out.StopWords = append(out.StopWords, v29)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1588,30 +1694,30 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo12(in *jlexer.Lexer,
 				for !in.IsDelim('}') {
 					key := string(in.String())
 					in.WantColon()
-					var v27 []string
+					var v30 []string
 					if in.IsNull() {
 						in.Skip()
-						v27 = nil
+						v30 = nil
 					} else {
 						in.Delim('[')
-						if v27 == nil {
+						if v30 == nil {
 							if !in.IsDelim(']') {
-								v27 = make([]string, 0, 4)
+								v30 = make([]string, 0, 4)
 							} else {
-								v27 = []string{}
+								v30 = []string{}
 							}
 						} else {
-							v27 = (v27)[:0]
+							v30 = (v30)[:0]
 						}
 						for !in.IsDelim(']') {
-							var v28 string
-							v28 = string(in.String())
-							v27 = append(v27, v28)
+							var v31 string
+							v31 = string(in.String())
+							v30 = append(v30, v31)
 							in.WantComma()
 						}
 						in.Delim(']')
 					}
-					(out.Synonyms)[key] = v27
+					(out.Synonyms)[key] = v30
 					in.WantComma()
 				}
 				in.Delim('}')
@@ -1632,9 +1738,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo12(in *jlexer.Lexer,
 					out.FilterableAttributes = (out.FilterableAttributes)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v29 string
-					v29 = string(in.String())
-					out.FilterableAttributes = append(out.FilterableAttributes, v29)
+					var v32 string
+					v32 = string(in.String())
+					out.FilterableAttributes = append(out.FilterableAttributes, v32)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1655,9 +1761,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo12(in *jlexer.Lexer,
 					out.SortableAttributes = (out.SortableAttributes)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v30 string
-					v30 = string(in.String())
-					out.SortableAttributes = append(out.SortableAttributes, v30)
+					var v33 string
+					v33 = string(in.String())
+					out.SortableAttributes = append(out.SortableAttributes, v33)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1712,11 +1818,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo12(out *jwriter.Writ
 		out.RawString(prefix[1:])
 		{
 			out.RawByte('[')
-			for v31, v32 := range in.RankingRules {
-				if v31 > 0 {
+			for v34, v35 := range in.RankingRules {
+				if v34 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v32))
+				out.String(string(v35))
 			}
 			out.RawByte(']')
 		}
@@ -1741,11 +1847,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo12(out *jwriter.Writ
 		}
 		{
 			out.RawByte('[')
-			for v33, v34 := range in.SearchableAttributes {
-				if v33 > 0 {
+			for v36, v37 := range in.SearchableAttributes {
+				if v36 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v34))
+				out.String(string(v37))
 			}
 			out.RawByte(']')
 		}
@@ -1760,11 +1866,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo12(out *jwriter.Writ
 		}
 		{
 			out.RawByte('[')
-			for v35, v36 := range in.DisplayedAttributes {
-				if v35 > 0 {
+			for v38, v39 := range in.DisplayedAttributes {
+				if v38 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v36))
+				out.String(string(v39))
 			}
 			out.RawByte(']')
 		}
@@ -1779,11 +1885,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo12(out *jwriter.Writ
 		}
 		{
 			out.RawByte('[')
-			for v37, v38 := range in.StopWords {
-				if v37 > 0 {
+			for v40, v41 := range in.StopWords {
+				if v40 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v38))
+				out.String(string(v41))
 			}
 			out.RawByte(']')
 		}
@@ -1798,24 +1904,24 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo12(out *jwriter.Writ
 		}
 		{
 			out.RawByte('{')
-			v39First := true
-			for v39Name, v39Value := range in.Synonyms {
-				if v39First {
-					v39First = false
+			v42First := true
+			for v42Name, v42Value := range in.Synonyms {
+				if v42First {
+					v42First = false
 				} else {
 					out.RawByte(',')
 				}
-				out.String(string(v39Name))
+				out.String(string(v42Name))
 				out.RawByte(':')
-				if v39Value == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+				if v42Value == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
 					out.RawString("null")
 				} else {
 					out.RawByte('[')
-					for v40, v41 := range v39Value {
-						if v40 > 0 {
+					for v43, v44 := range v42Value {
+						if v43 > 0 {
 							out.RawByte(',')
 						}
-						out.String(string(v41))
+						out.String(string(v44))
 					}
 					out.RawByte(']')
 				}
@@ -1833,11 +1939,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo12(out *jwriter.Writ
 		}
 		{
 			out.RawByte('[')
-			for v42, v43 := range in.FilterableAttributes {
-				if v42 > 0 {
+			for v45, v46 := range in.FilterableAttributes {
+				if v45 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v43))
+				out.String(string(v46))
 			}
 			out.RawByte(']')
 		}
@@ -1852,11 +1958,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo12(out *jwriter.Writ
 		}
 		{
 			out.RawByte('[')
-			for v44, v45 := range in.SortableAttributes {
-				if v44 > 0 {
+			for v47, v48 := range in.SortableAttributes {
+				if v47 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v45))
+				out.String(string(v48))
 			}
 			out.RawByte(']')
 		}
@@ -1952,15 +2058,15 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo13(in *jlexer.Lexer,
 					out.Hits = (out.Hits)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v46 interface{}
-					if m, ok := v46.(easyjson.Unmarshaler); ok {
+					var v49 interface{}
+					if m, ok := v49.(easyjson.Unmarshaler); ok {
 						m.UnmarshalEasyJSON(in)
-					} else if m, ok := v46.(json.Unmarshaler); ok {
+					} else if m, ok := v49.(json.Unmarshaler); ok {
 						_ = m.UnmarshalJSON(in.Raw())
 					} else {
-						v46 = in.Interface()
+						v49 = in.Interface()
 					}
-					out.Hits = append(out.Hits, v46)
+					out.Hits = append(out.Hits, v49)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -2004,16 +2110,16 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo13(out *jwriter.Writ
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v47, v48 := range in.Hits {
-				if v47 > 0 {
+			for v50, v51 := range in.Hits {
+				if v50 > 0 {
 					out.RawByte(',')
 				}
-				if m, ok := v48.(easyjson.Marshaler); ok {
+				if m, ok := v51.(easyjson.Marshaler); ok {
 					m.MarshalEasyJSON(out)
-				} else if m, ok := v48.(json.Marshaler); ok {
+				} else if m, ok := v51.(json.Marshaler); ok {
 					out.Raw(m.MarshalJSON())
 				} else {
-					out.Raw(json.Marshal(v48))
+					out.Raw(json.Marshal(v51))
 				}
 			}
 			out.RawByte(']')
@@ -2120,9 +2226,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo14(in *jlexer.Lexer,
 					out.AttributesToRetrieve = (out.AttributesToRetrieve)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v49 string
-					v49 = string(in.String())
-					out.AttributesToRetrieve = append(out.AttributesToRetrieve, v49)
+					var v52 string
+					v52 = string(in.String())
+					out.AttributesToRetrieve = append(out.AttributesToRetrieve, v52)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -2143,9 +2249,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo14(in *jlexer.Lexer,
 					out.AttributesToCrop = (out.AttributesToCrop)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v50 string
-					v50 = string(in.String())
-					out.AttributesToCrop = append(out.AttributesToCrop, v50)
+					var v53 string
+					v53 = string(in.String())
+					out.AttributesToCrop = append(out.AttributesToCrop, v53)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -2170,9 +2276,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo14(in *jlexer.Lexer,
 					out.AttributesToHighlight = (out.AttributesToHighlight)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v51 string
-					v51 = string(in.String())
-					out.AttributesToHighlight = append(out.AttributesToHighlight, v51)
+					var v54 string
+					v54 = string(in.String())
+					out.AttributesToHighlight = append(out.AttributesToHighlight, v54)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -2209,9 +2315,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo14(in *jlexer.Lexer,
 					out.Facets = (out.Facets)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v52 string
-					v52 = string(in.String())
-					out.Facets = append(out.Facets, v52)
+					var v55 string
+					v55 = string(in.String())
+					out.Facets = append(out.Facets, v55)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -2234,9 +2340,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo14(in *jlexer.Lexer,
 					out.Sort = (out.Sort)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v53 string
-					v53 = string(in.String())
-					out.Sort = append(out.Sort, v53)
+					var v56 string
+					v56 = string(in.String())
+					out.Sort = append(out.Sort, v56)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -2272,11 +2378,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo14(out *jwriter.Writ
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v54, v55 := range in.AttributesToRetrieve {
-				if v54 > 0 {
+			for v57, v58 := range in.AttributesToRetrieve {
+				if v57 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v55))
+				out.String(string(v58))
 			}
 			out.RawByte(']')
 		}
@@ -2288,11 +2394,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo14(out *jwriter.Writ
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v56, v57 := range in.AttributesToCrop {
-				if v56 > 0 {
+			for v59, v60 := range in.AttributesToCrop {
+				if v59 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v57))
+				out.String(string(v60))
 			}
 			out.RawByte(']')
 		}
@@ -2314,11 +2420,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo14(out *jwriter.Writ
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v58, v59 := range in.AttributesToHighlight {
-				if v58 > 0 {
+			for v61, v62 := range in.AttributesToHighlight {
+				if v61 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v59))
+				out.String(string(v62))
 			}
 			out.RawByte(']')
 		}
@@ -2361,11 +2467,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo14(out *jwriter.Writ
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v60, v61 := range in.Facets {
-				if v60 > 0 {
+			for v63, v64 := range in.Facets {
+				if v63 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v61))
+				out.String(string(v64))
 			}
 			out.RawByte(']')
 		}
@@ -2382,11 +2488,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo14(out *jwriter.Writ
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v62, v63 := range in.Sort {
-				if v62 > 0 {
+			for v65, v66 := range in.Sort {
+				if v65 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v63))
+				out.String(string(v66))
 			}
 			out.RawByte(']')
 		}
@@ -2597,9 +2703,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo17(in *jlexer.Lexer,
 					out.Results = (out.Results)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v64 Key
-					(v64).UnmarshalEasyJSON(in)
-					out.Results = append(out.Results, v64)
+					var v67 Key
+					(v67).UnmarshalEasyJSON(in)
+					out.Results = append(out.Results, v67)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -2631,11 +2737,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo17(out *jwriter.Writ
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v65, v66 := range in.Results {
-				if v65 > 0 {
+			for v68, v69 := range in.Results {
+				if v68 > 0 {
 					out.RawByte(',')
 				}
-				(v66).MarshalEasyJSON(out)
+				(v69).MarshalEasyJSON(out)
 			}
 			out.RawByte(']')
 		}
@@ -2880,9 +2986,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo20(in *jlexer.Lexer,
 					out.Actions = (out.Actions)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v67 string
-					v67 = string(in.String())
-					out.Actions = append(out.Actions, v67)
+					var v70 string
+					v70 = string(in.String())
+					out.Actions = append(out.Actions, v70)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -2903,9 +3009,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo20(in *jlexer.Lexer,
 					out.Indexes = (out.Indexes)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v68 string
-					v68 = string(in.String())
-					out.Indexes = append(out.Indexes, v68)
+					var v71 string
+					v71 = string(in.String())
+					out.Indexes = append(out.Indexes, v71)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -2962,11 +3068,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo20(out *jwriter.Writ
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v69, v70 := range in.Actions {
-				if v69 > 0 {
+			for v72, v73 := range in.Actions {
+				if v72 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v70))
+				out.String(string(v73))
 			}
 			out.RawByte(']')
 		}
@@ -2976,11 +3082,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo20(out *jwriter.Writ
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v71, v72 := range in.Indexes {
-				if v71 > 0 {
+			for v74, v75 := range in.Indexes {
+				if v74 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v72))
+				out.String(string(v75))
 			}
 			out.RawByte(']')
 		}
@@ -3073,9 +3179,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo21(in *jlexer.Lexer,
 					out.Actions = (out.Actions)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v73 string
-					v73 = string(in.String())
-					out.Actions = append(out.Actions, v73)
+					var v76 string
+					v76 = string(in.String())
+					out.Actions = append(out.Actions, v76)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -3096,9 +3202,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo21(in *jlexer.Lexer,
 					out.Indexes = (out.Indexes)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v74 string
-					v74 = string(in.String())
-					out.Indexes = append(out.Indexes, v74)
+					var v77 string
+					v77 = string(in.String())
+					out.Indexes = append(out.Indexes, v77)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -3154,11 +3260,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo21(out *jwriter.Writ
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v75, v76 := range in.Actions {
-				if v75 > 0 {
+			for v78, v79 := range in.Actions {
+				if v78 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v76))
+				out.String(string(v79))
 			}
 			out.RawByte(']')
 		}
@@ -3168,11 +3274,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo21(out *jwriter.Writ
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v77, v78 := range in.Indexes {
-				if v77 > 0 {
+			for v80, v81 := range in.Indexes {
+				if v80 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v78))
+				out.String(string(v81))
 			}
 			out.RawByte(']')
 		}
@@ -3253,9 +3359,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo22(in *jlexer.Lexer,
 					out.Results = (out.Results)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v79 Index
-					(v79).UnmarshalEasyJSON(in)
-					out.Results = append(out.Results, v79)
+					var v82 Index
+					(v82).UnmarshalEasyJSON(in)
+					out.Results = append(out.Results, v82)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -3287,11 +3393,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo22(out *jwriter.Writ
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v80, v81 := range in.Results {
-				if v80 > 0 {
+			for v83, v84 := range in.Results {
+				if v83 > 0 {
 					out.RawByte(',')
 				}
-				(v81).MarshalEasyJSON(out)
+				(v84).MarshalEasyJSON(out)
 			}
 			out.RawByte(']')
 		}
@@ -3674,29 +3780,29 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo27(in *jlexer.Lexer,
 					out.Results = (out.Results)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v82 map[string]interface{}
+					var v85 map[string]interface{}
 					if in.IsNull() {
 						in.Skip()
 					} else {
 						in.Delim('{')
-						v82 = make(map[string]interface{})
+						v85 = make(map[string]interface{})
 						for !in.IsDelim('}') {
 							key := string(in.String())
 							in.WantColon()
-							var v83 interface{}
-							if m, ok := v83.(easyjson.Unmarshaler); ok {
+							var v86 interface{}
+							if m, ok := v86.(easyjson.Unmarshaler); ok {
 								m.UnmarshalEasyJSON(in)
-							} else if m, ok := v83.(json.Unmarshaler); ok {
+							} else if m, ok := v86.(json.Unmarshaler); ok {
 								_ = m.UnmarshalJSON(in.Raw())
 							} else {
-								v83 = in.Interface()
+								v86 = in.Interface()
 							}
-							(v82)[key] = v83
+							(v85)[key] = v86
 							in.WantComma()
 						}
 						in.Delim('}')
 					}
-					out.Results = append(out.Results, v82)
+					out.Results = append(out.Results, v85)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -3728,29 +3834,29 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo27(out *jwriter.Writ
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v84, v85 := range in.Results {
-				if v84 > 0 {
+			for v87, v88 := range in.Results {
+				if v87 > 0 {
 					out.RawByte(',')
 				}
-				if v85 == nil && (out.Flags&jwriter.NilMapAsEmpty) == 0 {
+				if v88 == nil && (out.Flags&jwriter.NilMapAsEmpty) == 0 {
 					out.RawString(`null`)
 				} else {
 					out.RawByte('{')
-					v86First := true
-					for v86Name, v86Value := range v85 {
-						if v86First {
-							v86First = false
+					v89First := true
+					for v89Name, v89Value := range v88 {
+						if v89First {
+							v89First = false
 						} else {
 							out.RawByte(',')
 						}
-						out.String(string(v86Name))
+						out.String(string(v89Name))
 						out.RawByte(':')
-						if m, ok := v86Value.(easyjson.Marshaler); ok {
+						if m, ok := v89Value.(easyjson.Marshaler); ok {
 							m.MarshalEasyJSON(out)
-						} else if m, ok := v86Value.(json.Marshaler); ok {
+						} else if m, ok := v89Value.(json.Marshaler); ok {
 							out.Raw(m.MarshalJSON())
 						} else {
-							out.Raw(json.Marshal(v86Value))
+							out.Raw(json.Marshal(v89Value))
 						}
 					}
 					out.RawByte('}')
@@ -3839,9 +3945,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo28(in *jlexer.Lexer,
 					out.Fields = (out.Fields)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v87 string
-					v87 = string(in.String())
-					out.Fields = append(out.Fields, v87)
+					var v90 string
+					v90 = string(in.String())
+					out.Fields = append(out.Fields, v90)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -3886,11 +3992,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo28(out *jwriter.Writ
 		}
 		{
 			out.RawByte('[')
-			for v88, v89 := range in.Fields {
-				if v88 > 0 {
+			for v91, v92 := range in.Fields {
+				if v91 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v89))
+				out.String(string(v92))
 			}
 			out.RawByte(']')
 		}
@@ -3956,9 +4062,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo29(in *jlexer.Lexer,
 					out.Fields = (out.Fields)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v90 string
-					v90 = string(in.String())
-					out.Fields = append(out.Fields, v90)
+					var v93 string
+					v93 = string(in.String())
+					out.Fields = append(out.Fields, v93)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -3983,11 +4089,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo29(out *jwriter.Writ
 		out.RawString(prefix[1:])
 		{
 			out.RawByte('[')
-			for v91, v92 := range in.Fields {
-				if v91 > 0 {
+			for v94, v95 := range in.Fields {
+				if v94 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v92))
+				out.String(string(v95))
 			}
 			out.RawByte(']')
 		}
@@ -4061,9 +4167,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo30(in *jlexer.Lexer,
 					out.RankingRules = (out.RankingRules)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v93 string
-					v93 = string(in.String())
-					out.RankingRules = append(out.RankingRules, v93)
+					var v96 string
+					v96 = string(in.String())
+					out.RankingRules = append(out.RankingRules, v96)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -4094,9 +4200,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo30(in *jlexer.Lexer,
 					out.SearchableAttributes = (out.SearchableAttributes)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v94 string
-					v94 = string(in.String())
-					out.SearchableAttributes = append(out.SearchableAttributes, v94)
+					var v97 string
+					v97 = string(in.String())
+					out.SearchableAttributes = append(out.SearchableAttributes, v97)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -4117,9 +4223,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo30(in *jlexer.Lexer,
 					out.DisplayedAttributes = (out.DisplayedAttributes)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v95 string
-					v95 = string(in.String())
-					out.DisplayedAttributes = append(out.DisplayedAttributes, v95)
+					var v98 string
+					v98 = string(in.String())
+					out.DisplayedAttributes = append(out.DisplayedAttributes, v98)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -4140,9 +4246,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo30(in *jlexer.Lexer,
 					out.StopWords = (out.StopWords)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v96 string
-					v96 = string(in.String())
-					out.StopWords = append(out.StopWords, v96)
+					var v99 string
+					v99 = string(in.String())
+					out.StopWords = append(out.StopWords, v99)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -4160,30 +4266,30 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo30(in *jlexer.Lexer,
 				for !in.IsDelim('}') {
 					key := string(in.String())
 					in.WantColon()
-					var v97 []string
+					var v100 []string
 					if in.IsNull() {
 						in.Skip()
-						v97 = nil
+						v100 = nil
 					} else {
 						in.Delim('[')
-						if v97 == nil {
+						if v100 == nil {
 							if !in.IsDelim(']') {
-								v97 = make([]string, 0, 4)
+								v100 = make([]string, 0, 4)
 							} else {
-								v97 = []string{}
+								v100 = []string{}
 							}
 						} else {
-							v97 = (v97)[:0]
+							v100 = (v100)[:0]
 						}
 						for !in.IsDelim(']') {
-							var v98 string
-							v98 = string(in.String())
-							v97 = append(v97, v98)
+							var v101 string
+							v101 = string(in.String())
+							v100 = append(v100, v101)
 							in.WantComma()
 						}
 						in.Delim(']')
 					}
-					(out.Synonyms)[key] = v97
+					(out.Synonyms)[key] = v100
 					in.WantComma()
 				}
 				in.Delim('}')
@@ -4204,9 +4310,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo30(in *jlexer.Lexer,
 					out.FilterableAttributes = (out.FilterableAttributes)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v99 string
-					v99 = string(in.String())
-					out.FilterableAttributes = append(out.FilterableAttributes, v99)
+					var v102 string
+					v102 = string(in.String())
+					out.FilterableAttributes = append(out.FilterableAttributes, v102)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -4227,9 +4333,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo30(in *jlexer.Lexer,
 					out.SortableAttributes = (out.SortableAttributes)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v100 string
-					v100 = string(in.String())
-					out.SortableAttributes = append(out.SortableAttributes, v100)
+					var v103 string
+					v103 = string(in.String())
+					out.SortableAttributes = append(out.SortableAttributes, v103)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -4294,11 +4400,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo30(out *jwriter.Writ
 		}
 		{
 			out.RawByte('[')
-			for v101, v102 := range in.RankingRules {
-				if v101 > 0 {
+			for v104, v105 := range in.RankingRules {
+				if v104 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v102))
+				out.String(string(v105))
 			}
 			out.RawByte(']')
 		}
@@ -4323,11 +4429,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo30(out *jwriter.Writ
 		}
 		{
 			out.RawByte('[')
-			for v103, v104 := range in.SearchableAttributes {
-				if v103 > 0 {
+			for v106, v107 := range in.SearchableAttributes {
+				if v106 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v104))
+				out.String(string(v107))
 			}
 			out.RawByte(']')
 		}
@@ -4342,11 +4448,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo30(out *jwriter.Writ
 		}
 		{
 			out.RawByte('[')
-			for v105, v106 := range in.DisplayedAttributes {
-				if v105 > 0 {
+			for v108, v109 := range in.DisplayedAttributes {
+				if v108 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v106))
+				out.String(string(v109))
 			}
 			out.RawByte(']')
 		}
@@ -4361,11 +4467,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo30(out *jwriter.Writ
 		}
 		{
 			out.RawByte('[')
-			for v107, v108 := range in.StopWords {
-				if v107 > 0 {
+			for v110, v111 := range in.StopWords {
+				if v110 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v108))
+				out.String(string(v111))
 			}
 			out.RawByte(']')
 		}
@@ -4380,24 +4486,24 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo30(out *jwriter.Writ
 		}
 		{
 			out.RawByte('{')
-			v109First := true
-			for v109Name, v109Value := range in.Synonyms {
-				if v109First {
-					v109First = false
+			v112First := true
+			for v112Name, v112Value := range in.Synonyms {
+				if v112First {
+					v112First = false
 				} else {
 					out.RawByte(',')
 				}
-				out.String(string(v109Name))
+				out.String(string(v112Name))
 				out.RawByte(':')
-				if v109Value == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+				if v112Value == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
 					out.RawString("null")
 				} else {
 					out.RawByte('[')
-					for v110, v111 := range v109Value {
-						if v110 > 0 {
+					for v113, v114 := range v112Value {
+						if v113 > 0 {
 							out.RawByte(',')
 						}
-						out.String(string(v111))
+						out.String(string(v114))
 					}
 					out.RawByte(']')
 				}
@@ -4415,11 +4521,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo30(out *jwriter.Writ
 		}
 		{
 			out.RawByte('[')
-			for v112, v113 := range in.FilterableAttributes {
-				if v112 > 0 {
+			for v115, v116 := range in.FilterableAttributes {
+				if v115 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v113))
+				out.String(string(v116))
 			}
 			out.RawByte(']')
 		}
@@ -4434,11 +4540,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo30(out *jwriter.Writ
 		}
 		{
 			out.RawByte('[')
-			for v114, v115 := range in.SortableAttributes {
-				if v114 > 0 {
+			for v117, v118 := range in.SortableAttributes {
+				if v117 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v115))
+				out.String(string(v118))
 			}
 			out.RawByte(']')
 		}


### PR DESCRIPTION
Add new filters on the `get /tasks` route.

Present in this [spec](https://github.com/meilisearch/specifications/pull/195)

V0.30.0
in TasksQuery:
  - [x] Add `uid`
  - [x] Add `CanceledBy`
  - [x] Add `BeforeEnqueuedAt`
  - [x] Add `AfterEnqueuedAt`
  - [x] Add `BeforeStartedAt`
  - [x] Add `AfterStatedAt`
  - [x] Add `BeforeFinishedAt`
  - [x] Add `AfterFinishedAt`

Tests:
  - [x] `uid`
  - [x] `canceledBy`
  - [x] `beforeEnqueuedAt`

