### PR TITLE
Improve the check-release tag parser to be more robust

### DIFF
--- a/.github/scripts/check-release.sh
+++ b/.github/scripts/check-release.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
 # Checking if current tag matches the package version
-current_tag=$(echo $GITHUB_REF | tr -d 'refs/tags/')
+current_tag=$(echo $GITHUB_REF | cut -d '/' -f 3 | sed -r 's/^v//')
+
 file1='version.go'
 file_tag1=$(grep 'const VERSION' -A 0 $file1 | cut -d '=' -f2 | tr -d '"' | tr -d ' ')
 


### PR DESCRIPTION
`check-release.yml` used to parse the `GITHUB_REF` with `tr -d 'refs/tags/v'`. But, `tr` deletes characters and not a specific string. Which results in a wrong parsing of tags containings the characters present in `refs/tags/v`. Example: 
  `refs/tags/v0.1.0-strapi-v3.1` becomes `0.1.0-pi-v3.1`

To avoid this issue, the command is changed to a more robust parsing method: `cut -d '/' -f 3 | sed -r 's/^v//'`
- `cut -d '/' -f 3` splits our string based on the `/` and takes the 3th element. `refs/tags/v0.1.0-strapi-v3.1` => `["refs", "tags", "v0.1.0-strapi-v3.1"]`
- `sed -r 's/^v//'` removes the prepending `v`. `v0.1.0-strapi-v3.1` => `0.1.0-strapi-v3.1`
