### PR TITLE
Add method DeleteDocumentsByFilter for Meilisearch v1.2

### DIFF
--- a/index_documents.go
+++ b/index_documents.go
@@ -526,6 +526,25 @@ func (i Index) DeleteDocuments(identifier []string) (resp *TaskInfo, err error) 
 	return resp, nil
 }
 
+func (i Index) DeleteDocumentsByFilter(filter interface{}) (resp *TaskInfo, err error) {
+	resp = &TaskInfo{}
+	req := internalRequest{
+		endpoint:    "/indexes/" + i.UID + "/documents/delete",
+		method:      http.MethodPost,
+		contentType: contentTypeJSON,
+		withRequest: map[string]interface{}{
+			"filter": filter,
+		},
+		withResponse:        resp,
+		acceptedStatusCodes: []int{http.StatusAccepted},
+		functionName:        "DeleteDocumentsByFilter",
+	}
+	if err := i.client.executeRequest(req); err != nil {
+		return nil, VersionErrorHintMessage(err, &req)
+	}
+	return resp, nil
+}
+
 func (i Index) DeleteAllDocuments() (resp *TaskInfo, err error) {
 	resp = &TaskInfo{}
 	req := internalRequest{

--- a/index_documents_test.go
+++ b/index_documents_test.go
@@ -1285,7 +1285,7 @@ func TestIndex_DeleteDocuments(t *testing.T) {
 		wantResp *TaskInfo
 	}{
 		{
-			name: "TestIndexBasicDeleteDocument",
+			name: "TestIndexBasicDeleteDocuments",
 			args: args{
 				UID:        "1",
 				client:     defaultClient,
@@ -1301,7 +1301,7 @@ func TestIndex_DeleteDocuments(t *testing.T) {
 			},
 		},
 		{
-			name: "TestIndexDeleteDocumentWithCustomClient",
+			name: "TestIndexDeleteDocumentsWithCustomClient",
 			args: args{
 				UID:        "2",
 				client:     customClient,
@@ -1317,7 +1317,7 @@ func TestIndex_DeleteDocuments(t *testing.T) {
 			},
 		},
 		{
-			name: "TestIndexBasicDeleteDocument",
+			name: "TestIndexDeleteOneDocumentOnMultiple",
 			args: args{
 				UID:        "3",
 				client:     defaultClient,
@@ -1335,7 +1335,7 @@ func TestIndex_DeleteDocuments(t *testing.T) {
 			},
 		},
 		{
-			name: "TestIndexBasicDeleteDocument",
+			name: "TestIndexDeleteMultipleDocuments",
 			args: args{
 				UID:        "4",
 				client:     defaultClient,
@@ -1379,6 +1379,129 @@ func TestIndex_DeleteDocuments(t *testing.T) {
 				require.Error(t, err)
 				require.Empty(t, document)
 			}
+		})
+	}
+}
+
+func TestIndex_DeleteDocumentsByFilter(t *testing.T) {
+	type args struct {
+		UID            string
+		client         *Client
+		filterToDelete interface{}
+		filterToApply  []string
+		documentsPtr   []docTestBooks
+	}
+	tests := []struct {
+		name     string
+		args     args
+		wantResp *TaskInfo
+	}{
+		{
+			name: "TestIndexDeleteDocumentsByFilterString",
+			args: args{
+				UID:            "1",
+				client:         defaultClient,
+				filterToApply:  []string{"book_id"},
+				filterToDelete: "book_id = 123",
+				documentsPtr: []docTestBooks{
+					{BookID: 123, Title: "Pride and Prejudice", Tag: "Romance", Year: 1813},
+				},
+			},
+			wantResp: &TaskInfo{
+				TaskUID: 1,
+				Status:  "enqueued",
+				Type:    "documentDeletion",
+			},
+		},
+		{
+			name: "TestIndexDeleteMultipleDocumentsByFilterArrayOfString",
+			args: args{
+				UID:            "1",
+				client:         customClient,
+				filterToApply:  []string{"tag"},
+				filterToDelete: []string{"tag = 'Epic fantasy'"},
+				documentsPtr: []docTestBooks{
+					{BookID: 1344, Title: "The Hobbit", Tag: "Epic fantasy", Year: 1937},
+					{BookID: 4, Title: "Harry Potter and the Half-Blood Prince", Tag: "Epic fantasy", Year: 2005},
+					{BookID: 42, Title: "The Hitchhiker's Guide to the Galaxy", Tag: "Epic fantasy", Year: 1978},
+				},
+			},
+			wantResp: &TaskInfo{
+				TaskUID: 1,
+				Status:  "enqueued",
+				Type:    "documentDeletion",
+			},
+		},
+		{
+			name: "TestIndexDeleteMultipleDocumentsAndMultipleFiltersWithArrayOfString",
+			args: args{
+				UID:            "1",
+				client:         customClient,
+				filterToApply:  []string{"tag", "year"},
+				filterToDelete: []string{"tag = 'Epic fantasy'", "year > 1936"},
+				documentsPtr: []docTestBooks{
+					{BookID: 1344, Title: "The Hobbit", Tag: "Epic fantasy", Year: 1937},
+					{BookID: 4, Title: "Harry Potter and the Half-Blood Prince", Tag: "Epic fantasy", Year: 2005},
+					{BookID: 42, Title: "The Hitchhiker's Guide to the Galaxy", Tag: "Epic fantasy", Year: 1978},
+				},
+			},
+			wantResp: &TaskInfo{
+				TaskUID: 1,
+				Status:  "enqueued",
+				Type:    "documentDeletion",
+			},
+		},
+		{
+			name: "TestIndexDeleteMultipleDocumentsAndMultipleFiltersWithInterface",
+			args: args{
+				UID:            "1",
+				client:         customClient,
+				filterToApply:  []string{"book_id", "tag"},
+				filterToDelete: []interface{}{[]string{"tag = 'Epic fantasy'", "book_id = 123"}},
+				documentsPtr: []docTestBooks{
+					{BookID: 123, Title: "Pride and Prejudice", Tag: "Romance", Year: 1813},
+					{BookID: 1344, Title: "The Hobbit", Tag: "Epic fantasy", Year: 1937},
+					{BookID: 4, Title: "Harry Potter and the Half-Blood Prince", Tag: "Epic fantasy", Year: 2005},
+					{BookID: 42, Title: "The Hitchhiker's Guide to the Galaxy", Tag: "Epic fantasy", Year: 1978},
+				},
+			},
+			wantResp: &TaskInfo{
+				TaskUID: 1,
+				Status:  "enqueued",
+				Type:    "documentDeletion",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := tt.args.client
+			i := c.Index(tt.args.UID)
+			t.Cleanup(cleanup(c))
+
+			gotAddResp, err := i.AddDocuments(tt.args.documentsPtr)
+			require.NoError(t, err)
+
+			testWaitForTask(t, i, gotAddResp)
+
+			if tt.args.filterToApply != nil && len(tt.args.filterToApply) != 0 {
+				gotTask, err := i.UpdateFilterableAttributes(&tt.args.filterToApply)
+				require.NoError(t, err)
+				testWaitForTask(t, i, gotTask)
+			}
+
+			gotResp, err := i.DeleteDocumentsByFilter(tt.args.filterToDelete)
+			require.NoError(t, err)
+			require.GreaterOrEqual(t, gotResp.TaskUID, tt.wantResp.TaskUID)
+			require.Equal(t, tt.wantResp.Status, gotResp.Status)
+			require.Equal(t, tt.wantResp.Type, gotResp.Type)
+			require.NotZero(t, gotResp.EnqueuedAt)
+
+			testWaitForTask(t, i, gotResp)
+
+			var documents DocumentsResult
+			err = i.GetDocuments(&DocumentsQuery{}, &documents)
+			require.NoError(t, err)
+			require.Zero(t, len(documents.Results))
 		})
 	}
 }


### PR DESCRIPTION
As per the specification: https://github.com/meilisearch/specifications/pull/236

Added method `DeleteDocumentsByFilter`, this method takes an `interface{}` which allows you to send different types of filters (`string`, `[]string`, `[]interface{}{[]string{}}`, ...)

The `filter` field works precisely like the `filter` field used on the `search` method. See [the docs on how to use filters](https://www.meilisearch.com/docs/learn/advanced/filtering#filter-basics).