### PR TITLE
Add cancel task api for v0.30.0

### DIFF
--- a/client.go
+++ b/client.go
@@ -54,7 +54,7 @@ type ClientInterface interface {
 	IsHealthy() bool
 	GetTask(taskUID int64) (resp *Task, err error)
 	GetTasks(param *TasksQuery) (resp *TaskResult, err error)
-	CancelTasks(param *TasksQuery) (resp *TaskInfo, err error)
+	CancelTasks(param *CancelTasksQuery) (resp *TaskInfo, err error)
 	WaitForTask(taskUID int64, options ...WaitParams) (*Task, error)
 	GenerateTenantToken(APIKeyUID string, searchRules map[string]interface{}, options *TenantTokenOptions) (resp string, err error)
 }
@@ -286,7 +286,7 @@ func (c *Client) GetTasks(param *TasksQuery) (resp *TaskResult, err error) {
 	return resp, nil
 }
 
-func (c *Client) CancelTasks(param *TasksQuery) (resp *TaskInfo, err error) {
+func (c *Client) CancelTasks(param *CancelTasksQuery) (resp *TaskInfo, err error) {
 	resp = &TaskInfo{}
 	req := internalRequest{
 		endpoint:            "/tasks/cancel",
@@ -298,7 +298,17 @@ func (c *Client) CancelTasks(param *TasksQuery) (resp *TaskInfo, err error) {
 		functionName:        "CancelTasks",
 	}
 	if param != nil {
-		encodeTasksQuery(param, &req)
+		paramToSend := &TasksQuery{
+			UIDS:             param.UIDS,
+			IndexUIDS:        param.IndexUIDS,
+			Statuses:         param.Statuses,
+			Types:            param.Types,
+			BeforeEnqueuedAt: param.BeforeEnqueuedAt,
+			AfterEnqueuedAt:  param.AfterEnqueuedAt,
+			BeforeStartedAt:  param.BeforeStartedAt,
+			AfterStartedAt:   param.AfterStartedAt,
+		}
+		encodeTasksQuery(paramToSend, &req)
 	}
 	if err := c.executeRequest(req); err != nil {
 		return nil, err

--- a/client.go
+++ b/client.go
@@ -55,7 +55,7 @@ type ClientInterface interface {
 	GetTask(taskUID int64) (resp *Task, err error)
 	GetTasks(param *TasksQuery) (resp *TaskResult, err error)
 	CancelTasks(param *CancelTasksQuery) (resp *TaskInfo, err error)
-  DeleteTasks(param *DeleteTasksQuery) (resp *TaskInfo, err error)
+	DeleteTasks(param *DeleteTasksQuery) (resp *TaskInfo, err error)
 	SwapIndexes(param []SwapIndexesParams) (resp *TaskInfo, err error)
 	WaitForTask(taskUID int64, options ...WaitParams) (*Task, error)
 	GenerateTenantToken(APIKeyUID string, searchRules map[string]interface{}, options *TenantTokenOptions) (resp string, err error)

--- a/client.go
+++ b/client.go
@@ -54,6 +54,7 @@ type ClientInterface interface {
 	IsHealthy() bool
 	GetTask(taskUID int64) (resp *Task, err error)
 	GetTasks(param *TasksQuery) (resp *TaskResult, err error)
+	CancelTasks(param *TasksQuery) (resp *TaskInfo, err error)
 	WaitForTask(taskUID int64, options ...WaitParams) (*Task, error)
 	GenerateTenantToken(APIKeyUID string, searchRules map[string]interface{}, options *TenantTokenOptions) (resp string, err error)
 }
@@ -275,6 +276,26 @@ func (c *Client) GetTasks(param *TasksQuery) (resp *TaskResult, err error) {
 		withQueryParams:     map[string]string{},
 		acceptedStatusCodes: []int{http.StatusOK},
 		functionName:        "GetTasks",
+	}
+	if param != nil {
+		encodeTasksQuery(param, &req)
+	}
+	if err := c.executeRequest(req); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (c *Client) CancelTasks(param *TasksQuery) (resp *TaskInfo, err error) {
+	resp = &TaskInfo{}
+	req := internalRequest{
+		endpoint:            "/tasks/cancel",
+		method:              http.MethodPost,
+		withRequest:         nil,
+		withResponse:        &resp,
+		withQueryParams:     map[string]string{},
+		acceptedStatusCodes: []int{http.StatusOK},
+		functionName:        "CancelTasks",
 	}
 	if param != nil {
 		encodeTasksQuery(param, &req)

--- a/types.go
+++ b/types.go
@@ -130,22 +130,18 @@ type Task struct {
 	StartedAt  time.Time           `json:"startedAt,omitempty"`
 	FinishedAt time.Time           `json:"finishedAt,omitempty"`
 	Details    Details             `json:"details,omitempty"`
+	CanceledBy int64               `json:"canceledBy,omitempty"`
 }
 
 // TaskInfo indicates information regarding a task returned by an asynchronous method
 //
 // Documentation: https://docs.meilisearch.com/reference/api/tasks.html#tasks
 type TaskInfo struct {
-	Status     TaskStatus          `json:"status"`
-	TaskUID    int64               `json:"taskUid,omitempty"`
-	IndexUID   string              `json:"indexUid"`
-	Type       string              `json:"type"`
-	Error      meilisearchApiError `json:"error,omitempty"`
-	Duration   string              `json:"duration,omitempty"`
-	EnqueuedAt time.Time           `json:"enqueuedAt"`
-	StartedAt  time.Time           `json:"startedAt,omitempty"`
-	FinishedAt time.Time           `json:"finishedAt,omitempty"`
-	Details    Details             `json:"details,omitempty"`
+	Status     TaskStatus `json:"status"`
+	TaskUID    int64      `json:"taskUid"`
+	IndexUID   string     `json:"indexUid"`
+	Type       string     `json:"type"`
+	EnqueuedAt time.Time  `json:"enqueuedAt"`
 }
 
 // TasksQuery is the request body for list documents method
@@ -166,15 +162,26 @@ type TasksQuery struct {
 }
 
 type Details struct {
-	ReceivedDocuments    int                 `json:"receivedDocuments,omitempty"`
-	IndexedDocuments     int                 `json:"indexedDocuments,omitempty"`
-	DeletedDocuments     int                 `json:"deletedDocuments,omitempty"`
+	ReceivedDocuments    int64               `json:"receivedDocuments,omitempty"`
+	IndexedDocuments     int64               `json:"indexedDocuments,omitempty"`
+	DeletedDocuments     int64               `json:"deletedDocuments,omitempty"`
 	PrimaryKey           string              `json:"primaryKey,omitempty"`
+	ProvidedIds          int64               `json:"providedIds,omitempty"`
 	RankingRules         []string            `json:"rankingRules,omitempty"`
 	DistinctAttribute    *string             `json:"distinctAttribute,omitempty"`
+	SearchableAttributes []string            `json:"searchableAttributes,omitempty"`
+	DisplayedAttributes  []string            `json:"displayedAttributes,omitempty"`
+	StopWords            []string            `json:"stopWords,omitempty"`
 	Synonyms             map[string][]string `json:"synonyms,omitempty"`
 	FilterableAttributes []string            `json:"filterableAttributes,omitempty"`
 	SortableAttributes   []string            `json:"sortableAttributes,omitempty"`
+	TypoTolerance        *TypoTolerance      `json:"typoTolerance,omitempty"`
+	Pagination           *Pagination         `json:"pagination,omitempty"`
+	Faceting             *Faceting           `json:"faceting,omitempty"`
+	MatchedTasks         int64               `json:"matchedTasks,omitempty"`
+	CanceledTasks        int64               `json:"canceledTasks,omitempty"`
+	DeletedTasks         int64               `json:"deletedTasks,omitempty"`
+	OriginalFilter       string              `json:"originalFilter,omitempty"`
 }
 
 // Return of multiple tasks is wrap in a TaskResult

--- a/types.go
+++ b/types.go
@@ -144,7 +144,7 @@ type TaskInfo struct {
 	EnqueuedAt time.Time  `json:"enqueuedAt"`
 }
 
-// TasksQuery is the request body for list documents method
+// TasksQuery is a list of filter available to send as query parameters
 type TasksQuery struct {
 	UIDS             []int64
 	Limit            int64
@@ -159,6 +159,18 @@ type TasksQuery struct {
 	AfterStartedAt   time.Time
 	BeforeFinishedAt time.Time
 	AfterFinishedAt  time.Time
+}
+
+// CancelTasksQuery is a list of filter available to send as query parameters
+type CancelTasksQuery struct {
+	UIDS             []int64
+	IndexUIDS        []string
+	Statuses         []string
+	Types            []string
+	BeforeEnqueuedAt time.Time
+	AfterEnqueuedAt  time.Time
+	BeforeStartedAt  time.Time
+	AfterStartedAt   time.Time
 }
 
 type Details struct {

--- a/types_easyjson.go
+++ b/types_easyjson.go
@@ -1036,24 +1036,10 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo7(in *jlexer.Lexer, 
 			out.IndexUID = string(in.String())
 		case "type":
 			out.Type = string(in.String())
-		case "error":
-			easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo8(in, &out.Error)
-		case "duration":
-			out.Duration = string(in.String())
 		case "enqueuedAt":
 			if data := in.Raw(); in.Ok() {
 				in.AddError((out.EnqueuedAt).UnmarshalJSON(data))
 			}
-		case "startedAt":
-			if data := in.Raw(); in.Ok() {
-				in.AddError((out.StartedAt).UnmarshalJSON(data))
-			}
-		case "finishedAt":
-			if data := in.Raw(); in.Ok() {
-				in.AddError((out.FinishedAt).UnmarshalJSON(data))
-			}
-		case "details":
-			(out.Details).UnmarshalEasyJSON(in)
 		default:
 			in.SkipRecursive()
 		}
@@ -1073,7 +1059,7 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo7(out *jwriter.Write
 		out.RawString(prefix[1:])
 		out.String(string(in.Status))
 	}
-	if in.TaskUID != 0 {
+	{
 		const prefix string = ",\"taskUid\":"
 		out.RawString(prefix)
 		out.Int64(int64(in.TaskUID))
@@ -1088,35 +1074,10 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo7(out *jwriter.Write
 		out.RawString(prefix)
 		out.String(string(in.Type))
 	}
-	if true {
-		const prefix string = ",\"error\":"
-		out.RawString(prefix)
-		easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo8(out, in.Error)
-	}
-	if in.Duration != "" {
-		const prefix string = ",\"duration\":"
-		out.RawString(prefix)
-		out.String(string(in.Duration))
-	}
 	{
 		const prefix string = ",\"enqueuedAt\":"
 		out.RawString(prefix)
 		out.Raw((in.EnqueuedAt).MarshalJSON())
-	}
-	if true {
-		const prefix string = ",\"startedAt\":"
-		out.RawString(prefix)
-		out.Raw((in.StartedAt).MarshalJSON())
-	}
-	if true {
-		const prefix string = ",\"finishedAt\":"
-		out.RawString(prefix)
-		out.Raw((in.FinishedAt).MarshalJSON())
-	}
-	if true {
-		const prefix string = ",\"details\":"
-		out.RawString(prefix)
-		(in.Details).MarshalEasyJSON(out)
 	}
 	out.RawByte('}')
 }
@@ -1144,7 +1105,156 @@ func (v *TaskInfo) UnmarshalJSON(data []byte) error {
 func (v *TaskInfo) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo7(l, v)
 }
-func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo8(in *jlexer.Lexer, out *meilisearchApiError) {
+func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo8(in *jlexer.Lexer, out *Task) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "status":
+			out.Status = TaskStatus(in.String())
+		case "uid":
+			out.UID = int64(in.Int64())
+		case "taskUid":
+			out.TaskUID = int64(in.Int64())
+		case "indexUid":
+			out.IndexUID = string(in.String())
+		case "type":
+			out.Type = string(in.String())
+		case "error":
+			easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo9(in, &out.Error)
+		case "duration":
+			out.Duration = string(in.String())
+		case "enqueuedAt":
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.EnqueuedAt).UnmarshalJSON(data))
+			}
+		case "startedAt":
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.StartedAt).UnmarshalJSON(data))
+			}
+		case "finishedAt":
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.FinishedAt).UnmarshalJSON(data))
+			}
+		case "details":
+			(out.Details).UnmarshalEasyJSON(in)
+		case "canceledBy":
+			out.CanceledBy = int64(in.Int64())
+		default:
+			in.SkipRecursive()
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo8(out *jwriter.Writer, in Task) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	{
+		const prefix string = ",\"status\":"
+		out.RawString(prefix[1:])
+		out.String(string(in.Status))
+	}
+	if in.UID != 0 {
+		const prefix string = ",\"uid\":"
+		out.RawString(prefix)
+		out.Int64(int64(in.UID))
+	}
+	if in.TaskUID != 0 {
+		const prefix string = ",\"taskUid\":"
+		out.RawString(prefix)
+		out.Int64(int64(in.TaskUID))
+	}
+	{
+		const prefix string = ",\"indexUid\":"
+		out.RawString(prefix)
+		out.String(string(in.IndexUID))
+	}
+	{
+		const prefix string = ",\"type\":"
+		out.RawString(prefix)
+		out.String(string(in.Type))
+	}
+	if true {
+		const prefix string = ",\"error\":"
+		out.RawString(prefix)
+		easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo9(out, in.Error)
+	}
+	if in.Duration != "" {
+		const prefix string = ",\"duration\":"
+		out.RawString(prefix)
+		out.String(string(in.Duration))
+	}
+	{
+		const prefix string = ",\"enqueuedAt\":"
+		out.RawString(prefix)
+		out.Raw((in.EnqueuedAt).MarshalJSON())
+	}
+	if true {
+		const prefix string = ",\"startedAt\":"
+		out.RawString(prefix)
+		out.Raw((in.StartedAt).MarshalJSON())
+	}
+	if true {
+		const prefix string = ",\"finishedAt\":"
+		out.RawString(prefix)
+		out.Raw((in.FinishedAt).MarshalJSON())
+	}
+	if true {
+		const prefix string = ",\"details\":"
+		out.RawString(prefix)
+		(in.Details).MarshalEasyJSON(out)
+	}
+	if in.CanceledBy != 0 {
+		const prefix string = ",\"canceledBy\":"
+		out.RawString(prefix)
+		out.Int64(int64(in.CanceledBy))
+	}
+	out.RawByte('}')
+}
+
+// MarshalJSON supports json.Marshaler interface
+func (v Task) MarshalJSON() ([]byte, error) {
+	w := jwriter.Writer{}
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo8(&w, v)
+	return w.Buffer.BuildBytes(), w.Error
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v Task) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo8(w, v)
+}
+
+// UnmarshalJSON supports json.Unmarshaler interface
+func (v *Task) UnmarshalJSON(data []byte) error {
+	r := jlexer.Lexer{Data: data}
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo8(&r, v)
+	return r.Error()
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *Task) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo8(l, v)
+}
+func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo9(in *jlexer.Lexer, out *meilisearchApiError) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -1181,7 +1291,7 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo8(in *jlexer.Lexer, 
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo8(out *jwriter.Writer, in meilisearchApiError) {
+func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo9(out *jwriter.Writer, in meilisearchApiError) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1206,148 +1316,6 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo8(out *jwriter.Write
 		out.String(string(in.Link))
 	}
 	out.RawByte('}')
-}
-func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo9(in *jlexer.Lexer, out *Task) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "status":
-			out.Status = TaskStatus(in.String())
-		case "uid":
-			out.UID = int64(in.Int64())
-		case "taskUid":
-			out.TaskUID = int64(in.Int64())
-		case "indexUid":
-			out.IndexUID = string(in.String())
-		case "type":
-			out.Type = string(in.String())
-		case "error":
-			easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo8(in, &out.Error)
-		case "duration":
-			out.Duration = string(in.String())
-		case "enqueuedAt":
-			if data := in.Raw(); in.Ok() {
-				in.AddError((out.EnqueuedAt).UnmarshalJSON(data))
-			}
-		case "startedAt":
-			if data := in.Raw(); in.Ok() {
-				in.AddError((out.StartedAt).UnmarshalJSON(data))
-			}
-		case "finishedAt":
-			if data := in.Raw(); in.Ok() {
-				in.AddError((out.FinishedAt).UnmarshalJSON(data))
-			}
-		case "details":
-			(out.Details).UnmarshalEasyJSON(in)
-		default:
-			in.SkipRecursive()
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo9(out *jwriter.Writer, in Task) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	{
-		const prefix string = ",\"status\":"
-		out.RawString(prefix[1:])
-		out.String(string(in.Status))
-	}
-	if in.UID != 0 {
-		const prefix string = ",\"uid\":"
-		out.RawString(prefix)
-		out.Int64(int64(in.UID))
-	}
-	if in.TaskUID != 0 {
-		const prefix string = ",\"taskUid\":"
-		out.RawString(prefix)
-		out.Int64(int64(in.TaskUID))
-	}
-	{
-		const prefix string = ",\"indexUid\":"
-		out.RawString(prefix)
-		out.String(string(in.IndexUID))
-	}
-	{
-		const prefix string = ",\"type\":"
-		out.RawString(prefix)
-		out.String(string(in.Type))
-	}
-	if true {
-		const prefix string = ",\"error\":"
-		out.RawString(prefix)
-		easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo8(out, in.Error)
-	}
-	if in.Duration != "" {
-		const prefix string = ",\"duration\":"
-		out.RawString(prefix)
-		out.String(string(in.Duration))
-	}
-	{
-		const prefix string = ",\"enqueuedAt\":"
-		out.RawString(prefix)
-		out.Raw((in.EnqueuedAt).MarshalJSON())
-	}
-	if true {
-		const prefix string = ",\"startedAt\":"
-		out.RawString(prefix)
-		out.Raw((in.StartedAt).MarshalJSON())
-	}
-	if true {
-		const prefix string = ",\"finishedAt\":"
-		out.RawString(prefix)
-		out.Raw((in.FinishedAt).MarshalJSON())
-	}
-	if true {
-		const prefix string = ",\"details\":"
-		out.RawString(prefix)
-		(in.Details).MarshalEasyJSON(out)
-	}
-	out.RawByte('}')
-}
-
-// MarshalJSON supports json.Marshaler interface
-func (v Task) MarshalJSON() ([]byte, error) {
-	w := jwriter.Writer{}
-	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo9(&w, v)
-	return w.Buffer.BuildBytes(), w.Error
-}
-
-// MarshalEasyJSON supports easyjson.Marshaler interface
-func (v Task) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo9(w, v)
-}
-
-// UnmarshalJSON supports json.Unmarshaler interface
-func (v *Task) UnmarshalJSON(data []byte) error {
-	r := jlexer.Lexer{Data: data}
-	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo9(&r, v)
-	return r.Error()
-}
-
-// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *Task) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo9(l, v)
 }
 func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo10(in *jlexer.Lexer, out *StatsIndex) {
 	isTopLevel := in.IsStart()
@@ -4143,13 +4111,15 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo30(in *jlexer.Lexer,
 		}
 		switch key {
 		case "receivedDocuments":
-			out.ReceivedDocuments = int(in.Int())
+			out.ReceivedDocuments = int64(in.Int64())
 		case "indexedDocuments":
-			out.IndexedDocuments = int(in.Int())
+			out.IndexedDocuments = int64(in.Int64())
 		case "deletedDocuments":
-			out.DeletedDocuments = int(in.Int())
+			out.DeletedDocuments = int64(in.Int64())
 		case "primaryKey":
 			out.PrimaryKey = string(in.String())
+		case "providedIds":
+			out.ProvidedIds = int64(in.Int64())
 		case "rankingRules":
 			if in.IsNull() {
 				in.Skip()
@@ -4183,6 +4153,75 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo30(in *jlexer.Lexer,
 				}
 				*out.DistinctAttribute = string(in.String())
 			}
+		case "searchableAttributes":
+			if in.IsNull() {
+				in.Skip()
+				out.SearchableAttributes = nil
+			} else {
+				in.Delim('[')
+				if out.SearchableAttributes == nil {
+					if !in.IsDelim(']') {
+						out.SearchableAttributes = make([]string, 0, 4)
+					} else {
+						out.SearchableAttributes = []string{}
+					}
+				} else {
+					out.SearchableAttributes = (out.SearchableAttributes)[:0]
+				}
+				for !in.IsDelim(']') {
+					var v100 string
+					v100 = string(in.String())
+					out.SearchableAttributes = append(out.SearchableAttributes, v100)
+					in.WantComma()
+				}
+				in.Delim(']')
+			}
+		case "displayedAttributes":
+			if in.IsNull() {
+				in.Skip()
+				out.DisplayedAttributes = nil
+			} else {
+				in.Delim('[')
+				if out.DisplayedAttributes == nil {
+					if !in.IsDelim(']') {
+						out.DisplayedAttributes = make([]string, 0, 4)
+					} else {
+						out.DisplayedAttributes = []string{}
+					}
+				} else {
+					out.DisplayedAttributes = (out.DisplayedAttributes)[:0]
+				}
+				for !in.IsDelim(']') {
+					var v101 string
+					v101 = string(in.String())
+					out.DisplayedAttributes = append(out.DisplayedAttributes, v101)
+					in.WantComma()
+				}
+				in.Delim(']')
+			}
+		case "stopWords":
+			if in.IsNull() {
+				in.Skip()
+				out.StopWords = nil
+			} else {
+				in.Delim('[')
+				if out.StopWords == nil {
+					if !in.IsDelim(']') {
+						out.StopWords = make([]string, 0, 4)
+					} else {
+						out.StopWords = []string{}
+					}
+				} else {
+					out.StopWords = (out.StopWords)[:0]
+				}
+				for !in.IsDelim(']') {
+					var v102 string
+					v102 = string(in.String())
+					out.StopWords = append(out.StopWords, v102)
+					in.WantComma()
+				}
+				in.Delim(']')
+			}
 		case "synonyms":
 			if in.IsNull() {
 				in.Skip()
@@ -4196,30 +4235,30 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo30(in *jlexer.Lexer,
 				for !in.IsDelim('}') {
 					key := string(in.String())
 					in.WantColon()
-					var v100 []string
+					var v103 []string
 					if in.IsNull() {
 						in.Skip()
-						v100 = nil
+						v103 = nil
 					} else {
 						in.Delim('[')
-						if v100 == nil {
+						if v103 == nil {
 							if !in.IsDelim(']') {
-								v100 = make([]string, 0, 4)
+								v103 = make([]string, 0, 4)
 							} else {
-								v100 = []string{}
+								v103 = []string{}
 							}
 						} else {
-							v100 = (v100)[:0]
+							v103 = (v103)[:0]
 						}
 						for !in.IsDelim(']') {
-							var v101 string
-							v101 = string(in.String())
-							v100 = append(v100, v101)
+							var v104 string
+							v104 = string(in.String())
+							v103 = append(v103, v104)
 							in.WantComma()
 						}
 						in.Delim(']')
 					}
-					(out.Synonyms)[key] = v100
+					(out.Synonyms)[key] = v103
 					in.WantComma()
 				}
 				in.Delim('}')
@@ -4240,9 +4279,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo30(in *jlexer.Lexer,
 					out.FilterableAttributes = (out.FilterableAttributes)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v102 string
-					v102 = string(in.String())
-					out.FilterableAttributes = append(out.FilterableAttributes, v102)
+					var v105 string
+					v105 = string(in.String())
+					out.FilterableAttributes = append(out.FilterableAttributes, v105)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -4263,13 +4302,51 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo30(in *jlexer.Lexer,
 					out.SortableAttributes = (out.SortableAttributes)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v103 string
-					v103 = string(in.String())
-					out.SortableAttributes = append(out.SortableAttributes, v103)
+					var v106 string
+					v106 = string(in.String())
+					out.SortableAttributes = append(out.SortableAttributes, v106)
 					in.WantComma()
 				}
 				in.Delim(']')
 			}
+		case "typoTolerance":
+			if in.IsNull() {
+				in.Skip()
+				out.TypoTolerance = nil
+			} else {
+				if out.TypoTolerance == nil {
+					out.TypoTolerance = new(TypoTolerance)
+				}
+				(*out.TypoTolerance).UnmarshalEasyJSON(in)
+			}
+		case "pagination":
+			if in.IsNull() {
+				in.Skip()
+				out.Pagination = nil
+			} else {
+				if out.Pagination == nil {
+					out.Pagination = new(Pagination)
+				}
+				(*out.Pagination).UnmarshalEasyJSON(in)
+			}
+		case "faceting":
+			if in.IsNull() {
+				in.Skip()
+				out.Faceting = nil
+			} else {
+				if out.Faceting == nil {
+					out.Faceting = new(Faceting)
+				}
+				(*out.Faceting).UnmarshalEasyJSON(in)
+			}
+		case "matchedTasks":
+			out.MatchedTasks = int64(in.Int64())
+		case "canceledTasks":
+			out.CanceledTasks = int64(in.Int64())
+		case "deletedTasks":
+			out.DeletedTasks = int64(in.Int64())
+		case "originalFilter":
+			out.OriginalFilter = string(in.String())
 		default:
 			in.SkipRecursive()
 		}
@@ -4288,7 +4365,7 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo30(out *jwriter.Writ
 		const prefix string = ",\"receivedDocuments\":"
 		first = false
 		out.RawString(prefix[1:])
-		out.Int(int(in.ReceivedDocuments))
+		out.Int64(int64(in.ReceivedDocuments))
 	}
 	if in.IndexedDocuments != 0 {
 		const prefix string = ",\"indexedDocuments\":"
@@ -4298,7 +4375,7 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo30(out *jwriter.Writ
 		} else {
 			out.RawString(prefix)
 		}
-		out.Int(int(in.IndexedDocuments))
+		out.Int64(int64(in.IndexedDocuments))
 	}
 	if in.DeletedDocuments != 0 {
 		const prefix string = ",\"deletedDocuments\":"
@@ -4308,7 +4385,7 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo30(out *jwriter.Writ
 		} else {
 			out.RawString(prefix)
 		}
-		out.Int(int(in.DeletedDocuments))
+		out.Int64(int64(in.DeletedDocuments))
 	}
 	if in.PrimaryKey != "" {
 		const prefix string = ",\"primaryKey\":"
@@ -4320,6 +4397,16 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo30(out *jwriter.Writ
 		}
 		out.String(string(in.PrimaryKey))
 	}
+	if in.ProvidedIds != 0 {
+		const prefix string = ",\"providedIds\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.Int64(int64(in.ProvidedIds))
+	}
 	if len(in.RankingRules) != 0 {
 		const prefix string = ",\"rankingRules\":"
 		if first {
@@ -4330,11 +4417,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo30(out *jwriter.Writ
 		}
 		{
 			out.RawByte('[')
-			for v104, v105 := range in.RankingRules {
-				if v104 > 0 {
+			for v107, v108 := range in.RankingRules {
+				if v107 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v105))
+				out.String(string(v108))
 			}
 			out.RawByte(']')
 		}
@@ -4349,6 +4436,63 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo30(out *jwriter.Writ
 		}
 		out.String(string(*in.DistinctAttribute))
 	}
+	if len(in.SearchableAttributes) != 0 {
+		const prefix string = ",\"searchableAttributes\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		{
+			out.RawByte('[')
+			for v109, v110 := range in.SearchableAttributes {
+				if v109 > 0 {
+					out.RawByte(',')
+				}
+				out.String(string(v110))
+			}
+			out.RawByte(']')
+		}
+	}
+	if len(in.DisplayedAttributes) != 0 {
+		const prefix string = ",\"displayedAttributes\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		{
+			out.RawByte('[')
+			for v111, v112 := range in.DisplayedAttributes {
+				if v111 > 0 {
+					out.RawByte(',')
+				}
+				out.String(string(v112))
+			}
+			out.RawByte(']')
+		}
+	}
+	if len(in.StopWords) != 0 {
+		const prefix string = ",\"stopWords\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		{
+			out.RawByte('[')
+			for v113, v114 := range in.StopWords {
+				if v113 > 0 {
+					out.RawByte(',')
+				}
+				out.String(string(v114))
+			}
+			out.RawByte(']')
+		}
+	}
 	if len(in.Synonyms) != 0 {
 		const prefix string = ",\"synonyms\":"
 		if first {
@@ -4359,24 +4503,24 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo30(out *jwriter.Writ
 		}
 		{
 			out.RawByte('{')
-			v106First := true
-			for v106Name, v106Value := range in.Synonyms {
-				if v106First {
-					v106First = false
+			v115First := true
+			for v115Name, v115Value := range in.Synonyms {
+				if v115First {
+					v115First = false
 				} else {
 					out.RawByte(',')
 				}
-				out.String(string(v106Name))
+				out.String(string(v115Name))
 				out.RawByte(':')
-				if v106Value == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+				if v115Value == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
 					out.RawString("null")
 				} else {
 					out.RawByte('[')
-					for v107, v108 := range v106Value {
-						if v107 > 0 {
+					for v116, v117 := range v115Value {
+						if v116 > 0 {
 							out.RawByte(',')
 						}
-						out.String(string(v108))
+						out.String(string(v117))
 					}
 					out.RawByte(']')
 				}
@@ -4394,11 +4538,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo30(out *jwriter.Writ
 		}
 		{
 			out.RawByte('[')
-			for v109, v110 := range in.FilterableAttributes {
-				if v109 > 0 {
+			for v118, v119 := range in.FilterableAttributes {
+				if v118 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v110))
+				out.String(string(v119))
 			}
 			out.RawByte(']')
 		}
@@ -4413,14 +4557,84 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo30(out *jwriter.Writ
 		}
 		{
 			out.RawByte('[')
-			for v111, v112 := range in.SortableAttributes {
-				if v111 > 0 {
+			for v120, v121 := range in.SortableAttributes {
+				if v120 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v112))
+				out.String(string(v121))
 			}
 			out.RawByte(']')
 		}
+	}
+	if in.TypoTolerance != nil {
+		const prefix string = ",\"typoTolerance\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		(*in.TypoTolerance).MarshalEasyJSON(out)
+	}
+	if in.Pagination != nil {
+		const prefix string = ",\"pagination\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		(*in.Pagination).MarshalEasyJSON(out)
+	}
+	if in.Faceting != nil {
+		const prefix string = ",\"faceting\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		(*in.Faceting).MarshalEasyJSON(out)
+	}
+	if in.MatchedTasks != 0 {
+		const prefix string = ",\"matchedTasks\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.Int64(int64(in.MatchedTasks))
+	}
+	if in.CanceledTasks != 0 {
+		const prefix string = ",\"canceledTasks\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.Int64(int64(in.CanceledTasks))
+	}
+	if in.DeletedTasks != 0 {
+		const prefix string = ",\"deletedTasks\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.Int64(int64(in.DeletedTasks))
+	}
+	if in.OriginalFilter != "" {
+		const prefix string = ",\"originalFilter\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.OriginalFilter))
 	}
 	out.RawByte('}')
 }

--- a/types_easyjson.go
+++ b/types_easyjson.go
@@ -4802,7 +4802,7 @@ func (v *Details) UnmarshalJSON(data []byte) error {
 func (v *Details) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo31(l, v)
 }
-func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo31(in *jlexer.Lexer, out *DeleteTasksQuery) {
+func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo32(in *jlexer.Lexer, out *DeleteTasksQuery) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -4837,9 +4837,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo31(in *jlexer.Lexer,
 					out.UIDS = (out.UIDS)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v122 int64
-					v122 = int64(in.Int64())
-					out.UIDS = append(out.UIDS, v122)
+					var v128 int64
+					v128 = int64(in.Int64())
+					out.UIDS = append(out.UIDS, v128)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -4860,9 +4860,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo31(in *jlexer.Lexer,
 					out.IndexUIDS = (out.IndexUIDS)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v123 string
-					v123 = string(in.String())
-					out.IndexUIDS = append(out.IndexUIDS, v123)
+					var v129 string
+					v129 = string(in.String())
+					out.IndexUIDS = append(out.IndexUIDS, v129)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -4883,9 +4883,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo31(in *jlexer.Lexer,
 					out.Statuses = (out.Statuses)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v124 string
-					v124 = string(in.String())
-					out.Statuses = append(out.Statuses, v124)
+					var v130 string
+					v130 = string(in.String())
+					out.Statuses = append(out.Statuses, v130)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -4906,9 +4906,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo31(in *jlexer.Lexer,
 					out.Types = (out.Types)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v125 string
-					v125 = string(in.String())
-					out.Types = append(out.Types, v125)
+					var v131 string
+					v131 = string(in.String())
+					out.Types = append(out.Types, v131)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -4929,9 +4929,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo31(in *jlexer.Lexer,
 					out.CanceledBy = (out.CanceledBy)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v126 int64
-					v126 = int64(in.Int64())
-					out.CanceledBy = append(out.CanceledBy, v126)
+					var v132 int64
+					v132 = int64(in.Int64())
+					out.CanceledBy = append(out.CanceledBy, v132)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -4970,7 +4970,7 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo31(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo31(out *jwriter.Writer, in DeleteTasksQuery) {
+func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo32(out *jwriter.Writer, in DeleteTasksQuery) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4981,11 +4981,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo31(out *jwriter.Writ
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v127, v128 := range in.UIDS {
-				if v127 > 0 {
+			for v133, v134 := range in.UIDS {
+				if v133 > 0 {
 					out.RawByte(',')
 				}
-				out.Int64(int64(v128))
+				out.Int64(int64(v134))
 			}
 			out.RawByte(']')
 		}
@@ -4997,11 +4997,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo31(out *jwriter.Writ
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v129, v130 := range in.IndexUIDS {
-				if v129 > 0 {
+			for v135, v136 := range in.IndexUIDS {
+				if v135 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v130))
+				out.String(string(v136))
 			}
 			out.RawByte(']')
 		}
@@ -5013,11 +5013,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo31(out *jwriter.Writ
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v131, v132 := range in.Statuses {
-				if v131 > 0 {
+			for v137, v138 := range in.Statuses {
+				if v137 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v132))
+				out.String(string(v138))
 			}
 			out.RawByte(']')
 		}
@@ -5029,11 +5029,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo31(out *jwriter.Writ
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v133, v134 := range in.Types {
-				if v133 > 0 {
+			for v139, v140 := range in.Types {
+				if v139 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v134))
+				out.String(string(v140))
 			}
 			out.RawByte(']')
 		}
@@ -5045,11 +5045,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo31(out *jwriter.Writ
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v135, v136 := range in.CanceledBy {
-				if v135 > 0 {
+			for v141, v142 := range in.CanceledBy {
+				if v141 > 0 {
 					out.RawByte(',')
 				}
-				out.Int64(int64(v136))
+				out.Int64(int64(v142))
 			}
 			out.RawByte(']')
 		}
@@ -5090,27 +5090,27 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo31(out *jwriter.Writ
 // MarshalJSON supports json.Marshaler interface
 func (v DeleteTasksQuery) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo31(&w, v)
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo32(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v DeleteTasksQuery) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo31(w, v)
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo32(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *DeleteTasksQuery) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo31(&r, v)
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo32(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *DeleteTasksQuery) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo31(l, v)
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo32(l, v)
 }
-func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo32(in *jlexer.Lexer, out *CreateIndexRequest) {
+func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo33(in *jlexer.Lexer, out *CreateIndexRequest) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -5143,7 +5143,7 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo32(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo32(out *jwriter.Writer, in CreateIndexRequest) {
+func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo33(out *jwriter.Writer, in CreateIndexRequest) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -5169,27 +5169,27 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo32(out *jwriter.Writ
 // MarshalJSON supports json.Marshaler interface
 func (v CreateIndexRequest) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo32(&w, v)
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo33(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v CreateIndexRequest) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo32(w, v)
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo33(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *CreateIndexRequest) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo32(&r, v)
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo33(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *CreateIndexRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo32(l, v)
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo33(l, v)
 }
-func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo33(in *jlexer.Lexer, out *Client) {
+func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo34(in *jlexer.Lexer, out *Client) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -5218,7 +5218,7 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo33(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo33(out *jwriter.Writer, in Client) {
+func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo34(out *jwriter.Writer, in Client) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -5228,27 +5228,27 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo33(out *jwriter.Writ
 // MarshalJSON supports json.Marshaler interface
 func (v Client) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo33(&w, v)
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo34(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v Client) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo33(w, v)
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo34(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *Client) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo33(&r, v)
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo34(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *Client) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo33(l, v)
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo34(l, v)
 }
-func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo34(in *jlexer.Lexer, out *CancelTasksQuery) {
+func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo35(in *jlexer.Lexer, out *CancelTasksQuery) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -5283,9 +5283,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo34(in *jlexer.Lexer,
 					out.UIDS = (out.UIDS)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v137 int64
-					v137 = int64(in.Int64())
-					out.UIDS = append(out.UIDS, v137)
+					var v143 int64
+					v143 = int64(in.Int64())
+					out.UIDS = append(out.UIDS, v143)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -5306,9 +5306,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo34(in *jlexer.Lexer,
 					out.IndexUIDS = (out.IndexUIDS)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v138 string
-					v138 = string(in.String())
-					out.IndexUIDS = append(out.IndexUIDS, v138)
+					var v144 string
+					v144 = string(in.String())
+					out.IndexUIDS = append(out.IndexUIDS, v144)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -5329,9 +5329,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo34(in *jlexer.Lexer,
 					out.Statuses = (out.Statuses)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v139 string
-					v139 = string(in.String())
-					out.Statuses = append(out.Statuses, v139)
+					var v145 string
+					v145 = string(in.String())
+					out.Statuses = append(out.Statuses, v145)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -5352,9 +5352,9 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo34(in *jlexer.Lexer,
 					out.Types = (out.Types)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v140 string
-					v140 = string(in.String())
-					out.Types = append(out.Types, v140)
+					var v146 string
+					v146 = string(in.String())
+					out.Types = append(out.Types, v146)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -5385,7 +5385,7 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo34(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo34(out *jwriter.Writer, in CancelTasksQuery) {
+func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo35(out *jwriter.Writer, in CancelTasksQuery) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -5396,11 +5396,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo34(out *jwriter.Writ
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v141, v142 := range in.UIDS {
-				if v141 > 0 {
+			for v147, v148 := range in.UIDS {
+				if v147 > 0 {
 					out.RawByte(',')
 				}
-				out.Int64(int64(v142))
+				out.Int64(int64(v148))
 			}
 			out.RawByte(']')
 		}
@@ -5412,11 +5412,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo34(out *jwriter.Writ
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v143, v144 := range in.IndexUIDS {
-				if v143 > 0 {
+			for v149, v150 := range in.IndexUIDS {
+				if v149 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v144))
+				out.String(string(v150))
 			}
 			out.RawByte(']')
 		}
@@ -5428,11 +5428,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo34(out *jwriter.Writ
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v145, v146 := range in.Statuses {
-				if v145 > 0 {
+			for v151, v152 := range in.Statuses {
+				if v151 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v146))
+				out.String(string(v152))
 			}
 			out.RawByte(']')
 		}
@@ -5444,11 +5444,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo34(out *jwriter.Writ
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v147, v148 := range in.Types {
-				if v147 > 0 {
+			for v153, v154 := range in.Types {
+				if v153 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v148))
+				out.String(string(v154))
 			}
 			out.RawByte(']')
 		}
@@ -5479,23 +5479,23 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo34(out *jwriter.Writ
 // MarshalJSON supports json.Marshaler interface
 func (v CancelTasksQuery) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo34(&w, v)
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo35(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v CancelTasksQuery) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo34(w, v)
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo35(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *CancelTasksQuery) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo34(&r, v)
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo35(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *CancelTasksQuery) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo34(l, v)
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo35(l, v)
 }

--- a/types_easyjson.go
+++ b/types_easyjson.go
@@ -4800,3 +4800,254 @@ func (v *Client) UnmarshalJSON(data []byte) error {
 func (v *Client) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo32(l, v)
 }
+func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo33(in *jlexer.Lexer, out *CancelTasksQuery) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "UIDS":
+			if in.IsNull() {
+				in.Skip()
+				out.UIDS = nil
+			} else {
+				in.Delim('[')
+				if out.UIDS == nil {
+					if !in.IsDelim(']') {
+						out.UIDS = make([]int64, 0, 8)
+					} else {
+						out.UIDS = []int64{}
+					}
+				} else {
+					out.UIDS = (out.UIDS)[:0]
+				}
+				for !in.IsDelim(']') {
+					var v122 int64
+					v122 = int64(in.Int64())
+					out.UIDS = append(out.UIDS, v122)
+					in.WantComma()
+				}
+				in.Delim(']')
+			}
+		case "IndexUIDS":
+			if in.IsNull() {
+				in.Skip()
+				out.IndexUIDS = nil
+			} else {
+				in.Delim('[')
+				if out.IndexUIDS == nil {
+					if !in.IsDelim(']') {
+						out.IndexUIDS = make([]string, 0, 4)
+					} else {
+						out.IndexUIDS = []string{}
+					}
+				} else {
+					out.IndexUIDS = (out.IndexUIDS)[:0]
+				}
+				for !in.IsDelim(']') {
+					var v123 string
+					v123 = string(in.String())
+					out.IndexUIDS = append(out.IndexUIDS, v123)
+					in.WantComma()
+				}
+				in.Delim(']')
+			}
+		case "Statuses":
+			if in.IsNull() {
+				in.Skip()
+				out.Statuses = nil
+			} else {
+				in.Delim('[')
+				if out.Statuses == nil {
+					if !in.IsDelim(']') {
+						out.Statuses = make([]string, 0, 4)
+					} else {
+						out.Statuses = []string{}
+					}
+				} else {
+					out.Statuses = (out.Statuses)[:0]
+				}
+				for !in.IsDelim(']') {
+					var v124 string
+					v124 = string(in.String())
+					out.Statuses = append(out.Statuses, v124)
+					in.WantComma()
+				}
+				in.Delim(']')
+			}
+		case "Types":
+			if in.IsNull() {
+				in.Skip()
+				out.Types = nil
+			} else {
+				in.Delim('[')
+				if out.Types == nil {
+					if !in.IsDelim(']') {
+						out.Types = make([]string, 0, 4)
+					} else {
+						out.Types = []string{}
+					}
+				} else {
+					out.Types = (out.Types)[:0]
+				}
+				for !in.IsDelim(']') {
+					var v125 string
+					v125 = string(in.String())
+					out.Types = append(out.Types, v125)
+					in.WantComma()
+				}
+				in.Delim(']')
+			}
+		case "BeforeEnqueuedAt":
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.BeforeEnqueuedAt).UnmarshalJSON(data))
+			}
+		case "AfterEnqueuedAt":
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.AfterEnqueuedAt).UnmarshalJSON(data))
+			}
+		case "BeforeStartedAt":
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.BeforeStartedAt).UnmarshalJSON(data))
+			}
+		case "AfterStartedAt":
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.AfterStartedAt).UnmarshalJSON(data))
+			}
+		default:
+			in.SkipRecursive()
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo33(out *jwriter.Writer, in CancelTasksQuery) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	{
+		const prefix string = ",\"UIDS\":"
+		out.RawString(prefix[1:])
+		if in.UIDS == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+			out.RawString("null")
+		} else {
+			out.RawByte('[')
+			for v126, v127 := range in.UIDS {
+				if v126 > 0 {
+					out.RawByte(',')
+				}
+				out.Int64(int64(v127))
+			}
+			out.RawByte(']')
+		}
+	}
+	{
+		const prefix string = ",\"IndexUIDS\":"
+		out.RawString(prefix)
+		if in.IndexUIDS == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+			out.RawString("null")
+		} else {
+			out.RawByte('[')
+			for v128, v129 := range in.IndexUIDS {
+				if v128 > 0 {
+					out.RawByte(',')
+				}
+				out.String(string(v129))
+			}
+			out.RawByte(']')
+		}
+	}
+	{
+		const prefix string = ",\"Statuses\":"
+		out.RawString(prefix)
+		if in.Statuses == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+			out.RawString("null")
+		} else {
+			out.RawByte('[')
+			for v130, v131 := range in.Statuses {
+				if v130 > 0 {
+					out.RawByte(',')
+				}
+				out.String(string(v131))
+			}
+			out.RawByte(']')
+		}
+	}
+	{
+		const prefix string = ",\"Types\":"
+		out.RawString(prefix)
+		if in.Types == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+			out.RawString("null")
+		} else {
+			out.RawByte('[')
+			for v132, v133 := range in.Types {
+				if v132 > 0 {
+					out.RawByte(',')
+				}
+				out.String(string(v133))
+			}
+			out.RawByte(']')
+		}
+	}
+	{
+		const prefix string = ",\"BeforeEnqueuedAt\":"
+		out.RawString(prefix)
+		out.Raw((in.BeforeEnqueuedAt).MarshalJSON())
+	}
+	{
+		const prefix string = ",\"AfterEnqueuedAt\":"
+		out.RawString(prefix)
+		out.Raw((in.AfterEnqueuedAt).MarshalJSON())
+	}
+	{
+		const prefix string = ",\"BeforeStartedAt\":"
+		out.RawString(prefix)
+		out.Raw((in.BeforeStartedAt).MarshalJSON())
+	}
+	{
+		const prefix string = ",\"AfterStartedAt\":"
+		out.RawString(prefix)
+		out.Raw((in.AfterStartedAt).MarshalJSON())
+	}
+	out.RawByte('}')
+}
+
+// MarshalJSON supports json.Marshaler interface
+func (v CancelTasksQuery) MarshalJSON() ([]byte, error) {
+	w := jwriter.Writer{}
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo33(&w, v)
+	return w.Buffer.BuildBytes(), w.Error
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v CancelTasksQuery) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo33(w, v)
+}
+
+// UnmarshalJSON supports json.Unmarshaler interface
+func (v *CancelTasksQuery) UnmarshalJSON(data []byte) error {
+	r := jlexer.Lexer{Data: data}
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo33(&r, v)
+	return r.Error()
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *CancelTasksQuery) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo33(l, v)
+}


### PR DESCRIPTION
Add the cancel task api see spec:  https://github.com/meilisearch/specifications/pull/195

- [x] Update `Task` structure
  - [x] Add `canceledBy`
- [x] Update `TaskInfo` structure
  - [x] All parameters `Status`, `Type`, `TaskUID`, `IndexUID` and `EnqueuedAt` are no longer optional.
- [x] Implement `CancelTasks()` in the client
  - params: `TasksQuery`
  - returns: `TaskInfo`
- [x] add new `Tasks.Details` fields:
   - [x] matchedTasks
   - [x] canceledTasks
   - [x] originalFilters
- [x] Tests cancelation on query parameters
- [x] Test on new details