### PR TITLE
Add `FacetStats` field in `SearchResponse`

### DIFF
--- a/index_search_test.go
+++ b/index_search_test.go
@@ -524,6 +524,45 @@ func TestIndex_SearchFacets(t *testing.T) {
 					}),
 			},
 		},
+		{
+			name: "TestIndexSearchWithFacetsAndFacetsStats",
+			args: args{
+				UID:    "indexUID",
+				client: defaultClient,
+				query:  "prince",
+				request: SearchRequest{
+					Facets: []string{"book_id"},
+				},
+				filterableAttributes: []string{"book_id"},
+			},
+			want: &SearchResponse{
+				Hits: []interface{}{
+					map[string]interface{}{
+						"book_id": float64(456), "title": "Le Petit Prince",
+					},
+					map[string]interface{}{
+						"book_id": float64(4), "title": "Harry Potter and the Half-Blood Prince",
+					},
+				},
+				EstimatedTotalHits: 2,
+				Offset:             0,
+				Limit:              20,
+				FacetDistribution: map[string]interface{}(
+					map[string]interface{}{
+						"book_id": map[string]interface{}{
+							"4":   float64(1),
+							"456": float64(1),
+						},
+					}),
+				FacetStats: map[string]interface{}(
+					map[string]interface{}{
+						"book_id": map[string]interface{}{
+							"max": float64(456),
+							"min": float64(4),
+						},
+					}),
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -548,6 +587,9 @@ func TestIndex_SearchFacets(t *testing.T) {
 			require.Equal(t, tt.want.Offset, got.Offset)
 			require.Equal(t, tt.want.Limit, got.Limit)
 			require.Equal(t, tt.want.FacetDistribution, got.FacetDistribution)
+			if tt.want.FacetStats != nil {
+				require.Equal(t, tt.want.FacetStats, got.FacetStats)
+			}
 		})
 	}
 }

--- a/types.go
+++ b/types.go
@@ -328,6 +328,7 @@ type SearchResponse struct {
 	HitsPerPage        int64         `json:"hitsPerPage,omitempty"`
 	Page               int64         `json:"page,omitempty"`
 	TotalPages         int64         `json:"totalPages,omitempty"`
+	FacetStats         interface{}   `json:"facetStats,omitempty"`
 }
 
 // DocumentQuery is the request body get one documents method

--- a/types_easyjson.go
+++ b/types_easyjson.go
@@ -2174,6 +2174,14 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo14(in *jlexer.Lexer,
 			out.Page = int64(in.Int64())
 		case "totalPages":
 			out.TotalPages = int64(in.Int64())
+		case "facetStats":
+			if m, ok := out.FacetStats.(easyjson.Unmarshaler); ok {
+				m.UnmarshalEasyJSON(in)
+			} else if m, ok := out.FacetStats.(json.Unmarshaler); ok {
+				_ = m.UnmarshalJSON(in.Raw())
+			} else {
+				out.FacetStats = in.Interface()
+			}
 		default:
 			in.SkipRecursive()
 		}
@@ -2265,6 +2273,17 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo14(out *jwriter.Writ
 		const prefix string = ",\"totalPages\":"
 		out.RawString(prefix)
 		out.Int64(int64(in.TotalPages))
+	}
+	if in.FacetStats != nil {
+		const prefix string = ",\"facetStats\":"
+		out.RawString(prefix)
+		if m, ok := in.FacetStats.(easyjson.Marshaler); ok {
+			m.MarshalEasyJSON(out)
+		} else if m, ok := in.FacetStats.(json.Marshaler); ok {
+			out.Raw(m.MarshalJSON())
+		} else {
+			out.Raw(json.Marshal(in.FacetStats))
+		}
 	}
 	out.RawByte('}')
 }


### PR DESCRIPTION
As per [the specification](https://github.com/meilisearch/specifications/pull/224)
SDK requirements: https://github.com/meilisearch/integration-guides/issues/251

A new `facetStats` field is returned when `facets` is used in the search parameters and contains numerical values. The min and max numeric values of these facets will be returned.

@brunoocasali I added a test in the case tests to check that the returned types were well declared
