### PR TITLE
fix(indexes): Fill in `client` for `GetIndexes` results

### DIFF
--- a/client_index.go
+++ b/client_index.go
@@ -70,6 +70,11 @@ func (c *Client) GetIndexes(param *IndexesQuery) (resp *IndexesResults, err erro
 	if err := c.executeRequest(req); err != nil {
 		return nil, err
 	}
+
+	for i := range resp.Results {
+		resp.Results[i].client = c
+	}
+
 	return resp, nil
 }
 


### PR DESCRIPTION
# Pull Request

## What does this PR do?
- Fills in the `client` field for every `Index` entry returned by `GetIndexes`. If left empty the resulting indexes cannot be used to query parameters of the index, update settings, etc.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
