### PR TITLE
Add delete task api for v0.30.0

### DIFF
--- a/client.go
+++ b/client.go
@@ -55,6 +55,7 @@ type ClientInterface interface {
 	GetTask(taskUID int64) (resp *Task, err error)
 	GetTasks(param *TasksQuery) (resp *TaskResult, err error)
 	CancelTasks(param *CancelTasksQuery) (resp *TaskInfo, err error)
+	DeleteTasks(param *DeleteTasksQuery) (resp *TaskInfo, err error)
 	WaitForTask(taskUID int64, options ...WaitParams) (*Task, error)
 	GenerateTenantToken(APIKeyUID string, searchRules map[string]interface{}, options *TenantTokenOptions) (resp string, err error)
 }
@@ -307,6 +308,39 @@ func (c *Client) CancelTasks(param *CancelTasksQuery) (resp *TaskInfo, err error
 			AfterEnqueuedAt:  param.AfterEnqueuedAt,
 			BeforeStartedAt:  param.BeforeStartedAt,
 			AfterStartedAt:   param.AfterStartedAt,
+		}
+		encodeTasksQuery(paramToSend, &req)
+	}
+	if err := c.executeRequest(req); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (c *Client) DeleteTasks(param *DeleteTasksQuery) (resp *TaskInfo, err error) {
+	resp = &TaskInfo{}
+	req := internalRequest{
+		endpoint:            "/tasks",
+		method:              http.MethodDelete,
+		withRequest:         nil,
+		withResponse:        &resp,
+		withQueryParams:     map[string]string{},
+		acceptedStatusCodes: []int{http.StatusOK},
+		functionName:        "DeleteTasks",
+	}
+	if param != nil {
+		paramToSend := &TasksQuery{
+			UIDS:             param.UIDS,
+			IndexUIDS:        param.IndexUIDS,
+			Statuses:         param.Statuses,
+			Types:            param.Types,
+			CanceledBy:       param.CanceledBy,
+			BeforeEnqueuedAt: param.BeforeEnqueuedAt,
+			AfterEnqueuedAt:  param.AfterEnqueuedAt,
+			BeforeStartedAt:  param.BeforeStartedAt,
+			AfterStartedAt:   param.AfterStartedAt,
+			BeforeFinishedAt: param.BeforeFinishedAt,
+			AfterFinishedAt:  param.AfterFinishedAt,
 		}
 		encodeTasksQuery(paramToSend, &req)
 	}

--- a/types.go
+++ b/types.go
@@ -173,6 +173,21 @@ type CancelTasksQuery struct {
 	AfterStartedAt   time.Time
 }
 
+// DeleteTasksQuery is a list of filter available to send as query parameters
+type DeleteTasksQuery struct {
+	UIDS             []int64
+	IndexUIDS        []string
+	Statuses         []string
+	Types            []string
+	CanceledBy       []int64
+	BeforeEnqueuedAt time.Time
+	AfterEnqueuedAt  time.Time
+	BeforeStartedAt  time.Time
+	AfterStartedAt   time.Time
+	BeforeFinishedAt time.Time
+	AfterFinishedAt  time.Time
+}
+
 type Details struct {
 	ReceivedDocuments    int64               `json:"receivedDocuments,omitempty"`
 	IndexedDocuments     int64               `json:"indexedDocuments,omitempty"`

--- a/types_easyjson.go
+++ b/types_easyjson.go
@@ -4662,145 +4662,7 @@ func (v *Details) UnmarshalJSON(data []byte) error {
 func (v *Details) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo30(l, v)
 }
-func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo31(in *jlexer.Lexer, out *CreateIndexRequest) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "uid":
-			out.UID = string(in.String())
-		case "primaryKey":
-			out.PrimaryKey = string(in.String())
-		default:
-			in.SkipRecursive()
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo31(out *jwriter.Writer, in CreateIndexRequest) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	if in.UID != "" {
-		const prefix string = ",\"uid\":"
-		first = false
-		out.RawString(prefix[1:])
-		out.String(string(in.UID))
-	}
-	if in.PrimaryKey != "" {
-		const prefix string = ",\"primaryKey\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		out.String(string(in.PrimaryKey))
-	}
-	out.RawByte('}')
-}
-
-// MarshalJSON supports json.Marshaler interface
-func (v CreateIndexRequest) MarshalJSON() ([]byte, error) {
-	w := jwriter.Writer{}
-	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo31(&w, v)
-	return w.Buffer.BuildBytes(), w.Error
-}
-
-// MarshalEasyJSON supports easyjson.Marshaler interface
-func (v CreateIndexRequest) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo31(w, v)
-}
-
-// UnmarshalJSON supports json.Unmarshaler interface
-func (v *CreateIndexRequest) UnmarshalJSON(data []byte) error {
-	r := jlexer.Lexer{Data: data}
-	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo31(&r, v)
-	return r.Error()
-}
-
-// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *CreateIndexRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo31(l, v)
-}
-func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo32(in *jlexer.Lexer, out *Client) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		default:
-			in.SkipRecursive()
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo32(out *jwriter.Writer, in Client) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	out.RawByte('}')
-}
-
-// MarshalJSON supports json.Marshaler interface
-func (v Client) MarshalJSON() ([]byte, error) {
-	w := jwriter.Writer{}
-	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo32(&w, v)
-	return w.Buffer.BuildBytes(), w.Error
-}
-
-// MarshalEasyJSON supports easyjson.Marshaler interface
-func (v Client) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo32(w, v)
-}
-
-// UnmarshalJSON supports json.Unmarshaler interface
-func (v *Client) UnmarshalJSON(data []byte) error {
-	r := jlexer.Lexer{Data: data}
-	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo32(&r, v)
-	return r.Error()
-}
-
-// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *Client) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo32(l, v)
-}
-func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo33(in *jlexer.Lexer, out *CancelTasksQuery) {
+func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo31(in *jlexer.Lexer, out *DeleteTasksQuery) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -4911,6 +4773,452 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo33(in *jlexer.Lexer,
 				}
 				in.Delim(']')
 			}
+		case "CanceledBy":
+			if in.IsNull() {
+				in.Skip()
+				out.CanceledBy = nil
+			} else {
+				in.Delim('[')
+				if out.CanceledBy == nil {
+					if !in.IsDelim(']') {
+						out.CanceledBy = make([]int64, 0, 8)
+					} else {
+						out.CanceledBy = []int64{}
+					}
+				} else {
+					out.CanceledBy = (out.CanceledBy)[:0]
+				}
+				for !in.IsDelim(']') {
+					var v126 int64
+					v126 = int64(in.Int64())
+					out.CanceledBy = append(out.CanceledBy, v126)
+					in.WantComma()
+				}
+				in.Delim(']')
+			}
+		case "BeforeEnqueuedAt":
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.BeforeEnqueuedAt).UnmarshalJSON(data))
+			}
+		case "AfterEnqueuedAt":
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.AfterEnqueuedAt).UnmarshalJSON(data))
+			}
+		case "BeforeStartedAt":
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.BeforeStartedAt).UnmarshalJSON(data))
+			}
+		case "AfterStartedAt":
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.AfterStartedAt).UnmarshalJSON(data))
+			}
+		case "BeforeFinishedAt":
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.BeforeFinishedAt).UnmarshalJSON(data))
+			}
+		case "AfterFinishedAt":
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.AfterFinishedAt).UnmarshalJSON(data))
+			}
+		default:
+			in.SkipRecursive()
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo31(out *jwriter.Writer, in DeleteTasksQuery) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	{
+		const prefix string = ",\"UIDS\":"
+		out.RawString(prefix[1:])
+		if in.UIDS == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+			out.RawString("null")
+		} else {
+			out.RawByte('[')
+			for v127, v128 := range in.UIDS {
+				if v127 > 0 {
+					out.RawByte(',')
+				}
+				out.Int64(int64(v128))
+			}
+			out.RawByte(']')
+		}
+	}
+	{
+		const prefix string = ",\"IndexUIDS\":"
+		out.RawString(prefix)
+		if in.IndexUIDS == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+			out.RawString("null")
+		} else {
+			out.RawByte('[')
+			for v129, v130 := range in.IndexUIDS {
+				if v129 > 0 {
+					out.RawByte(',')
+				}
+				out.String(string(v130))
+			}
+			out.RawByte(']')
+		}
+	}
+	{
+		const prefix string = ",\"Statuses\":"
+		out.RawString(prefix)
+		if in.Statuses == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+			out.RawString("null")
+		} else {
+			out.RawByte('[')
+			for v131, v132 := range in.Statuses {
+				if v131 > 0 {
+					out.RawByte(',')
+				}
+				out.String(string(v132))
+			}
+			out.RawByte(']')
+		}
+	}
+	{
+		const prefix string = ",\"Types\":"
+		out.RawString(prefix)
+		if in.Types == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+			out.RawString("null")
+		} else {
+			out.RawByte('[')
+			for v133, v134 := range in.Types {
+				if v133 > 0 {
+					out.RawByte(',')
+				}
+				out.String(string(v134))
+			}
+			out.RawByte(']')
+		}
+	}
+	{
+		const prefix string = ",\"CanceledBy\":"
+		out.RawString(prefix)
+		if in.CanceledBy == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+			out.RawString("null")
+		} else {
+			out.RawByte('[')
+			for v135, v136 := range in.CanceledBy {
+				if v135 > 0 {
+					out.RawByte(',')
+				}
+				out.Int64(int64(v136))
+			}
+			out.RawByte(']')
+		}
+	}
+	{
+		const prefix string = ",\"BeforeEnqueuedAt\":"
+		out.RawString(prefix)
+		out.Raw((in.BeforeEnqueuedAt).MarshalJSON())
+	}
+	{
+		const prefix string = ",\"AfterEnqueuedAt\":"
+		out.RawString(prefix)
+		out.Raw((in.AfterEnqueuedAt).MarshalJSON())
+	}
+	{
+		const prefix string = ",\"BeforeStartedAt\":"
+		out.RawString(prefix)
+		out.Raw((in.BeforeStartedAt).MarshalJSON())
+	}
+	{
+		const prefix string = ",\"AfterStartedAt\":"
+		out.RawString(prefix)
+		out.Raw((in.AfterStartedAt).MarshalJSON())
+	}
+	{
+		const prefix string = ",\"BeforeFinishedAt\":"
+		out.RawString(prefix)
+		out.Raw((in.BeforeFinishedAt).MarshalJSON())
+	}
+	{
+		const prefix string = ",\"AfterFinishedAt\":"
+		out.RawString(prefix)
+		out.Raw((in.AfterFinishedAt).MarshalJSON())
+	}
+	out.RawByte('}')
+}
+
+// MarshalJSON supports json.Marshaler interface
+func (v DeleteTasksQuery) MarshalJSON() ([]byte, error) {
+	w := jwriter.Writer{}
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo31(&w, v)
+	return w.Buffer.BuildBytes(), w.Error
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v DeleteTasksQuery) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo31(w, v)
+}
+
+// UnmarshalJSON supports json.Unmarshaler interface
+func (v *DeleteTasksQuery) UnmarshalJSON(data []byte) error {
+	r := jlexer.Lexer{Data: data}
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo31(&r, v)
+	return r.Error()
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *DeleteTasksQuery) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo31(l, v)
+}
+func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo32(in *jlexer.Lexer, out *CreateIndexRequest) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "uid":
+			out.UID = string(in.String())
+		case "primaryKey":
+			out.PrimaryKey = string(in.String())
+		default:
+			in.SkipRecursive()
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo32(out *jwriter.Writer, in CreateIndexRequest) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	if in.UID != "" {
+		const prefix string = ",\"uid\":"
+		first = false
+		out.RawString(prefix[1:])
+		out.String(string(in.UID))
+	}
+	if in.PrimaryKey != "" {
+		const prefix string = ",\"primaryKey\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.PrimaryKey))
+	}
+	out.RawByte('}')
+}
+
+// MarshalJSON supports json.Marshaler interface
+func (v CreateIndexRequest) MarshalJSON() ([]byte, error) {
+	w := jwriter.Writer{}
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo32(&w, v)
+	return w.Buffer.BuildBytes(), w.Error
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v CreateIndexRequest) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo32(w, v)
+}
+
+// UnmarshalJSON supports json.Unmarshaler interface
+func (v *CreateIndexRequest) UnmarshalJSON(data []byte) error {
+	r := jlexer.Lexer{Data: data}
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo32(&r, v)
+	return r.Error()
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *CreateIndexRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo32(l, v)
+}
+func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo33(in *jlexer.Lexer, out *Client) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		default:
+			in.SkipRecursive()
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo33(out *jwriter.Writer, in Client) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	out.RawByte('}')
+}
+
+// MarshalJSON supports json.Marshaler interface
+func (v Client) MarshalJSON() ([]byte, error) {
+	w := jwriter.Writer{}
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo33(&w, v)
+	return w.Buffer.BuildBytes(), w.Error
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v Client) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo33(w, v)
+}
+
+// UnmarshalJSON supports json.Unmarshaler interface
+func (v *Client) UnmarshalJSON(data []byte) error {
+	r := jlexer.Lexer{Data: data}
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo33(&r, v)
+	return r.Error()
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *Client) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo33(l, v)
+}
+func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo34(in *jlexer.Lexer, out *CancelTasksQuery) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "UIDS":
+			if in.IsNull() {
+				in.Skip()
+				out.UIDS = nil
+			} else {
+				in.Delim('[')
+				if out.UIDS == nil {
+					if !in.IsDelim(']') {
+						out.UIDS = make([]int64, 0, 8)
+					} else {
+						out.UIDS = []int64{}
+					}
+				} else {
+					out.UIDS = (out.UIDS)[:0]
+				}
+				for !in.IsDelim(']') {
+					var v137 int64
+					v137 = int64(in.Int64())
+					out.UIDS = append(out.UIDS, v137)
+					in.WantComma()
+				}
+				in.Delim(']')
+			}
+		case "IndexUIDS":
+			if in.IsNull() {
+				in.Skip()
+				out.IndexUIDS = nil
+			} else {
+				in.Delim('[')
+				if out.IndexUIDS == nil {
+					if !in.IsDelim(']') {
+						out.IndexUIDS = make([]string, 0, 4)
+					} else {
+						out.IndexUIDS = []string{}
+					}
+				} else {
+					out.IndexUIDS = (out.IndexUIDS)[:0]
+				}
+				for !in.IsDelim(']') {
+					var v138 string
+					v138 = string(in.String())
+					out.IndexUIDS = append(out.IndexUIDS, v138)
+					in.WantComma()
+				}
+				in.Delim(']')
+			}
+		case "Statuses":
+			if in.IsNull() {
+				in.Skip()
+				out.Statuses = nil
+			} else {
+				in.Delim('[')
+				if out.Statuses == nil {
+					if !in.IsDelim(']') {
+						out.Statuses = make([]string, 0, 4)
+					} else {
+						out.Statuses = []string{}
+					}
+				} else {
+					out.Statuses = (out.Statuses)[:0]
+				}
+				for !in.IsDelim(']') {
+					var v139 string
+					v139 = string(in.String())
+					out.Statuses = append(out.Statuses, v139)
+					in.WantComma()
+				}
+				in.Delim(']')
+			}
+		case "Types":
+			if in.IsNull() {
+				in.Skip()
+				out.Types = nil
+			} else {
+				in.Delim('[')
+				if out.Types == nil {
+					if !in.IsDelim(']') {
+						out.Types = make([]string, 0, 4)
+					} else {
+						out.Types = []string{}
+					}
+				} else {
+					out.Types = (out.Types)[:0]
+				}
+				for !in.IsDelim(']') {
+					var v140 string
+					v140 = string(in.String())
+					out.Types = append(out.Types, v140)
+					in.WantComma()
+				}
+				in.Delim(']')
+			}
 		case "BeforeEnqueuedAt":
 			if data := in.Raw(); in.Ok() {
 				in.AddError((out.BeforeEnqueuedAt).UnmarshalJSON(data))
@@ -4937,7 +5245,7 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo33(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo33(out *jwriter.Writer, in CancelTasksQuery) {
+func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo34(out *jwriter.Writer, in CancelTasksQuery) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4948,11 +5256,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo33(out *jwriter.Writ
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v126, v127 := range in.UIDS {
-				if v126 > 0 {
+			for v141, v142 := range in.UIDS {
+				if v141 > 0 {
 					out.RawByte(',')
 				}
-				out.Int64(int64(v127))
+				out.Int64(int64(v142))
 			}
 			out.RawByte(']')
 		}
@@ -4964,11 +5272,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo33(out *jwriter.Writ
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v128, v129 := range in.IndexUIDS {
-				if v128 > 0 {
+			for v143, v144 := range in.IndexUIDS {
+				if v143 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v129))
+				out.String(string(v144))
 			}
 			out.RawByte(']')
 		}
@@ -4980,11 +5288,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo33(out *jwriter.Writ
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v130, v131 := range in.Statuses {
-				if v130 > 0 {
+			for v145, v146 := range in.Statuses {
+				if v145 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v131))
+				out.String(string(v146))
 			}
 			out.RawByte(']')
 		}
@@ -4996,11 +5304,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo33(out *jwriter.Writ
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v132, v133 := range in.Types {
-				if v132 > 0 {
+			for v147, v148 := range in.Types {
+				if v147 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v133))
+				out.String(string(v148))
 			}
 			out.RawByte(']')
 		}
@@ -5031,23 +5339,23 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo33(out *jwriter.Writ
 // MarshalJSON supports json.Marshaler interface
 func (v CancelTasksQuery) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo33(&w, v)
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo34(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v CancelTasksQuery) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo33(w, v)
+	easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo34(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *CancelTasksQuery) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo33(&r, v)
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo34(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *CancelTasksQuery) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo33(l, v)
+	easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo34(l, v)
 }


### PR DESCRIPTION
Add the delete task api see spec:  https://github.com/meilisearch/specifications/pull/198

- [x] Implement `DeleteTasks()` in the client
  - params: `TasksQuery`
  - returns: `TaskInfo`
- [x] Tests deletion on query parameters
- [x] Test on details