### PR TITLE
feat: add disableOnNumbers to TypoTolerance

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -523,6 +523,10 @@ typo_tolerance_guide_4: |-
       TwoTypos: 10,
     },
   })
+typo_tolerance_guide_5: |-
+  client.Index("movies").UpdateTypoTolerance(&meilisearch.TypoTolerance{
+    DisableOnNumbers: true
+  })
 add_movies_json_1: |-
   import (
     "encoding/json"

--- a/index_settings_test.go
+++ b/index_settings_test.go
@@ -1700,6 +1700,7 @@ func TestIndex_UpdateSettings(t *testing.T) {
 						},
 						DisableOnWords:      []string{},
 						DisableOnAttributes: []string{},
+						DisableOnNumbers:    true,
 					},
 					Pagination: &Pagination{
 						MaxTotalHits: 1200,
@@ -1793,6 +1794,7 @@ func TestIndex_UpdateSettings(t *testing.T) {
 						},
 						DisableOnWords:      []string{},
 						DisableOnAttributes: []string{},
+						DisableOnNumbers:    true,
 					},
 					Pagination: &Pagination{
 						MaxTotalHits: 1200,
@@ -2532,6 +2534,7 @@ func TestIndex_UpdateSettingsOneByOne(t *testing.T) {
 						},
 						DisableOnWords:      []string{},
 						DisableOnAttributes: []string{},
+						DisableOnNumbers:    false,
 					},
 				},
 				firstResponse: Settings{
@@ -2551,6 +2554,7 @@ func TestIndex_UpdateSettingsOneByOne(t *testing.T) {
 						},
 						DisableOnWords:      []string{},
 						DisableOnAttributes: []string{},
+						DisableOnNumbers:    false,
 					},
 					FilterableAttributes: []string{},
 					SortableAttributes:   []string{},
@@ -2577,6 +2581,7 @@ func TestIndex_UpdateSettingsOneByOne(t *testing.T) {
 						DisableOnAttributes: []string{
 							"year",
 						},
+						DisableOnNumbers: true,
 					},
 				},
 				secondResponse: Settings{
@@ -2602,6 +2607,7 @@ func TestIndex_UpdateSettingsOneByOne(t *testing.T) {
 						DisableOnAttributes: []string{
 							"year",
 						},
+						DisableOnNumbers: true,
 					},
 					Pagination:         &defaultPagination,
 					Faceting:           &defaultFaceting,
@@ -3183,12 +3189,22 @@ func TestIndex_UpdateTypoTolerance(t *testing.T) {
 					},
 					DisableOnWords:      []string{},
 					DisableOnAttributes: []string{},
+					DisableOnNumbers:    true,
 				},
 			},
 			wantTask: &TaskInfo{
 				TaskUID: 1,
 			},
-			wantResp: &defaultTypoTolerance,
+			wantResp: &TypoTolerance{
+				Enabled: true,
+				MinWordSizeForTypos: MinWordSizeForTypos{
+					OneTypo:  7,
+					TwoTypos: 10,
+				},
+				DisableOnWords:      []string{},
+				DisableOnAttributes: []string{},
+				DisableOnNumbers:    true,
+			},
 		},
 		{
 			name: "TestIndexUpdateTypoToleranceWithCustomClient",
@@ -3203,12 +3219,22 @@ func TestIndex_UpdateTypoTolerance(t *testing.T) {
 					},
 					DisableOnWords:      []string{},
 					DisableOnAttributes: []string{},
+					DisableOnNumbers:    false,
 				},
 			},
 			wantTask: &TaskInfo{
 				TaskUID: 1,
 			},
-			wantResp: &defaultTypoTolerance,
+			wantResp: &TypoTolerance{
+				Enabled: true,
+				MinWordSizeForTypos: MinWordSizeForTypos{
+					OneTypo:  7,
+					TwoTypos: 10,
+				},
+				DisableOnWords:      []string{},
+				DisableOnAttributes: []string{},
+				DisableOnNumbers:    false,
+			},
 		},
 		{
 			name: "TestIndexUpdateTypoToleranceWithDisableOnWords",
@@ -3225,12 +3251,22 @@ func TestIndex_UpdateTypoTolerance(t *testing.T) {
 						"and",
 					},
 					DisableOnAttributes: []string{},
+					DisableOnNumbers:    true,
 				},
 			},
 			wantTask: &TaskInfo{
 				TaskUID: 1,
 			},
-			wantResp: &defaultTypoTolerance,
+			wantResp: &TypoTolerance{
+				Enabled: true,
+				MinWordSizeForTypos: MinWordSizeForTypos{
+					OneTypo:  7,
+					TwoTypos: 10,
+				},
+				DisableOnWords:      []string{"and"},
+				DisableOnAttributes: []string{},
+				DisableOnNumbers:    true,
+			},
 		},
 		{
 			name: "TestIndexUpdateTypoToleranceWithDisableOnAttributes",
@@ -3247,12 +3283,22 @@ func TestIndex_UpdateTypoTolerance(t *testing.T) {
 					DisableOnAttributes: []string{
 						"year",
 					},
+					DisableOnNumbers: true,
 				},
 			},
 			wantTask: &TaskInfo{
 				TaskUID: 1,
 			},
-			wantResp: &defaultTypoTolerance,
+			wantResp: &TypoTolerance{
+				Enabled: true,
+				MinWordSizeForTypos: MinWordSizeForTypos{
+					OneTypo:  7,
+					TwoTypos: 10,
+				},
+				DisableOnWords:      []string{},
+				DisableOnAttributes: []string{"year"},
+				DisableOnNumbers:    true,
+			},
 		},
 		{
 			name: "TestIndexDisableTypoTolerance",
@@ -3267,6 +3313,7 @@ func TestIndex_UpdateTypoTolerance(t *testing.T) {
 					},
 					DisableOnWords:      []string{},
 					DisableOnAttributes: []string{},
+					DisableOnNumbers:    false,
 				},
 			},
 			wantTask: &TaskInfo{
@@ -3274,6 +3321,13 @@ func TestIndex_UpdateTypoTolerance(t *testing.T) {
 			},
 			wantResp: &TypoTolerance{
 				Enabled: false,
+				MinWordSizeForTypos: MinWordSizeForTypos{
+					OneTypo:  5,
+					TwoTypos: 9,
+				},
+				DisableOnWords:      []string{},
+				DisableOnAttributes: []string{},
+				DisableOnNumbers:    false,
 			},
 		},
 	}
@@ -3291,7 +3345,7 @@ func TestIndex_UpdateTypoTolerance(t *testing.T) {
 
 			gotResp, err := i.GetTypoTolerance()
 			require.NoError(t, err)
-			require.Equal(t, &tt.args.request, gotResp)
+			require.Equal(t, tt.wantResp, gotResp)
 		})
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -27,6 +27,7 @@ var (
 		},
 		DisableOnWords:      []string{},
 		DisableOnAttributes: []string{},
+		DisableOnNumbers:    false,
 	}
 	defaultPagination = Pagination{
 		MaxTotalHits: 1000,

--- a/types.go
+++ b/types.go
@@ -77,6 +77,7 @@ type TypoTolerance struct {
 	MinWordSizeForTypos MinWordSizeForTypos `json:"minWordSizeForTypos,omitempty"`
 	DisableOnWords      []string            `json:"disableOnWords,omitempty"`
 	DisableOnAttributes []string            `json:"disableOnAttributes,omitempty"`
+	DisableOnNumbers    bool                `json:"disableOnNumbers,omitempty"`
 }
 
 // MinWordSizeForTypos is the type that represents the minWordSizeForTypos setting in the typo tolerance setting in meilisearch


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #638

## What does this PR do?
- Add new field disableOnNumbers to typoTolerance settings API
- Update Index_UpdateSettings setting with new field disableOnNumbers

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `DisableOnNumbers` option in typo tolerance settings, allowing users to control whether typo tolerance is applied to numbers in search queries.
  * Updated code samples and tests to demonstrate and validate the new `DisableOnNumbers` setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->