### PR TITLE
Add pagination feature for v0.30.0

### DIFF
--- a/index_search.go
+++ b/index_search.go
@@ -85,6 +85,12 @@ func searchPostRequestParams(query string, request *SearchRequest) map[string]in
 	if request.CropLength != 0 {
 		params["cropLength"] = request.CropLength
 	}
+	if request.HitsPerPage != 0 {
+		params["hitsPerPage"] = request.HitsPerPage
+	}
+	if request.Page != 0 {
+		params["page"] = request.Page
+	}
 	if request.CropMarker != "" {
 		params["cropMarker"] = request.CropMarker
 	}

--- a/types.go
+++ b/types.go
@@ -278,6 +278,8 @@ type SearchRequest struct {
 	Facets                []string
 	PlaceholderSearch     bool
 	Sort                  []string
+	HitsPerPage           int64
+	Page                  int64
 }
 
 // SearchResponse is the response body for search method
@@ -289,6 +291,10 @@ type SearchResponse struct {
 	ProcessingTimeMs   int64         `json:"processingTimeMs"`
 	Query              string        `json:"query"`
 	FacetDistribution  interface{}   `json:"facetDistribution,omitempty"`
+	TotalHits          int64         `json:"totalHits"`
+	HitsPerPage        int64         `json:"hitsPerPage"`
+	Page               int64         `json:"page"`
+	TotalPages         int64         `json:"totalPages"`
 }
 
 // DocumentQuery is the request body get one documents method

--- a/types.go
+++ b/types.go
@@ -285,16 +285,16 @@ type SearchRequest struct {
 // SearchResponse is the response body for search method
 type SearchResponse struct {
 	Hits               []interface{} `json:"hits"`
-	EstimatedTotalHits int64         `json:"estimatedTotalHits"`
-	Offset             int64         `json:"offset"`
-	Limit              int64         `json:"limit"`
+	EstimatedTotalHits int64         `json:"estimatedTotalHits,omitempty"`
+	Offset             int64         `json:"offset,omitempty"`
+	Limit              int64         `json:"limit,omitempty"`
 	ProcessingTimeMs   int64         `json:"processingTimeMs"`
 	Query              string        `json:"query"`
 	FacetDistribution  interface{}   `json:"facetDistribution,omitempty"`
-	TotalHits          int64         `json:"totalHits"`
-	HitsPerPage        int64         `json:"hitsPerPage"`
-	Page               int64         `json:"page"`
-	TotalPages         int64         `json:"totalPages"`
+	TotalHits          int64         `json:"totalHits,omitempty"`
+	HitsPerPage        int64         `json:"hitsPerPage,omitempty"`
+	Page               int64         `json:"page,omitempty"`
+	TotalPages         int64         `json:"totalPages,omitempty"`
 }
 
 // DocumentQuery is the request body get one documents method

--- a/types_easyjson.go
+++ b/types_easyjson.go
@@ -2100,6 +2100,14 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo13(in *jlexer.Lexer,
 			} else {
 				out.FacetDistribution = in.Interface()
 			}
+		case "totalHits":
+			out.TotalHits = int64(in.Int64())
+		case "hitsPerPage":
+			out.HitsPerPage = int64(in.Int64())
+		case "page":
+			out.Page = int64(in.Int64())
+		case "totalPages":
+			out.TotalPages = int64(in.Int64())
 		default:
 			in.SkipRecursive()
 		}
@@ -2171,6 +2179,26 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo13(out *jwriter.Writ
 		} else {
 			out.Raw(json.Marshal(in.FacetDistribution))
 		}
+	}
+	{
+		const prefix string = ",\"totalHits\":"
+		out.RawString(prefix)
+		out.Int64(int64(in.TotalHits))
+	}
+	{
+		const prefix string = ",\"hitsPerPage\":"
+		out.RawString(prefix)
+		out.Int64(int64(in.HitsPerPage))
+	}
+	{
+		const prefix string = ",\"page\":"
+		out.RawString(prefix)
+		out.Int64(int64(in.Page))
+	}
+	{
+		const prefix string = ",\"totalPages\":"
+		out.RawString(prefix)
+		out.Int64(int64(in.TotalPages))
 	}
 	out.RawByte('}')
 }
@@ -2358,6 +2386,10 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo14(in *jlexer.Lexer,
 				}
 				in.Delim(']')
 			}
+		case "HitsPerPage":
+			out.HitsPerPage = int64(in.Int64())
+		case "Page":
+			out.Page = int64(in.Int64())
 		default:
 			in.SkipRecursive()
 		}
@@ -2507,6 +2539,16 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo14(out *jwriter.Writ
 			}
 			out.RawByte(']')
 		}
+	}
+	{
+		const prefix string = ",\"HitsPerPage\":"
+		out.RawString(prefix)
+		out.Int64(int64(in.HitsPerPage))
+	}
+	{
+		const prefix string = ",\"Page\":"
+		out.RawString(prefix)
+		out.Int64(int64(in.Page))
 	}
 	out.RawByte('}')
 }

--- a/types_easyjson.go
+++ b/types_easyjson.go
@@ -2144,17 +2144,17 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo13(out *jwriter.Writ
 			out.RawByte(']')
 		}
 	}
-	{
+	if in.EstimatedTotalHits != 0 {
 		const prefix string = ",\"estimatedTotalHits\":"
 		out.RawString(prefix)
 		out.Int64(int64(in.EstimatedTotalHits))
 	}
-	{
+	if in.Offset != 0 {
 		const prefix string = ",\"offset\":"
 		out.RawString(prefix)
 		out.Int64(int64(in.Offset))
 	}
-	{
+	if in.Limit != 0 {
 		const prefix string = ",\"limit\":"
 		out.RawString(prefix)
 		out.Int64(int64(in.Limit))
@@ -2180,22 +2180,22 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo13(out *jwriter.Writ
 			out.Raw(json.Marshal(in.FacetDistribution))
 		}
 	}
-	{
+	if in.TotalHits != 0 {
 		const prefix string = ",\"totalHits\":"
 		out.RawString(prefix)
 		out.Int64(int64(in.TotalHits))
 	}
-	{
+	if in.HitsPerPage != 0 {
 		const prefix string = ",\"hitsPerPage\":"
 		out.RawString(prefix)
 		out.Int64(int64(in.HitsPerPage))
 	}
-	{
+	if in.Page != 0 {
 		const prefix string = ",\"page\":"
 		out.RawString(prefix)
 		out.Int64(int64(in.Page))
 	}
-	{
+	if in.TotalPages != 0 {
 		const prefix string = ",\"totalPages\":"
 		out.RawString(prefix)
 		out.Int64(int64(in.TotalPages))


### PR DESCRIPTION
Adds the new page selection component 

TODO: 
- [x] Add `HitsPerPage`
- [x]  Add two new search parameters: `Page` and `HitsPerPage`
- [x]  Add 4 new search responses: `Page`, `HitsPerPage`, `TotalHits`, `TotalPages`
- [x] Add tests

Response: 
- [x] `limit` is now optional
- [x] `offset` is now optional
- [x] `estimatedTotalHits` is now optional
- [x] new `page` is optional
- [x] new `hitsPerPage` is optional
- [x] new `totalPages` is optional
- [x] new `totalHits` is optional

Tests
- [x] add tests for new search parameters: `page` and `hitsPerPage` check `totalHits`, `totalPages` in the response.

