### PR TITLE
Enable to use `DeleteDocumentsByFilter` through `IndexInterface`

### DIFF
--- a/index.go
+++ b/index.go
@@ -42,6 +42,7 @@ type IndexInterface interface {
 	GetDocuments(param *DocumentsQuery, resp *DocumentsResult) error
 	DeleteDocument(uid string) (resp *TaskInfo, err error)
 	DeleteDocuments(uid []string) (resp *TaskInfo, err error)
+	DeleteDocumentsByFilter(filter interface{}) (resp *TaskInfo, err error)
 	DeleteAllDocuments() (resp *TaskInfo, err error)
 	Search(query string, request *SearchRequest) (*SearchResponse, error)
 	SearchRaw(query string, request *SearchRequest) (*json.RawMessage, error)


### PR DESCRIPTION
# Pull Request

## Related issue
*None*

## What does this PR do?
Add `DeleteDocumentsByFilter` method to `IndexInterface` to be able to use the method through the interface.

https://github.com/meilisearch/meilisearch-go/blob/3310833cd68e1fd42c9f63e9028edf41410e5b5c/index_documents.go#L535

Without this change, the following document doesn't work as expected.

<img width="1005" alt="image" src="https://github.com/meilisearch/meilisearch-go/assets/96157/605981da-ca73-4b17-a4b0-ac9f623f5206">

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
