### PR TITLE
Update version for the next release (0.22.0)

### DIFF
--- a/version.go
+++ b/version.go
@@ -2,7 +2,7 @@ package meilisearch
 
 import "fmt"
 
-const VERSION = "0.21.1"
+const VERSION = "0.22.0"
 
 func GetQualifiedVersion() (qualifiedVersion string) {
 	return getQualifiedVersion(VERSION)


### PR DESCRIPTION
This version makes this package compatible with Meilisearch v0.30.0 :tada:
Check out the changelog of [Meilisearch v0.30.0](https://github.com/meilisearch/meilisearch/releases/tag/v0.30.0) for more information on the changes.

## 🚀 Enhancements

- New `pagination` strategy with the search parameters `Page` and `HitsPerPage` #392
- New filters on `GetTasks`: `UID`, `BeforeEnqueuedAt`, `AfterEnqueuedAt`, ... see #390 
- New `client.CancelTasks` method that lets you cancel `enqueued` and `processing` tasks #395
- New `client.DeleteTasks` method that lets you delete tasks #396 
- New `client.SwapIndexes` method that lets you swap two indexes #397
- New fields on `Task.Details` #395

## ⚠️ Breaking change

- Parameters on `GetTasks` name changes: #390
   - `Status` -> `Statuses`
   - `IndexUID` -> `IndexUIDS`
   - `Type` -> `Types`
