### PR TITLE
feat: add ids to DocumentsQuery

### DIFF
--- a/index_document_test.go
+++ b/index_document_test.go
@@ -7,6 +7,39 @@ import (
 	"testing"
 )
 
+func Test_GetDocumentsByIDS(t *testing.T) {
+	sv := setup(t, "")
+	t.Cleanup(cleanup(sv))
+
+	_, err := sv.CreateIndex(&IndexConfig{
+		Uid: "TestGetDocumentsByIDs",
+	})
+
+	require.NoError(t, err)
+	request := []map[string]interface{}{
+		{"ID": "1", "Name": "Pride and Prejudice 1"},
+		{"ID": "2", "Name": "Pride and Prejudice 2"},
+		{"ID": "3", "Name": "Pride and Prejudice 3"},
+	}
+	i := sv.Index("TestGetDocumentsByIDs")
+
+	ts, err := i.AddDocuments(request)
+	require.NoError(t, err)
+
+	testWaitForTask(t, i, ts)
+
+	var documents DocumentsResult
+	err = sv.Index("TestGetDocumentsByIDs").GetDocuments(&DocumentsQuery{Ids: []string{"1", "2", "3"}}, &documents)
+	require.NoError(t, err)
+
+	results := Hits{
+		{"ID": toRawMessage("1"), "Name": toRawMessage("Pride and Prejudice 1")},
+		{"ID": toRawMessage("2"), "Name": toRawMessage("Pride and Prejudice 2")},
+		{"ID": toRawMessage("3"), "Name": toRawMessage("Pride and Prejudice 3")},
+	}
+	require.Equal(t, results, documents.Results)
+}
+
 func Test_AddOrUpdateDocumentsWithContentEncoding(t *testing.T) {
 	tests := []struct {
 		Name            string

--- a/types.go
+++ b/types.go
@@ -467,6 +467,7 @@ type DocumentsQuery struct {
 	Fields          []string    `json:"fields,omitempty"`
 	Filter          interface{} `json:"filter,omitempty"`
 	RetrieveVectors bool        `json:"retrieveVectors,omitempty"`
+	Ids             []string    `json:"ids,omitempty"`
 }
 
 // SimilarDocumentQuery is query parameters of similar documents


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #628

## What does this PR do?
- Adds support for fetching documents by a list of IDs in the DocumentsQuery struct.
- Enables clients to retrieve multiple documents in a single request using document IDs.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
