### PR TITLE
Enhance Flexibility and Extensibility by Supporting net/http

### DIFF
--- a/client_index_test.go
+++ b/client_index_test.go
@@ -46,6 +46,19 @@ func TestClient_CreateIndex(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:   "TestCreateIndexWithNetHTTPClient",
+			client: netHTTPClient,
+			args: args{
+				config: IndexConfig{
+					Uid: "TestCreateIndexWithNetHTTPClient",
+				},
+			},
+			wantResp: &Index{
+				UID: "TestCreateIndexWithNetHTTPClient",
+			},
+			wantErr: false,
+		},
+		{
 			name:   "TestCreateIndexWithPrimaryKey",
 			client: defaultClient,
 			args: args{
@@ -150,6 +163,15 @@ func TestClient_DeleteIndex(t *testing.T) {
 			args: args{
 				createUid: []string{"TestDeleteIndexWithCustomClient"},
 				deleteUid: []string{"TestDeleteIndexWithCustomClient"},
+			},
+			wantErr: false,
+		},
+		{
+			name:   "TestDeleteIndexWithNetHTTPClient",
+			client: netHTTPClient,
+			args: args{
+				createUid: []string{"TestDeleteIndexNetHTTP"},
+				deleteUid: []string{"TestDeleteIndexNetHTTP"},
 			},
 			wantErr: false,
 		},
@@ -286,6 +308,24 @@ func TestClient_GetIndexes(t *testing.T) {
 				Results: []Index{
 					{
 						UID: "TestGetIndexesWithCustomClient",
+					},
+				},
+				Offset: 0,
+				Limit:  20,
+				Total:  1,
+			},
+		},
+		{
+			name:   "TestGetIndexesWithNetHTTPClient",
+			client: netHTTPClient,
+			args: args{
+				uid:     []string{"TestGetIndexesWithNetHTTPClient"},
+				request: nil,
+			},
+			wantResp: &IndexesResults{
+				Results: []Index{
+					{
+						UID: "TestGetIndexesWithNetHTTPClient",
 					},
 				},
 				Offset: 0,
@@ -461,6 +501,24 @@ func TestClient_GetRawIndexes(t *testing.T) {
 			},
 		},
 		{
+			name:   "TestGetRawIndexesWithNetHTTPClient",
+			client: netHTTPClient,
+			args: args{
+				uid:     []string{"TestGetRawIndexesNetHTTP"},
+				request: nil,
+			},
+			wantResp: map[string]interface{}{
+				"results": []map[string]string{
+					{
+						"uid": "TestGetRawIndexesWithNetHTTPClient",
+					},
+				},
+				"offset": float64(0),
+				"limit":  float64(20),
+				"total":  float64(1),
+			},
+		},
+		{
 			name:   "TestGetRawIndexesOnMultipleIndex",
 			client: defaultClient,
 			args: args{
@@ -605,6 +663,20 @@ func TestClient_GetIndex(t *testing.T) {
 			wantCmp: false,
 		},
 		{
+			name:   "TestGetIndexWithNetHTTPClient",
+			client: netHTTPClient,
+			args: args{
+				config: IndexConfig{
+					Uid: "TestGetIndexWithNetHTTPClient",
+				},
+				uid: "TestGetIndexWithNetHTTPClient",
+			},
+			wantResp: &Index{
+				UID: "TestGetIndexWithNetHTTPClient",
+			},
+			wantCmp: false,
+		},
+		{
 			name:   "TestGetIndexWithPrimaryKey",
 			client: defaultClient,
 			args: args{
@@ -689,6 +761,19 @@ func TestClient_GetRawIndex(t *testing.T) {
 			},
 		},
 		{
+			name:   "TestGetRawIndexWithNetHTTPClient",
+			client: netHTTPClient,
+			args: args{
+				config: IndexConfig{
+					Uid: "TestGetRawIndexWithNetHTTPClient",
+				},
+				uid: "TestGetRawIndexWithNetHTTPClient",
+			},
+			wantResp: map[string]interface{}{
+				"uid": string("TestGetRawIndexWithNetHTTPClient"),
+			},
+		},
+		{
 			name:   "TestGetRawIndexWithPrimaryKey",
 			client: defaultClient,
 			args: args{
@@ -752,6 +837,16 @@ func TestClient_Index(t *testing.T) {
 			},
 			want: Index{
 				UID: "TestIndexWithCustomClient",
+			},
+		},
+		{
+			name:   "TestIndexWithNetHTTPClient",
+			client: netHTTPClient,
+			args: args{
+				uid: "TestIndexWithNetHTTPClient",
+			},
+			want: Index{
+				UID: "TestIndexWithNetHTTPClient",
 			},
 		},
 	}

--- a/client_request.go
+++ b/client_request.go
@@ -1,6 +1,7 @@
 package meilisearch
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"net/http"
@@ -32,6 +33,22 @@ type internalRequest struct {
 }
 
 func (c *Client) executeRequest(req internalRequest) error {
+	return c.requestExecutor.executeRequest(req, c)
+}
+
+type requestExecutor interface {
+	executeRequest(req internalRequest, client *Client) error
+}
+
+// fasthttpRequestExecutor is a requestExecutor implementation using fasthttp
+type fasthttpRequestExecutor struct {
+	httpClient *fasthttp.Client
+}
+
+var _ requestExecutor = &fasthttpRequestExecutor{}
+
+// executeRequest implements requestExecutor interface
+func (c *fasthttpRequestExecutor) executeRequest(req internalRequest, client *Client) error {
 	internalError := &Error{
 		Endpoint:         req.endpoint,
 		Method:           req.method,
@@ -46,7 +63,7 @@ func (c *Client) executeRequest(req internalRequest) error {
 
 	response := fasthttp.AcquireResponse()
 	defer fasthttp.ReleaseResponse(response)
-	err := c.sendRequest(&req, internalError, response)
+	err := c.sendRequest(&req, internalError, response, client)
 	if err != nil {
 		return err
 	}
@@ -64,7 +81,7 @@ func (c *Client) executeRequest(req internalRequest) error {
 	return nil
 }
 
-func (c *Client) sendRequest(req *internalRequest, internalError *Error, response *fasthttp.Response) error {
+func (c *fasthttpRequestExecutor) sendRequest(req *internalRequest, internalError *Error, response *fasthttp.Response, client *Client) error {
 	var (
 		request *fasthttp.Request
 
@@ -72,7 +89,7 @@ func (c *Client) sendRequest(req *internalRequest, internalError *Error, respons
 	)
 
 	// Setup URL
-	requestURL, err := url.Parse(c.config.Host + req.endpoint)
+	requestURL, err := url.Parse(client.config.Host + req.endpoint)
 	if err != nil {
 		return fmt.Errorf("unable to parse url: %w", err)
 	}
@@ -102,9 +119,9 @@ func (c *Client) sendRequest(req *internalRequest, internalError *Error, respons
 		}
 
 		rawRequest := req.withRequest
-		if bytes, ok := rawRequest.([]byte); ok {
+		if b, ok := rawRequest.([]byte); ok {
 			// If the request body is already a []byte then use it directly
-			request.SetBody(bytes)
+			request.SetBody(b)
 		} else if reader, ok := rawRequest.(io.Reader); ok {
 			// If the request body is an io.Reader then stream it directly until io.EOF
 			// NOTE: Avoid using this, due to problems with streamed request bodies
@@ -132,15 +149,15 @@ func (c *Client) sendRequest(req *internalRequest, internalError *Error, respons
 	if req.contentType != "" {
 		request.Header.Set("Content-Type", req.contentType)
 	}
-	if c.config.APIKey != "" {
-		request.Header.Set("Authorization", "Bearer "+c.config.APIKey)
+	if client.config.APIKey != "" {
+		request.Header.Set("Authorization", "Bearer "+client.config.APIKey)
 	}
 
 	request.Header.Set("User-Agent", GetQualifiedVersion())
 
 	// request is sent
-	if c.config.Timeout != 0 {
-		err = c.httpClient.DoTimeout(request, response, c.config.Timeout)
+	if client.config.Timeout != 0 {
+		err = c.httpClient.DoTimeout(request, response, client.config.Timeout)
 	} else {
 		err = c.httpClient.Do(request, response)
 	}
@@ -157,47 +174,191 @@ func (c *Client) sendRequest(req *internalRequest, internalError *Error, respons
 	return nil
 }
 
-func (c *Client) handleStatusCode(req *internalRequest, response *fasthttp.Response, internalError *Error) error {
+func (c *fasthttpRequestExecutor) handleStatusCode(req *internalRequest, response *fasthttp.Response, internalError *Error) error {
 	if req.acceptedStatusCodes != nil {
-
-		// A successful status code is required so check if the response status code is in the
-		// expected status code list.
-		for _, acceptedCode := range req.acceptedStatusCodes {
-			if response.StatusCode() == acceptedCode {
-				return nil
-			}
-		}
-		// At this point the response status code is a failure.
-		rawBody := response.Body()
-
-		internalError.ErrorBody(rawBody)
-
-		if internalError.MeilisearchApiError.Code == "" {
-			return internalError.WithErrCode(MeilisearchApiErrorWithoutMessage)
-		}
-		return internalError.WithErrCode(MeilisearchApiError)
+		return handleStatusCode(req, response.StatusCode(), response.Body(), internalError)
 	}
-
 	return nil
 }
 
-func (c *Client) handleResponse(req *internalRequest, response *fasthttp.Response, internalError *Error) (err error) {
+func handleStatusCode(req *internalRequest, statusCode int, rawBody []byte, internalError *Error) error {
+	// A successful status code is required so check if the response status code is in the
+	// expected status code list.
+	for _, acceptedCode := range req.acceptedStatusCodes {
+		if statusCode == acceptedCode {
+			return nil
+		}
+	}
+	// At this point the response status code is a failure.
+	internalError.ErrorBody(rawBody)
+
+	if internalError.MeilisearchApiError.Code == "" {
+		return internalError.WithErrCode(MeilisearchApiErrorWithoutMessage)
+	}
+	return internalError.WithErrCode(MeilisearchApiError)
+}
+
+func (c *fasthttpRequestExecutor) handleResponse(req *internalRequest, response *fasthttp.Response, internalError *Error) (err error) {
 	if req.withResponse != nil {
+		return handleResponse(req, response.Body(), internalError)
+	}
+	return nil
+}
 
-		// A json response is mandatory, so the response interface{} need to be unmarshal from the response payload.
-		rawBody := response.Body()
-		internalError.ResponseToString = string(rawBody)
+func handleResponse(req *internalRequest, rawBody []byte, internalError *Error) error {
+	// A json response is mandatory, so the response interface{} need to be unmarshal from the response payload.
+	internalError.ResponseToString = string(rawBody)
 
-		var err error
-		if resp, ok := req.withResponse.(json.Unmarshaler); ok {
-			err = resp.UnmarshalJSON(rawBody)
-			req.withResponse = resp
+	var err error
+	if resp, ok := req.withResponse.(json.Unmarshaler); ok {
+		err = resp.UnmarshalJSON(rawBody)
+		req.withResponse = resp
+	} else {
+		err = json.Unmarshal(rawBody, req.withResponse)
+	}
+	if err != nil {
+		return internalError.WithErrCode(ErrCodeResponseUnmarshalBody, err)
+	}
+	return nil
+}
+
+type nethttpRequestExecutor struct {
+	httpClient *http.Client
+}
+
+var _ requestExecutor = &nethttpRequestExecutor{}
+
+func (c *nethttpRequestExecutor) executeRequest(req internalRequest, client *Client) error {
+	internalError := &Error{
+		Endpoint:         req.endpoint,
+		Method:           req.method,
+		Function:         req.functionName,
+		RequestToString:  "empty request",
+		ResponseToString: "empty response",
+		MeilisearchApiError: meilisearchApiError{
+			Message: "empty Meilisearch message",
+		},
+		StatusCodeExpected: req.acceptedStatusCodes,
+	}
+
+	response, err := c.sendRequest(&req, internalError, client)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+	internalError.StatusCode = response.StatusCode
+
+	rawBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		return err
+	}
+
+	err = c.handleStatusCode(&req, response.StatusCode, rawBody, internalError)
+	if err != nil {
+		return err
+	}
+
+	err = c.handleResponse(&req, rawBody, internalError)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *nethttpRequestExecutor) sendRequest(req *internalRequest, internalError *Error, client *Client) (*http.Response, error) {
+	var (
+		request *http.Request
+		err     error
+	)
+
+	// Setup URL
+	requestURL, err := url.Parse(client.config.Host + req.endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse url: %w", err)
+	}
+
+	// Build query parameters
+	if req.withQueryParams != nil {
+		query := requestURL.Query()
+		for key, value := range req.withQueryParams {
+			query.Set(key, value)
+		}
+		requestURL.RawQuery = query.Encode()
+	}
+
+	// Create request
+	request, err = http.NewRequest(req.method, requestURL.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create request: %w", err)
+	}
+
+	// Set request body
+	if req.withRequest != nil {
+		if req.method == http.MethodGet || req.method == http.MethodHead {
+			return nil, fmt.Errorf("sendRequest: request body is not expected for GET and HEAD requests")
+		}
+
+		if req.contentType == "" {
+			return nil, fmt.Errorf("sendRequest: request body without Content-Type is not allowed")
+		}
+
+		rawRequest := req.withRequest
+		if b, ok := rawRequest.([]byte); ok {
+			// If the request body is already a []byte then use it directly
+			request.Body = io.NopCloser(bytes.NewReader(b))
+		} else if readCloser, ok := rawRequest.(io.ReadCloser); ok {
+			// If the request body is an io.ReadCloser then use it directly
+			request.Body = readCloser
+		} else if reader, ok := rawRequest.(io.Reader); ok {
+			// If the request body is an io.Reader then use it directly
+			request.Body = io.NopCloser(reader)
 		} else {
-			err = json.Unmarshal(rawBody, req.withResponse)
+			// Otherwise convert it to JSON
+			var (
+				data []byte
+				err  error
+			)
+			if marshaler, ok := rawRequest.(json.Marshaler); ok {
+				data, err = marshaler.MarshalJSON()
+			} else {
+				data, err = json.Marshal(rawRequest)
+			}
+			internalError.RequestToString = string(data)
+			if err != nil {
+				return nil, internalError.WithErrCode(ErrCodeMarshalRequest, err)
+			}
+			request.Body = io.NopCloser(bytes.NewReader(data))
 		}
-		if err != nil {
-			return internalError.WithErrCode(ErrCodeResponseUnmarshalBody, err)
-		}
+	}
+
+	// Set request headers
+	if req.contentType != "" {
+		request.Header.Set("Content-Type", req.contentType)
+	}
+	if client.config.APIKey != "" {
+		request.Header.Set("Authorization", "Bearer "+client.config.APIKey)
+	}
+	request.Header.Set("User-Agent", GetQualifiedVersion())
+
+	// Send request
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, internalError.WithErrCode(MeilisearchCommunicationError, err)
+	}
+
+	return response, nil
+}
+
+func (c *nethttpRequestExecutor) handleStatusCode(req *internalRequest, statusCode int, rawBody []byte, internalError *Error) error {
+	if req.acceptedStatusCodes != nil {
+		return handleStatusCode(req, statusCode, rawBody, internalError)
+	}
+	return nil
+}
+
+func (c *nethttpRequestExecutor) handleResponse(req *internalRequest, rawBody []byte, internalError *Error) error {
+	if req.withResponse != nil {
+		return handleResponse(req, rawBody, internalError)
 	}
 	return nil
 }

--- a/client_request_test.go
+++ b/client_request_test.go
@@ -1,0 +1,29 @@
+package meilisearch
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type roundTripperFunc func(req *http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestClient_Transport(t *testing.T) {
+	called := false
+	client := NewClient(ClientConfig{
+		Host:   getenv("MEILISEARCH_URL", "http://localhost:7700"),
+		APIKey: masterKey,
+		Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			called = true
+			return http.DefaultTransport.RoundTrip(req)
+		}),
+	})
+	_, err := client.GetVersion()
+	require.NoError(t, err)
+	require.True(t, called)
+}

--- a/index_documents_test.go
+++ b/index_documents_test.go
@@ -80,6 +80,31 @@ func TestIndex_AddDocuments(t *testing.T) {
 			},
 		},
 		{
+			name: "TestIndexAddDocumentsWithNetHTTPClient",
+			args: args{
+				UID:    "TestIndexAddDocumentsWithNetHTTPClient",
+				client: netHTTPClient,
+				documentsPtr: []map[string]interface{}{
+					{"ID": "123", "Name": "Pride and Prejudice"},
+				},
+			},
+			resp: resp{
+				wantResp: &TaskInfo{
+					TaskUID: 0,
+					Status:  "enqueued",
+					Type:    TaskTypeDocumentAdditionOrUpdate,
+				},
+				documentsRes: DocumentsResult{
+					Results: []map[string]interface{}{
+						{"ID": "123", "Name": "Pride and Prejudice"},
+					},
+					Limit:  3,
+					Offset: 0,
+					Total:  1,
+				},
+			},
+		},
+		{
 			name: "TestIndexMultipleAddDocuments",
 			args: args{
 				UID:    "TestIndexMultipleAddDocuments",
@@ -138,6 +163,31 @@ func TestIndex_AddDocuments(t *testing.T) {
 			args: args{
 				UID:    "TestIndexAddDocumentsWithIntIDWithCustomClient",
 				client: customClient,
+				documentsPtr: []map[string]interface{}{
+					{"BookID": float64(123), "Title": "Pride and Prejudice"},
+				},
+			},
+			resp: resp{
+				wantResp: &TaskInfo{
+					TaskUID: 0,
+					Status:  "enqueued",
+					Type:    TaskTypeDocumentAdditionOrUpdate,
+				},
+				documentsRes: DocumentsResult{
+					Results: []map[string]interface{}{
+						{"BookID": float64(123), "Title": "Pride and Prejudice"},
+					},
+					Limit:  3,
+					Offset: 0,
+					Total:  1,
+				},
+			},
+		},
+		{
+			name: "TestIndexAddDocumentsWithIntIDWithNetHTTPClient",
+			args: args{
+				UID:    "TestIndexAddDocumentsWithIntIDWithNetHTTPClient",
+				client: netHTTPClient,
 				documentsPtr: []map[string]interface{}{
 					{"BookID": float64(123), "Title": "Pride and Prejudice"},
 				},
@@ -261,6 +311,32 @@ func TestIndex_AddDocumentsWithPrimaryKey(t *testing.T) {
 			args: args{
 				UID:    "TestIndexAddDocumentsWithPrimaryKeyWithCustomClient",
 				client: customClient,
+				documentsPtr: []map[string]interface{}{
+					{"key": "123", "Name": "Pride and Prejudice"},
+				},
+				primaryKey: "key",
+			},
+			resp: resp{
+				wantResp: &TaskInfo{
+					TaskUID: 0,
+					Status:  "enqueued",
+					Type:    TaskTypeDocumentAdditionOrUpdate,
+				},
+				documentsRes: DocumentsResult{
+					Results: []map[string]interface{}{
+						{"key": "123", "Name": "Pride and Prejudice"},
+					},
+					Limit:  3,
+					Offset: 0,
+					Total:  1,
+				},
+			},
+		},
+		{
+			name: "TestIndexAddDocumentsWithPrimaryKeyWithNetHTTPClient",
+			args: args{
+				UID:    "TestIndexAddDocumentsWithPrimaryKeyWithNetHTTPClient",
+				client: netHTTPClient,
 				documentsPtr: []map[string]interface{}{
 					{"key": "123", "Name": "Pride and Prejudice"},
 				},
@@ -1104,6 +1180,18 @@ func TestIndex_DeleteAllDocuments(t *testing.T) {
 				Type:    "documentDeletion",
 			},
 		},
+		{
+			name: "TestIndexDeleteAllDocumentsWithNetHTTPClient",
+			args: args{
+				UID:    "TestIndexDeleteAllDocumentsWithNetHTTPClient",
+				client: netHTTPClient,
+			},
+			wantResp: &TaskInfo{
+				TaskUID: 2,
+				Status:  "enqueued",
+				Type:    "documentDeletion",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1175,6 +1263,22 @@ func TestIndex_DeleteOneDocument(t *testing.T) {
 			},
 		},
 		{
+			name: "TestIndexDeleteOneDocumentWithNetHTTPClient",
+			args: args{
+				UID:        "2",
+				client:     netHTTPClient,
+				identifier: "123",
+				documentsPtr: []map[string]interface{}{
+					{"ID": "123", "Name": "Pride and Prejudice"},
+				},
+			},
+			wantResp: &TaskInfo{
+				TaskUID: 1,
+				Status:  "enqueued",
+				Type:    "documentDeletion",
+			},
+		},
+		{
 			name: "TestIndexDeleteOneDocumentinMultiple",
 			args: args{
 				UID:        "3",
@@ -1213,6 +1317,22 @@ func TestIndex_DeleteOneDocument(t *testing.T) {
 			args: args{
 				UID:        "5",
 				client:     customClient,
+				identifier: "123",
+				documentsPtr: []map[string]interface{}{
+					{"BookID": 123, "Title": "Pride and Prejudice"},
+				},
+			},
+			wantResp: &TaskInfo{
+				TaskUID: 1,
+				Status:  "enqueued",
+				Type:    "documentDeletion",
+			},
+		},
+		{
+			name: "TestIndexDeleteOneDocumentWithIntIDWithNetHTTPClient",
+			args: args{
+				UID:        "5",
+				client:     netHTTPClient,
 				identifier: "123",
 				documentsPtr: []map[string]interface{}{
 					{"BookID": 123, "Title": "Pride and Prejudice"},

--- a/index_search_test.go
+++ b/index_search_test.go
@@ -155,6 +155,29 @@ func TestIndex_Search(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "TestIndexSearchWithNetHTTPClient",
+			args: args{
+				UID:     "indexUID",
+				client:  netHTTPClient,
+				query:   "prince",
+				request: &SearchRequest{},
+			},
+			want: &SearchResponse{
+				Hits: []interface{}{
+					map[string]interface{}{
+						"book_id": float64(456), "title": "Le Petit Prince",
+					},
+					map[string]interface{}{
+						"Tag": "Epic fantasy", "book_id": float64(4), "title": "Harry Potter and the Half-Blood Prince",
+					},
+				},
+				EstimatedTotalHits: 2,
+				Offset:             0,
+				Limit:              20,
+			},
+			wantErr: false,
+		},
+		{
 			name: "TestIndexSearchWithLimit",
 			args: args{
 				UID:    "indexUID",
@@ -576,6 +599,39 @@ func TestIndex_SearchFacets(t *testing.T) {
 			args: args{
 				UID:    "indexUID",
 				client: customClient,
+				query:  "prince",
+				request: &SearchRequest{
+					Facets: []string{"*"},
+				},
+				filterableAttributes: []string{"tag"},
+			},
+			want: &SearchResponse{
+				Hits: []interface{}{
+					map[string]interface{}{
+						"book_id": float64(456), "title": "Le Petit Prince",
+					},
+					map[string]interface{}{
+						"book_id": float64(4), "title": "Harry Potter and the Half-Blood Prince",
+					},
+				},
+				EstimatedTotalHits: 2,
+				Offset:             0,
+				Limit:              20,
+				FacetDistribution: map[string]interface{}(
+					map[string]interface{}{
+						"tag": map[string]interface{}{
+							"Epic fantasy": float64(1),
+							"Tale":         float64(1),
+						},
+					}),
+			},
+			wantErr: false,
+		},
+		{
+			name: "TestIndexSearchWithFacetsWithNetHTTPClient",
+			args: args{
+				UID:    "indexUID",
+				client: netHTTPClient,
 				query:  "prince",
 				request: &SearchRequest{
 					Facets: []string{"*"},
@@ -1287,6 +1343,30 @@ func TestIndex_SearchOnNestedFileds(t *testing.T) {
 			args: args{
 				UID:     "TestIndexBasicSearchOnNestedFieldsWithCustomClient",
 				client:  customClient,
+				query:   "An awesome",
+				request: &SearchRequest{},
+			},
+			want: &SearchResponse{
+				Hits: []interface{}{
+					map[string]interface{}{
+						"id": float64(5), "title": "The Hobbit",
+						"info": map[string]interface{}{
+							"comment":  "An awesome book",
+							"reviewNb": float64(900),
+						},
+					},
+				},
+				EstimatedTotalHits: 1,
+				Offset:             0,
+				Limit:              20,
+			},
+			wantErr: false,
+		},
+		{
+			name: "TestIndexBasicSearchOnNestedFieldsWithNetHTTPClient",
+			args: args{
+				UID:     "TestIndexBasicSearchOnNestedFieldsWithNetHTTPClient",
+				client:  netHTTPClient,
 				query:   "An awesome",
 				request: &SearchRequest{},
 			},

--- a/main_test.go
+++ b/main_test.go
@@ -316,6 +316,12 @@ var customClient = NewFastHTTPCustomClient(ClientConfig{
 		Name:      "custom-client",
 	})
 
+var netHTTPClient = NewClient(ClientConfig{
+	Host:      getenv("MEILISEARCH_URL", "http://localhost:7700"),
+	APIKey:    masterKey,
+	Transport: http.DefaultTransport,
+})
+
 var brokenClient = NewFastHTTPCustomClient(ClientConfig{
 	Host:   getenv("MEILISEARCH_URL", "http://localhost:7700"),
 	APIKey: "WRONG",
@@ -325,10 +331,23 @@ var brokenClient = NewFastHTTPCustomClient(ClientConfig{
 		Name:      "broken-client",
 	})
 
+var brokenNetHTTPClient = NewClient(ClientConfig{
+	Host:      getenv("MEILISEARCH_URL", "http://localhost:7700"),
+	APIKey:    "WRONG",
+	Transport: http.DefaultTransport,
+})
+
 var timeoutClient = NewClient(ClientConfig{
 	Host:    getenv("MEILISEARCH_URL", "http://localhost:7700"),
 	APIKey:  masterKey,
 	Timeout: 1,
+})
+
+var timeoutNetHTTPClient = NewClient(ClientConfig{
+	Host:      getenv("MEILISEARCH_URL", "http://localhost:7700"),
+	APIKey:    masterKey,
+	Timeout:   1,
+	Transport: http.DefaultTransport,
 })
 
 var privateClient = NewClient(ClientConfig{

--- a/types.go
+++ b/types.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v4"
-	"github.com/valyala/fasthttp"
 )
 
 //
@@ -13,8 +12,8 @@ import (
 
 // Client is a structure that give you the power for interacting with an high-level api with Meilisearch.
 type Client struct {
-	config     ClientConfig
-	httpClient *fasthttp.Client
+	config          ClientConfig
+	requestExecutor requestExecutor
 }
 
 // Index is the type that represent an index in Meilisearch


### PR DESCRIPTION
# Pull Request

## Related issue
*None*

## What does this PR do?

The MeiliSearch Go client currently uses `fasthttp.Client`, which is incompatible with the standard Go `net/http` package. This incompatibility prevents the use of tools like [opentelemetry-go-contrib](https://github.com/open-telemetry/opentelemetry-go-contrib/blob/ae2a4f0031e4a20e7fc1f23f04a19285a2ba5ebe/instrumentation/net/http/otelhttp/transport.go#L42) and [go-vcr](https://github.com/dnaeon/go-vcr/blob/78b95994ca9ba11d6a7d659a1d24bcb4bb4bff0a/recorder/recorder.go#L451). Aligning with `net/http` will provide significant future benefits.

`go-vcr` uses `http.RoundTrip` to record and replay HTTP requests. This tool is valuable as it allows testing without accessing a live MeiliSearch server, avoiding the need to either mock interfaces or run an actual server, which can be cumbersome. Testability increases a lot.

This PR proposes to introduce `net/http` in addition to `fasthttp` by:

1. Adding an optional `Transport` field in `ClientConfig`.
2. Creating a `requestExecutor` interface to handle requests via both `fasthttp.Client` and `net/http.Client`.
3. Ensuring compatibility with the existing `fasthttp.Client` setup while providing an option for `net/http.Client`.

Usage sample:

```go
import "gopkg.in/dnaeon/go-vcr.v3/recorder"

func TestMeilisearchWithVCR(t *testing.T) {
  rec, _ := recorder.New("fixtures/matchers")
  defer rec.Stop()

  client := meilisearch.NewClient(meilisearch.ClientConfig{
    Host: "https://edge.meilisearch.com",
    APIKey: "...",
    Transport: rec, // with Transport, net/http.Client is used internally
  })

  // API call will be captured and replayed in the future.
}
```

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?