### PR TITLE
`Limit` redefinition in `DocumentsQuery`

### DIFF
--- a/index_documents.go
+++ b/index_documents.go
@@ -45,8 +45,8 @@ func (i Index) GetDocuments(request *DocumentsQuery, resp *DocumentsResult) erro
 		functionName:        "GetDocuments",
 	}
 	if request != nil {
-		if request.Limit != 0 {
-			req.withQueryParams["limit"] = strconv.FormatInt(request.Limit, 10)
+		if *request.Limit != 0 {
+			req.withQueryParams["limit"] = strconv.FormatInt(*request.Limit, 10)
 		}
 		if request.Offset != 0 {
 			req.withQueryParams["offset"] = strconv.FormatInt(request.Offset, 10)
@@ -413,4 +413,9 @@ func (i Index) DeleteAllDocuments() (resp *TaskInfo, err error) {
 		return nil, err
 	}
 	return resp, nil
+}
+
+// Helper function to create a pointer to int64
+func int64p(i int64) *int64 {
+	return &i
 }

--- a/index_documents_test.go
+++ b/index_documents_test.go
@@ -205,7 +205,7 @@ func TestIndex_AddDocuments(t *testing.T) {
 			testWaitForTask(t, i, gotResp)
 			var documents DocumentsResult
 			err = i.GetDocuments(&DocumentsQuery{
-				Limit: 3,
+				Limit: int64p(3),
 			}, &documents)
 			require.NoError(t, err)
 			require.Equal(t, tt.resp.documentsRes, documents)
@@ -386,7 +386,7 @@ func TestIndex_AddDocumentsWithPrimaryKey(t *testing.T) {
 			testWaitForTask(t, i, gotResp)
 
 			var documents DocumentsResult
-			err = i.GetDocuments(&DocumentsQuery{Limit: 3}, &documents)
+			err = i.GetDocuments(&DocumentsQuery{Limit: int64p(3)}, &documents)
 			require.NoError(t, err)
 			require.Equal(t, tt.resp.documentsRes, documents)
 		})
@@ -499,7 +499,7 @@ func TestIndex_AddDocumentsInBatches(t *testing.T) {
 
 			var documents DocumentsResult
 			err = i.GetDocuments(&DocumentsQuery{
-				Limit: 4,
+				Limit: int64p(4),
 			}, &documents)
 
 			require.NoError(t, err)
@@ -528,7 +528,7 @@ func TestIndex_AddDocumentsInBatches(t *testing.T) {
 
 			var documents DocumentsResult
 			err = i.GetDocuments(&DocumentsQuery{
-				Limit: 4,
+				Limit: int64p(4),
 			}, &documents)
 
 			require.NoError(t, err)
@@ -1004,7 +1004,7 @@ func TestIndex_DeleteAllDocuments(t *testing.T) {
 			testWaitForTask(t, i, gotResp)
 
 			var documents DocumentsResult
-			err = i.GetDocuments(&DocumentsQuery{Limit: 5}, &documents)
+			err = i.GetDocuments(&DocumentsQuery{Limit: int64p(5)}, &documents)
 			require.NoError(t, err)
 			require.Empty(t, documents.Results)
 		})
@@ -1401,7 +1401,7 @@ func TestIndex_GetDocuments(t *testing.T) {
 				UID:    "TestIndexGetDocumentsWithNoExistingDocument",
 				client: defaultClient,
 				request: &DocumentsQuery{
-					Limit: 3,
+					Limit: int64p(3),
 				},
 				resp: &DocumentsResult{},
 			},
@@ -1427,7 +1427,7 @@ func TestIndex_GetDocuments(t *testing.T) {
 
 			err := i.GetDocuments(tt.args.request, tt.args.resp)
 			require.NoError(t, err)
-			if tt.args.request != nil && tt.args.request.Limit != 0 {
+			if tt.args.request != nil && *tt.args.request.Limit != 0 {
 				require.Equal(t, tt.args.request.Limit, int64(len(tt.args.resp.Results)))
 			} else {
 				require.Equal(t, 6, len(tt.args.resp.Results))

--- a/types.go
+++ b/types.go
@@ -340,7 +340,7 @@ type DocumentQuery struct {
 // DocumentsQuery is the request body for list documents method
 type DocumentsQuery struct {
 	Offset int64    `json:"offset,omitempty"`
-	Limit  int64    `json:"limit,omitempty"`
+	Limit  *int64   `json:"limit,omitempty"`
 	Fields []string `json:"fields,omitempty"`
 }
 

--- a/types_easyjson.go
+++ b/types_easyjson.go
@@ -4035,7 +4035,15 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo29(in *jlexer.Lexer,
 		case "offset":
 			out.Offset = int64(in.Int64())
 		case "limit":
-			out.Limit = int64(in.Int64())
+			if in.IsNull() {
+				in.Skip()
+				out.Limit = nil
+			} else {
+				if out.Limit == nil {
+					out.Limit = new(int64)
+				}
+				*out.Limit = int64(in.Int64())
+			}
 		case "fields":
 			if in.IsNull() {
 				in.Skip()
@@ -4079,7 +4087,7 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo29(out *jwriter.Writ
 		out.RawString(prefix[1:])
 		out.Int64(int64(in.Offset))
 	}
-	if in.Limit != 0 {
+	if in.Limit != nil {
 		const prefix string = ",\"limit\":"
 		if first {
 			first = false
@@ -4087,7 +4095,7 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo29(out *jwriter.Writ
 		} else {
 			out.RawString(prefix)
 		}
-		out.Int64(int64(in.Limit))
+		out.Int64(int64(*in.Limit))
 	}
 	if len(in.Fields) != 0 {
 		const prefix string = ",\"fields\":"


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #331 

## What does this PR do?
- Adds support for sending 0 (zero) `Limit` when querying documents
- Creates a helper function for converting `int64` to `*int64`
- Adapts respective tests
- Regenerates easyjson file

## PR checklist
Please check if your PR fulfills the following requirements:
- [X] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [X] Have you read the contributing guidelines?
- [X] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
