### PR TITLE
Update meilisearch.Connect to return more specific errors

### DIFF
--- a/error.go
+++ b/error.go
@@ -186,4 +186,5 @@ var (
 	ErrNoSearchRequest               = errors.New("no search request provided")
 	ErrNoFacetSearchRequest          = errors.New("no search facet request provided")
 	ErrConnectingFailed              = errors.New("meilisearch is not connected")
+	ErrMeilisearchNotAvailable       = errors.New("meilisearch service is not available")
 )

--- a/meilisearch.go
+++ b/meilisearch.go
@@ -42,8 +42,14 @@ func New(host string, options ...Option) ServiceManager {
 func Connect(host string, options ...Option) (ServiceManager, error) {
 	meili := New(host, options...)
 
-	if !meili.IsHealthy() {
-		return nil, ErrConnectingFailed
+	resp, err := meili.HealthWithContext(context.Background())
+
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.Status != "available" {
+		return nil, ErrMeilisearchNotAvailable
 	}
 
 	return meili, nil


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #640 

## What does this PR do?
- meilisearch.Connect will now return a more specific error instead of the generic "meilisearch is not connected" which makes it easier to troubleshoot unsuccessful connections

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
