### PR TITLE
[v1.11.0] Make the embedder mandatory everywhere

### DIFF
--- a/index_search_test.go
+++ b/index_search_test.go
@@ -1943,19 +1943,6 @@ func TestIndex_SearchWithVectorStore(t *testing.T) {
 				RetrieveVectors: true,
 			},
 		},
-		{
-			name:   "empty Embedder",
-			UID:    "indexUID",
-			client: sv,
-			query:  "Pride and Prejudice",
-			request: SearchRequest{
-				Hybrid: &SearchRequestHybrid{
-					SemanticRatio: 0.5,
-					Embedder:      "",
-				},
-				RetrieveVectors: true,
-			},
-		},
 	}
 
 	for _, tt := range tests {
@@ -2029,6 +2016,7 @@ func TestIndex_SearchSimilarDocuments(t *testing.T) {
 			client: sv,
 			request: &SimilarDocumentQuery{
 				Id: "123",
+				Embedder: "default",
 			},
 			resp:    new(SimilarDocumentResult),
 			wantErr: false,
@@ -2036,7 +2024,9 @@ func TestIndex_SearchSimilarDocuments(t *testing.T) {
 		{
 			UID:     "indexUID",
 			client:  sv,
-			request: &SimilarDocumentQuery{},
+			request: &SimilarDocumentQuery{
+				Embedder: "default",
+			},
 			resp:    new(SimilarDocumentResult),
 			wantErr: true,
 		},

--- a/index_settings_test.go
+++ b/index_settings_test.go
@@ -3422,7 +3422,7 @@ func TestIndex_UpdateSettingsEmbedders(t *testing.T) {
 						"default": {
 							Source:           "openAi",
 							ApiKey:           "xxx",
-							Model:            "text-embedding-ada-002",
+							Model:            "text-embedding-3-small",
 							DocumentTemplate: "A movie titled '{{doc.title}}'",
 						},
 					},

--- a/types.go
+++ b/types.go
@@ -433,7 +433,7 @@ type SearchRequest struct {
 	IndexUID                string                   `json:"indexUid,omitempty"`
 	Query                   string                   `json:"q"`
 	Distinct                string                   `json:"distinct,omitempty"`
-	Hybrid                  *SearchRequestHybrid     `json:"hybrid,omitempty"`
+	Hybrid                  *SearchRequestHybrid     `json:"hybrid"`
 	RetrieveVectors         bool                     `json:"retrieveVectors,omitempty"`
 	RankingScoreThreshold   float64                  `json:"rankingScoreThreshold,omitempty"`
 	FederationOptions       *SearchFederationOptions `json:"federationOptions,omitempty"`
@@ -446,7 +446,7 @@ type SearchFederationOptions struct {
 
 type SearchRequestHybrid struct {
 	SemanticRatio float64 `json:"semanticRatio,omitempty"`
-	Embedder      string  `json:"embedder,omitempty"`
+	Embedder      string  `json:"embedder"`
 }
 
 type MultiSearchRequest struct {
@@ -517,7 +517,7 @@ type DocumentsQuery struct {
 // SimilarDocumentQuery is query parameters of similar documents
 type SimilarDocumentQuery struct {
 	Id                      interface{} `json:"id,omitempty"`
-	Embedder                string      `json:"embedder,omitempty"`
+	Embedder                string      `json:"embedder"`
 	AttributesToRetrieve    []string    `json:"attributesToRetrieve,omitempty"`
 	Offset                  int64       `json:"offset,omitempty"`
 	Limit                   int64       `json:"limit,omitempty"`


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #578 

## What does this PR do?
- Makes the `hybrid.embedder` field mandatory everywhere.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
