### PR TITLE
Check if SearchRequest is nil

### DIFF
--- a/index_search.go
+++ b/index_search.go
@@ -2,6 +2,7 @@ package meilisearch
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 )
 
@@ -12,14 +13,20 @@ const (
 	DefaultLimit int64 = 20
 )
 
+var ErrNoSearchRequest = errors.New("no search request provided")
+
 func (i Index) SearchRaw(query string, request *SearchRequest) (*json.RawMessage, error) {
-	resp := &json.RawMessage{}
+	if request == nil {
+		return nil, ErrNoSearchRequest
+	}
 
 	if request.Limit == 0 {
 		request.Limit = DefaultLimit
 	}
 
 	searchPostRequestParams := searchPostRequestParams(query, request)
+
+	resp := &json.RawMessage{}
 
 	req := internalRequest{
 		endpoint:            "/indexes/" + i.UID + "/search",
@@ -39,7 +46,9 @@ func (i Index) SearchRaw(query string, request *SearchRequest) (*json.RawMessage
 }
 
 func (i Index) Search(query string, request *SearchRequest) (*SearchResponse, error) {
-	resp := &SearchResponse{}
+	if request == nil {
+		return nil, ErrNoSearchRequest
+	}
 
 	if request.Limit == 0 {
 		request.Limit = DefaultLimit
@@ -49,6 +58,8 @@ func (i Index) Search(query string, request *SearchRequest) (*SearchResponse, er
 	}
 
 	searchPostRequestParams := searchPostRequestParams(query, request)
+
+	resp := &SearchResponse{}
 
 	req := internalRequest{
 		endpoint:            "/indexes/" + i.UID + "/search",


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #480 

## What does this PR do?
In the current scenario, if a nil SearchRequest object is passed to the Index search methods, a panic occurs. This PR is intended to introduce an error handling to prevent unexpected panic.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
