### PR TITLE
feat: add the retrieveVectors field to the GetDocument method

### DIFF
--- a/index_document.go
+++ b/index_document.go
@@ -262,6 +262,9 @@ func (i *index) GetDocumentWithContext(ctx context.Context, identifier string, r
 		if len(request.Fields) != 0 {
 			req.withQueryParams["fields"] = strings.Join(request.Fields, ",")
 		}
+		if request.RetrieveVectors {
+			req.withQueryParams["retrieveVectors"] = "true"
+		}
 	}
 	if err := i.client.executeRequest(ctx, req); err != nil {
 		return err
@@ -294,6 +297,9 @@ func (i *index) GetDocumentsWithContext(ctx context.Context, param *DocumentsQue
 		}
 		if len(param.Fields) != 0 {
 			req.withQueryParams["fields"] = strings.Join(param.Fields, ",")
+		}
+		if param.RetrieveVectors {
+			req.withQueryParams["retrieveVectors"] = "true"
 		}
 	} else if param != nil && param.Filter != nil {
 		req.withRequest = param

--- a/types.go
+++ b/types.go
@@ -516,15 +516,17 @@ type FacetSearchResponse struct {
 
 // DocumentQuery is the request body get one documents method
 type DocumentQuery struct {
-	Fields []string `json:"fields,omitempty"`
+	Fields          []string `json:"fields,omitempty"`
+	RetrieveVectors bool     `json:"retrieveVectors,omitempty"`
 }
 
 // DocumentsQuery is the request body for list documents method
 type DocumentsQuery struct {
-	Offset int64       `json:"offset,omitempty"`
-	Limit  int64       `json:"limit,omitempty"`
-	Fields []string    `json:"fields,omitempty"`
-	Filter interface{} `json:"filter,omitempty"`
+	Offset          int64       `json:"offset,omitempty"`
+	Limit           int64       `json:"limit,omitempty"`
+	Fields          []string    `json:"fields,omitempty"`
+	Filter          interface{} `json:"filter,omitempty"`
+	RetrieveVectors bool        `json:"retrieveVectors,omitempty"`
 }
 
 // SimilarDocumentQuery is query parameters of similar documents

--- a/types_easyjson.go
+++ b/types_easyjson.go
@@ -6674,6 +6674,8 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo44(in *jlexer.Lexer,
 			} else {
 				out.Filter = in.Interface()
 			}
+		case "retrieveVectors":
+			out.RetrieveVectors = bool(in.Bool())
 		default:
 			in.SkipRecursive()
 		}
@@ -6738,6 +6740,16 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo44(out *jwriter.Writ
 		} else {
 			out.Raw(json.Marshal(in.Filter))
 		}
+	}
+	if in.RetrieveVectors {
+		const prefix string = ",\"retrieveVectors\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.Bool(bool(in.RetrieveVectors))
 	}
 	out.RawByte('}')
 }
@@ -6807,6 +6819,8 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo45(in *jlexer.Lexer,
 				}
 				in.Delim(']')
 			}
+		case "retrieveVectors":
+			out.RetrieveVectors = bool(in.Bool())
 		default:
 			in.SkipRecursive()
 		}
@@ -6835,6 +6849,16 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo45(out *jwriter.Writ
 			}
 			out.RawByte(']')
 		}
+	}
+	if in.RetrieveVectors {
+		const prefix string = ",\"retrieveVectors\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.Bool(bool(in.RetrieveVectors))
 	}
 	out.RawByte('}')
 }


### PR DESCRIPTION
# Pull Request


## add the retrieveVectors field to the GetDocument method
When getting document, I need to return the document vector data, but the latest version of go SDK doesn't implement it. I added the retrieveVectors field [get-documents](https://www.meilisearch.com/docs/reference/api/documents#get-documents-with-post), which is a minor change. I hope it will be merged soon.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for retrieving vector data when fetching documents by introducing a new option in document query requests.
- **Enhancements**
	- Document queries now allow specifying whether to include vector information in responses, offering more flexible data retrieval for advanced use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->