### PR TITLE
Stabilize embedders, add remote federated search and composite embedders

### DIFF
--- a/enum.go
+++ b/enum.go
@@ -101,3 +101,35 @@ func (c ContentEncoding) String() string { return string(c) }
 func (c ContentEncoding) IsZero() bool { return c == "" }
 
 func (c EncodingCompressionLevel) Int() int { return int(c) }
+
+// EmbedderSource The source corresponds to a service that generates embeddings from your documents.
+type EmbedderSource string
+
+const (
+	OpenaiEmbedderSource      EmbedderSource = "openAi"
+	HuggingFaceEmbedderSource EmbedderSource = "huggingFace"
+	// RestEmbedderSource rest is a generic source compatible with any embeddings provider offering a REST API.
+	RestEmbedderSource   EmbedderSource = "rest"
+	OllamaEmbedderSource EmbedderSource = "ollama"
+	// UserProvidedEmbedderSource Use userProvided when you want to generate embeddings manually. In this case,
+	// you must include vector data in your documents’ _vectors field. You must also generate
+	//vectors for search queries.
+	UserProvidedEmbedderSource EmbedderSource = "userProvided"
+	// CompositeEmbedderSource Choose composite to use one embedder during indexing time, and another embedder at search time.
+	//Must be used together with indexingEmbedder and searchEmbedder.
+	CompositeEmbedderSource EmbedderSource = "composite"
+)
+
+// EmbedderPooling Configure how Meilisearch should merge individual tokens into a single embedding.
+//
+// pooling is optional for embedders with the huggingFace source.
+type EmbedderPooling string
+
+const (
+	// UseModelEmbedderPooling Meilisearch will fetch the pooling method from the model configuration. Default value for new embedders
+	UseModelEmbedderPooling EmbedderPooling = "useModel"
+	// ForceMeanEmbedderPooling always use mean pooling. Default value for embedders created in Meilisearch <=v1.13
+	ForceMeanEmbedderPooling EmbedderPooling = "forceMean"
+	// ForceClsEmbedderPooling always use CLS pooling
+	ForceClsEmbedderPooling EmbedderPooling = "forceCls"
+)

--- a/features.go
+++ b/features.go
@@ -39,6 +39,11 @@ func (ef *ExperimentalFeatures) SetNetwork(enable bool) *ExperimentalFeatures {
 	return ef
 }
 
+func (ef *ExperimentalFeatures) SetCompositeEmbedders(enable bool) *ExperimentalFeatures {
+	ef.CompositeEmbedders = &enable
+	return ef
+}
+
 func (ef *ExperimentalFeatures) Get() (*ExperimentalFeaturesResult, error) {
 	return ef.GetWithContext(context.Background())
 }
@@ -73,6 +78,7 @@ func (ef *ExperimentalFeatures) UpdateWithContext(ctx context.Context) (*Experim
 		EditDocumentsByFunction: ef.EditDocumentsByFunction,
 		ContainsFilter:          ef.ContainsFilter,
 		Network:                 ef.Network,
+		CompositeEmbedders:      ef.CompositeEmbedders,
 	}
 	resp := new(ExperimentalFeaturesResult)
 	req := &internalRequest{

--- a/features_test.go
+++ b/features_test.go
@@ -65,6 +65,7 @@ func TestUpdate_ExperimentalFeatures(t *testing.T) {
 			ef.SetEditDocumentsByFunction(true)
 			ef.SetContainsFilter(true)
 			ef.SetNetwork(true)
+			ef.SetCompositeEmbedders(true)
 			gotResp, err := ef.Update()
 			require.NoError(t, err)
 			require.Equal(t, true, gotResp.LogsRoute, "ExperimentalFeatures.Update() should return logsRoute as true")
@@ -72,6 +73,7 @@ func TestUpdate_ExperimentalFeatures(t *testing.T) {
 			require.Equal(t, true, gotResp.EditDocumentsByFunction, "ExperimentalFeatures.Update() should return editDocumentsByFunction as true")
 			require.Equal(t, true, gotResp.ContainsFilter, "ExperimentalFeatures.Update() should return containsFilter as true")
 			require.Equal(t, true, gotResp.Network, "ExperimentalFeatures.Update() should return network as true")
+			require.Equal(t, true, gotResp.CompositeEmbedders, "ExperimentalFeatures.Update() should return composite embedders as true")
 		})
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -337,7 +337,7 @@ func setUpIndexWithVector(client *meilisearch, indexUID string) (resp *IndexResu
 	taskInfo, err := idx.UpdateSettings(&Settings{
 		Embedders: map[string]Embedder{
 			"default": {
-				Source:     "userProvided",
+				Source:     UserProvidedEmbedderSource,
 				Dimensions: 3,
 			},
 		},

--- a/types.go
+++ b/types.go
@@ -385,7 +385,8 @@ type SearchRequest struct {
 }
 
 type SearchFederationOptions struct {
-	Weight float64 `json:"weight"`
+	Weight float64 `json:"weight,omitempty"`
+	Remote string  `json:"remote,omitempty"`
 }
 
 type SearchRequestHybrid struct {


### PR DESCRIPTION
# Pull Request

## Related issue
Resolves #611
Resolves #612
Resolves #625

## What does this PR do?
- This PR Stabilize AI-powered search
- Add remote for fedration option in multisearch
- Support composite embedders

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for composite embedders, allowing different embedders for indexing and searching.
  * Introduced new embedder sources, including HuggingFace and Ollama.
  * Added new pooling options for embedders, such as model default, mean, and CLS pooling.
  * Enhanced embedder settings with additional configuration options.

* **Bug Fixes**
  * Standardized embedder source values using constants to improve consistency.

* **Tests**
  * Expanded test coverage for new embedder sources, pooling options, and composite embedder configurations.
  * Improved test assertions for embedder settings updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->