### PR TITLE
Add Embedder.URL

### DIFF
--- a/types.go
+++ b/types.go
@@ -91,6 +91,7 @@ type Faceting struct {
 
 type Embedder struct {
 	Source           string `json:"source"`
+	URL              string `json:"url,omitempty"`
 	ApiKey           string `json:"apiKey,omitempty"`
 	Model            string `json:"model,omitempty"`
 	Dimensions       int    `json:"dimensions,omitempty"`

--- a/types_easyjson.go
+++ b/types_easyjson.go
@@ -5369,6 +5369,8 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo36(in *jlexer.Lexer,
 		switch key {
 		case "source":
 			out.Source = string(in.String())
+		case "url":
+			out.URL = string(in.String())
 		case "apiKey":
 			out.ApiKey = string(in.String())
 		case "model":
@@ -5395,6 +5397,11 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo36(out *jwriter.Writ
 		const prefix string = ",\"source\":"
 		out.RawString(prefix[1:])
 		out.String(string(in.Source))
+	}
+	if in.URL != "" {
+		const prefix string = ",\"url\":"
+		out.RawString(prefix)
+		out.String(string(in.URL))
 	}
 	if in.ApiKey != "" {
 		const prefix string = ",\"apiKey\":"


### PR DESCRIPTION
# Pull Request

## What does this PR do?
Partial fix for #576

The documentation for the Ollama Embedder states that there is an `url` field that can be used to specify how Ollama can be reached. However, this field is not present yet in this client library.

See: https://www.meilisearch.com/docs/learn/experimental/vector_search#generate-auto-embeddings

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?
