### PR TITLE
Update code-samples

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -452,6 +452,10 @@ search_parameter_guide_facet_stats_1: |-
       "rating",
     },
   })
+search_parameter_guide_attributes_to_search_on_1: |-
+  resp, err := client.Index("movies").Search("adventure", &meilisearch.SearchRequest{
+    AttributesToSearchOn: []string{"overview"},
+  })
 typo_tolerance_guide_1: |-
   client.Index("movies").UpdateTypoTolerance(&meilisearch.TypoTolerance{
     Enabled: false,


### PR DESCRIPTION
Add `search_parameter_guide_attributes_to_search_on_1`

# Pull Request

## Related issue
#466 
Implemented: #458
## What does this PR do?
- field `attributesToSearchOn` was implemented in #458, but author did not update code-samples. This PR add `search_parameter_guide_attributes_to_search_on_1`.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
