### PR TITLE
Drop Golang 1.16, 1.17 support

### DIFF
--- a/.github/workflows/pre-release-tests.yml
+++ b/.github/workflows/pre-release-tests.yml
@@ -14,11 +14,11 @@ jobs:
     strategy:
       matrix:
         # Current go.mod version and latest stable go version
-        go: [1.16, 1.17]
+        go: [1.18, 1.19, 1.20]
         include:
-          - go: 1.16
+          - go: 1.18
             tag: current
-          - go: 1.17
+          - go: 1.20
             tag: latest
 
     name: integration-tests-against-rc (go ${{ matrix.tag }} version)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.17
+          go-version: 1.20
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
@@ -37,11 +37,11 @@ jobs:
     strategy:
       matrix:
         # Current go.mod version and latest stable go version
-        go: [1.16, 1.17]
+        go: [1.18, 1.19, 1.20]
         include:
-          - go: 1.16
+          - go: 1.18
             tag: current
-          - go: 1.17
+          - go: 1.20
             tag: latest
 
     name: integration-tests (go ${{ matrix.tag }} version)
@@ -54,11 +54,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Get dependencies
         run: |
-          go get -v -t -d ./...
-          if [ -f Gopkg.toml ]; then
-            curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-            dep ensure
-          fi
+          go install -v ./...
       - name: Meilisearch setup (latest version) with Docker
         run: docker run -d -p 7700:7700 getmeili/meilisearch:latest meilisearch --master-key=masterKey --no-analytics
       - name: Run integration tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17.11-buster
+FROM golang:1.20-alpine
 
 WORKDIR /home/package
 

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,20 @@
 module github.com/meilisearch/meilisearch-go
 
-go 1.16
+go 1.18
 
 require (
 	github.com/golang-jwt/jwt/v4 v4.5.0
-	github.com/klauspost/compress v1.15.6 // indirect
 	github.com/mailru/easyjson v0.7.7
 	github.com/stretchr/testify v1.8.2
 	github.com/valyala/fasthttp v1.37.1-0.20220607072126-8a320890c08d
+)
+
+require (
+	github.com/andybalholm/brotli v1.0.4 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/josharian/intern v1.0.0 // indirect
+	github.com/klauspost/compress v1.15.6 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/valyala/bytebufferpool v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
# Pull Request

According to the [end-of-life](https://endoflife.date/go) date for Golang versions, versions up to 1.18 are no longer supported. Knowing that Go generally only supports the last two versions

## What does this PR do?
- Removes support for Golang 1.16 and 1.17

