### PR TITLE
Allow retrieving vectors when fetching documents

### DIFF
--- a/index_document.go
+++ b/index_document.go
@@ -262,6 +262,9 @@ func (i *index) GetDocumentWithContext(ctx context.Context, identifier string, r
 		if len(request.Fields) != 0 {
 			req.withQueryParams["fields"] = strings.Join(request.Fields, ",")
 		}
+		if request.RetrieveVectors {
+			req.withQueryParams["retrieveVectors"] = "true"
+		}
 	}
 	if err := i.client.executeRequest(ctx, req); err != nil {
 		return err
@@ -294,6 +297,9 @@ func (i *index) GetDocumentsWithContext(ctx context.Context, param *DocumentsQue
 		}
 		if len(param.Fields) != 0 {
 			req.withQueryParams["fields"] = strings.Join(param.Fields, ",")
+		}
+		if param.RetrieveVectors {
+			req.withQueryParams["retrieveVectors"] = "true"
 		}
 	} else if param != nil && param.Filter != nil {
 		req.withRequest = param

--- a/types.go
+++ b/types.go
@@ -516,15 +516,17 @@ type FacetSearchResponse struct {
 
 // DocumentQuery is the request body get one documents method
 type DocumentQuery struct {
-	Fields []string `json:"fields,omitempty"`
+	Fields          []string `json:"fields,omitempty"`
+	RetrieveVectors bool     `json:"retrieveVectors,omitempty"`
 }
 
 // DocumentsQuery is the request body for list documents method
 type DocumentsQuery struct {
-	Offset int64       `json:"offset,omitempty"`
-	Limit  int64       `json:"limit,omitempty"`
-	Fields []string    `json:"fields,omitempty"`
-	Filter interface{} `json:"filter,omitempty"`
+	Offset          int64       `json:"offset,omitempty"`
+	Limit           int64       `json:"limit,omitempty"`
+	Fields          []string    `json:"fields,omitempty"`
+	Filter          interface{} `json:"filter,omitempty"`
+	RetrieveVectors bool        `json:"retrieveVectors,omitempty"`
 }
 
 // SimilarDocumentQuery is query parameters of similar documents

--- a/types_easyjson.go
+++ b/types_easyjson.go
@@ -6701,6 +6701,8 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo44(in *jlexer.Lexer,
 			} else {
 				out.Filter = in.Interface()
 			}
+		case "retrieveVectors":
+			out.RetrieveVectors = bool(in.Bool())
 		default:
 			in.SkipRecursive()
 		}
@@ -6765,6 +6767,16 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo44(out *jwriter.Writ
 		} else {
 			out.Raw(json.Marshal(in.Filter))
 		}
+	}
+	if in.RetrieveVectors {
+		const prefix string = ",\"retrieveVectors\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.Bool(bool(in.RetrieveVectors))
 	}
 	out.RawByte('}')
 }
@@ -6834,6 +6846,8 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo45(in *jlexer.Lexer,
 				}
 				in.Delim(']')
 			}
+		case "retrieveVectors":
+			out.RetrieveVectors = bool(in.Bool())
 		default:
 			in.SkipRecursive()
 		}
@@ -6862,6 +6876,16 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo45(out *jwriter.Writ
 			}
 			out.RawByte(']')
 		}
+	}
+	if in.RetrieveVectors {
+		const prefix string = ",\"retrieveVectors\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.Bool(bool(in.RetrieveVectors))
 	}
 	out.RawByte('}')
 }


### PR DESCRIPTION
# Pull Request
This adds fields that are required for retrieving vectors from Meili.

## Related issue
I didn't open an issue as I just fixed it - however, if you want a more proper discussion about how to add this, I can open one.

## What does this PR do?
- Adds the `retrieveVectors` option for [document fetching endpoints](https://www.meilisearch.com/docs/reference/api/documents) to the Go client
- This is required for end-users who work with the vectors stored in their index

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?
