### PR TITLE
Add yaml linter test in ci

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -290,7 +290,7 @@ getting_started_typo_tolerance: |-
       OneTypo: 4,
     },
   })
-get_typo_tolerance_1:
+get_typo_tolerance_1: |-
   client.Index("books").GetTypoTolerance()
 update_typo_tolerance_1: |-
   client.Index("books").UpdateTypoTolerance(&meilisearch.TypoTolerance{
@@ -302,7 +302,7 @@ update_typo_tolerance_1: |-
   })
 reset_typo_tolerance_1: |-
   client.Index("books").ResetTypoTolerance()
-get_pagination_settings_1:
+get_pagination_settings_1: |-
   client.Index("books").GetPagination()
 update_pagination_settings_1: |-
   client.Index("books").UpdatePagination(&meilisearch.Pagination{
@@ -310,7 +310,7 @@ update_pagination_settings_1: |-
   })
 reset_pagination_settings_1: |-
   client.Index("books").ResetPagination()
-get_faceting_settings_1:
+get_faceting_settings_1: |-
   client.Index("books").GetFaceting()
 update_faceting_settings_1: |-
   client.Index("books").UpdateFaceting(&meilisearch.Faceting{
@@ -588,18 +588,18 @@ getting_started_search_md: |-
 
   [About this SDK](https://github.com/meilisearch/meilisearch-go/)
 getting_started_add_meteorites: |-
-    client := meilisearch.NewClient(meilisearch.ClientConfig{
-      Host: "http://localhost:7700",
-    })
+  client := meilisearch.NewClient(meilisearch.ClientConfig{
+    Host: "http://localhost:7700",
+  })
 
-    jsonFile, _ := os.Open("meteorites.json")
-    defer jsonFile.Close()
+  jsonFile, _ := os.Open("meteorites.json")
+  defer jsonFile.Close()
 
-    byteValue, _ := io.ReadAll(jsonFile)
-    var meteorites []map[string]interface{}
-    json.Unmarshal(byteValue, &meteorites)
+  byteValue, _ := io.ReadAll(jsonFile)
+  var meteorites []map[string]interface{}
+  json.Unmarshal(byteValue, &meteorites)
 
-    client.Index("meteorites").AddDocuments(meteorites)
+  client.Index("meteorites").AddDocuments(meteorites)
 getting_started_update_ranking_rules: |-
   rankingRules := []string{
     "exactness",
@@ -848,13 +848,3 @@ tenant_token_guide_search_sdk_1: |-
     APIKey: token,
   })
   frontEndClient.Index("patient_medical_records").Search("blood test", &meilisearch.SearchRequest{});
-get_all_tasks_paginating_1: |-
-  client.GetTasks(&meilisearch.TasksQuery{
-    Limit: 2,
-    From: 10,
-  });
-get_all_tasks_paginating_2: |-
-  client.GetTasks(&meilisearch.TasksQuery{
-    Limit: 2,
-    From: 8,
-  });

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,21 +1,21 @@
 version: 2
 updates:
-- package-ecosystem: "github-actions"
-  directory: "/"
-  schedule:
-    interval: "monthly"
-  labels:
-    - 'skip-changelog'
-    - 'dependencies'
-  rebase-strategy: disabled
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'monthly'
+    labels:
+      - 'skip-changelog'
+      - 'dependencies'
+    rebase-strategy: disabled
 
-- package-ecosystem: gomod
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "04:00"
-  open-pull-requests-limit: 10
-  labels:
-  - skip-changelog
-  - dependencies
-  rebase-strategy: disabled
+  - package-ecosystem: gomod
+    directory: '/'
+    schedule:
+      interval: daily
+      time: '04:00'
+    open-pull-requests-limit: 10
+    labels:
+      - skip-changelog
+      - dependencies
+    rebase-strategy: disabled

--- a/.github/workflows/pre-release-tests.yml
+++ b/.github/workflows/pre-release-tests.yml
@@ -9,37 +9,36 @@ on:
     branches: bump-meilisearch-v*
 
 jobs:
-
   integration_tests:
     runs-on: ubuntu-latest
     strategy:
-        matrix:
-          # Current go.mod version and latest stable go version
-          go: [1.16, 1.17]
-          include:
-            - go: 1.16
-              tag: current
-            - go: 1.17
-              tag: latest
+      matrix:
+        # Current go.mod version and latest stable go version
+        go: [1.16, 1.17]
+        include:
+          - go: 1.16
+            tag: current
+          - go: 1.17
+            tag: latest
 
     name: integration-tests-against-rc (go ${{ matrix.tag }} version)
     steps:
-    - name: Set up Go ${{ matrix.go }}
-      uses: actions/setup-go@v3
-      with:
-        go-version: ${{ matrix.go }}
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
-    - name: Get dependencies
-      run: |
-        go get -v -t -d ./...
-        if [ -f Gopkg.toml ]; then
-          curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-          dep ensure
-        fi
-    - name: Get the latest Meilisearch RC
-      run: echo "MEILISEARCH_VERSION=$(curl https://raw.githubusercontent.com/meilisearch/integration-guides/main/scripts/get-latest-meilisearch-rc.sh | bash)" >> $GITHUB_ENV
-    - name: Meilisearch (${{ env.MEILISEARCH_VERSION }}) setup with Docker
-      run: docker run -d -p 7700:7700 getmeili/meilisearch:${{ env.MEILISEARCH_VERSION }} meilisearch --master-key=masterKey --no-analytics
-    - name: Run integration tests
-      run: go test -v ./...
+      - name: Set up Go ${{ matrix.go }}
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go }}
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+      - name: Get dependencies
+        run: |
+          go get -v -t -d ./...
+          if [ -f Gopkg.toml ]; then
+            curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+            dep ensure
+          fi
+      - name: Get the latest Meilisearch RC
+        run: echo "MEILISEARCH_VERSION=$(curl https://raw.githubusercontent.com/meilisearch/integration-guides/main/scripts/get-latest-meilisearch-rc.sh | bash)" >> $GITHUB_ENV
+      - name: Meilisearch (${{ env.MEILISEARCH_VERSION }}) setup with Docker
+        run: docker run -d -p 7700:7700 getmeili/meilisearch:${{ env.MEILISEARCH_VERSION }} meilisearch --master-key=masterKey --no-analytics
+      - name: Run integration tests
+        run: go test -v ./...

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -3,7 +3,7 @@ name: Validate release version
 on:
   push:
     tags:
-      - "[0-9]+.[0-9]+.[0-9]+"
+      - '[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   publish:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,16 +14,20 @@ jobs:
     name: linter
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-go@v3
-      with:
-        go-version: 1.17
-    - uses: actions/checkout@v3
-    - name: golangci-lint
-      uses: golangci/golangci-lint-action@v3
-      with:
-        version: v1.45.2
-    - name: Run go vet
-      run: go vet
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.17
+      - uses: actions/checkout@v3
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.45.2
+      - name: Run go vet
+        run: go vet
+      - name: Yaml linter
+        uses: ibiqlik/action-yamllint@v3
+        with:
+          config_file: .yamllint.yml
 
   integration_tests:
     runs-on: ubuntu-latest
@@ -31,31 +35,31 @@ jobs:
     # Will still run for each push to bump-meilisearch-v*
     if: github.event_name != 'pull_request' || !startsWith(github.base_ref, 'bump-meilisearch-v')
     strategy:
-        matrix:
-          # Current go.mod version and latest stable go version
-          go: [1.16, 1.17]
-          include:
-            - go: 1.16
-              tag: current
-            - go: 1.17
-              tag: latest
+      matrix:
+        # Current go.mod version and latest stable go version
+        go: [1.16, 1.17]
+        include:
+          - go: 1.16
+            tag: current
+          - go: 1.17
+            tag: latest
 
     name: integration-tests (go ${{ matrix.tag }} version)
     steps:
-    - name: Set up Go ${{ matrix.go }}
-      uses: actions/setup-go@v3
-      with:
-        go-version: ${{ matrix.go }}
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
-    - name: Get dependencies
-      run: |
-        go get -v -t -d ./...
-        if [ -f Gopkg.toml ]; then
-          curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-          dep ensure
-        fi
-    - name: Meilisearch setup (latest version) with Docker
-      run: docker run -d -p 7700:7700 getmeili/meilisearch:latest meilisearch --master-key=masterKey --no-analytics
-    - name: Run integration tests
-      run: go test -v ./...
+      - name: Set up Go ${{ matrix.go }}
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go }}
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+      - name: Get dependencies
+        run: |
+          go get -v -t -d ./...
+          if [ -f Gopkg.toml ]; then
+            curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+            dep ensure
+          fi
+      - name: Meilisearch setup (latest version) with Docker
+        run: docker run -d -p 7700:7700 getmeili/meilisearch:latest meilisearch --master-key=masterKey --no-analytics
+      - name: Run integration tests
+        run: go test -v ./...

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,9 @@
+extends: default
+ignore: |
+  node_modules
+
+rules:
+  line-length: disable
+  document-start: disable
+  brackets: disable
+  truthy: disable


### PR DESCRIPTION
To ensure no yaml file are broken, I added a linter test on the yaml files. 
This ensures they are correctly formated and correctly linted.

To test it locally you need to use the [`yamllint` tool](https://github.com/adrienverge/yamllint) and then run it like that:

```
yamllint .
```

Example of output

<img width="883" alt="Screenshot 2022-12-22 at 14 22 38" src="https://user-images.githubusercontent.com/33010418/209143467-a9cdf07d-1b08-4379-9401-8c42cad0a397.png">
