### PR TITLE
Adds document database metric to stats object

### DIFF
--- a/index_test.go
+++ b/index_test.go
@@ -122,6 +122,8 @@ func TestIndex_GetStats(t *testing.T) {
 				NumberOfDocuments: 6,
 				IsIndexing:        false,
 				FieldDistribution: map[string]int64{"book_id": 6, "title": 6},
+				RawDocumentDbSize: 4096,
+				AvgDocumentSize:   674,
 			},
 		},
 		{
@@ -134,6 +136,8 @@ func TestIndex_GetStats(t *testing.T) {
 				NumberOfDocuments: 6,
 				IsIndexing:        false,
 				FieldDistribution: map[string]int64{"book_id": 6, "title": 6},
+				RawDocumentDbSize: 4096,
+				AvgDocumentSize:   674,
 			},
 		},
 	}

--- a/types.go
+++ b/types.go
@@ -153,6 +153,8 @@ type StatsIndex struct {
 	NumberOfDocuments int64            `json:"numberOfDocuments"`
 	IsIndexing        bool             `json:"isIndexing"`
 	FieldDistribution map[string]int64 `json:"fieldDistribution"`
+	RawDocumentDbSize int64            `json:"rawDocumentDbSize"`
+	AvgDocumentSize   int64            `json:"avgDocumentSize"`
 }
 
 // Stats is the type that represent all stats

--- a/types_easyjson.go
+++ b/types_easyjson.go
@@ -1582,6 +1582,10 @@ func easyjson6601e8cdDecodeGithubComMeilisearchMeilisearchGo12(in *jlexer.Lexer,
 				}
 				in.Delim('}')
 			}
+		case "rawDocumentDbSize":
+			out.RawDocumentDbSize = int64(in.Int64())
+		case "avgDocumentSize":
+			out.AvgDocumentSize = int64(in.Int64())
 		default:
 			in.SkipRecursive()
 		}
@@ -1626,6 +1630,16 @@ func easyjson6601e8cdEncodeGithubComMeilisearchMeilisearchGo12(out *jwriter.Writ
 			}
 			out.RawByte('}')
 		}
+	}
+	{
+		const prefix string = ",\"rawDocumentDbSize\":"
+		out.RawString(prefix)
+		out.Int64(int64(in.RawDocumentDbSize))
+	}
+	{
+		const prefix string = ",\"avgDocumentSize\":"
+		out.RawString(prefix)
+		out.Int64(int64(in.AvgDocumentSize))
 	}
 	out.RawByte('}')
 }


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #615 

## What does this PR do?
- Adds `indexes.INDEXNAME.rawDocumentDbSize` in SDK responses
- Adds `indexes.INDEXNAME.avgDocumentSize` in SDK responses

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
