### PR TITLE
Avoid panic when sending `(...[]string{})` in `AddDocument()`

### DIFF
--- a/index_documents.go
+++ b/index_documents.go
@@ -106,7 +106,7 @@ func (i Index) saveDocumentsInBatches(documentsPtr interface{}, batchSize int, d
 
 		batch := arr.Slice(j*batchSize, end).Interface()
 
-		if primaryKey != nil {
+		if len(primaryKey) != 0 {
 			respID, err := documentFunc(batch, primaryKey[0])
 			if err != nil {
 				return nil, err
@@ -177,7 +177,7 @@ func (i Index) GetDocuments(request *DocumentsQuery, resp *DocumentsResult) erro
 func (i Index) addDocuments(documentsPtr interface{}, contentType string, primaryKey ...string) (resp *TaskInfo, err error) {
 	resp = &TaskInfo{}
 	endpoint := ""
-	if primaryKey == nil {
+	if len(primaryKey) == 0 {
 		endpoint = "/indexes/" + i.UID + "/documents"
 	} else {
 		i.PrimaryKey = primaryKey[0] //nolint:golint,staticcheck
@@ -321,7 +321,7 @@ func (i Index) AddDocumentsNdjsonFromReaderInBatches(documents io.Reader, batchS
 func (i Index) updateDocuments(documentsPtr interface{}, contentType string, primaryKey ...string) (resp *TaskInfo, err error) {
 	resp = &TaskInfo{}
 	endpoint := ""
-	if primaryKey == nil {
+	if len(primaryKey) == 0 {
 		endpoint = "/indexes/" + i.UID + "/documents"
 	} else {
 		i.PrimaryKey = primaryKey[0] //nolint:golint,staticcheck


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #<issue_number>

## What does this PR do?
- Improve robustness
   Call ```client.Index("movies").AddDocuments(movies, []string{}...)``` will panic.

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [ ] Have you read the contributing guidelines?
- [ ] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
