### PR TITLE
Update version for the next release (v0.23.0)

### DIFF
--- a/version.go
+++ b/version.go
@@ -2,7 +2,7 @@ package meilisearch
 
 import "fmt"
 
-const VERSION = "0.22.0"
+const VERSION = "0.23.0"
 
 func GetQualifiedVersion() (qualifiedVersion string) {
 	return getQualifiedVersion(VERSION)


### PR DESCRIPTION
This version makes this package compatible with Meilisearch v1.0.0 🎉
Check out the changelog of [Meilisearch vv1.0.0](https://github.com/meilisearch/meilisearch/releases/tag/v1.0.0) for more information on the changes(https://github.com/meilisearch/meilisearch-go/pull/405).

## ⚠️ Breaking changes

* KeyParsed struct has been changed; this structure is used to manage the time format when creating a key, however, all the `Key` fields were available in the structure, while only those used to create a key should be available in it.
    - `createdAt` has been removed
    - `updatedAt` has been removed

Thanks again to @Thearas, @alallema, @bidoubiwa! 🎉