### PR TITLE
Alligned `SearchRequest.Vector` type to `[]float32`

### DIFF
--- a/index_search_test.go
+++ b/index_search_test.go
@@ -1612,7 +1612,7 @@ func TestIndex_SearchWithVectorStore(t *testing.T) {
 		client: defaultClient,
 		query:  "Pride and Prejudice",
 		request: SearchRequest{
-			Vector: []float64{0.1, 0.2, 0.3},
+			Vector: []float32{0.1, 0.2, 0.3},
 			Hybrid: &SearchRequestHybrid{
 				SemanticRatio: 0.5,
 				Embedder:      "default",

--- a/types.go
+++ b/types.go
@@ -354,7 +354,7 @@ type SearchRequest struct {
 	Facets                []string
 	PlaceholderSearch     bool
 	Sort                  []string
-	Vector                []float64
+	Vector                []float32
 	HitsPerPage           int64
 	Page                  int64
 	IndexUID              string

--- a/types_easyjson.go
+++ b/types_easyjson.go
@@ -2635,16 +2635,16 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo16(in *jlexer.Lexer,
 				in.Delim('[')
 				if out.Vector == nil {
 					if !in.IsDelim(']') {
-						out.Vector = make([]float64, 0, 8)
+						out.Vector = make([]float32, 0, 16)
 					} else {
-						out.Vector = []float64{}
+						out.Vector = []float32{}
 					}
 				} else {
 					out.Vector = (out.Vector)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v66 float64
-					v66 = float64(in.Float64())
+					var v66 float32
+					v66 = float32(in.Float32())
 					out.Vector = append(out.Vector, v66)
 					in.WantComma()
 				}
@@ -2850,7 +2850,7 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo16(out *jwriter.Writ
 				if v79 > 0 {
 					out.RawByte(',')
 				}
-				out.Float64(float64(v80))
+				out.Float32(float32(v80))
 			}
 			out.RawByte(']')
 		}


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes -

## What does this PR do?
- Changes the type of `SearchRequest.Vector` to a `[]float32`, as it aligns more with meilisearch and general embedding vectors.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
