### PR TITLE
Make connection errors more specific

### DIFF
--- a/meilisearch_interface.go
+++ b/meilisearch_interface.go
@@ -54,6 +54,9 @@ type ServiceManager interface {
 	// ExperimentalFeatures returns the experimental features manager.
 	ExperimentalFeatures() *ExperimentalFeatures
 
+	// Get the error result of HealthWithContext()
+	getErr() error
+
 	// Close closes the connection to the Meilisearch server.
 	Close()
 }


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #640 

## What does this PR do?
- meilisearch.Connect will now return a more specific error instead of the generic "meilisearch is not connected" which makes it easier to troubleshoot unsuccessful connections 

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved error reporting for connection issues, providing more detailed feedback when connection attempts fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->