### PR TITLE
Update max version of go to 1.24 in pipeline 

### DIFF
--- a/.github/workflows/pre-release-tests.yml
+++ b/.github/workflows/pre-release-tests.yml
@@ -14,11 +14,11 @@ jobs:
     strategy:
       matrix:
         # Current go.mod version and latest stable go version
-        go: [1.16, 1.17]
+        go: [1.16, 1.24]
         include:
           - go: 1.16
             tag: current
-          - go: 1.17
+          - go: 1.24
             tag: latest
 
     name: integration-tests-against-rc (go ${{ matrix.tag }} version)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,11 +37,11 @@ jobs:
     strategy:
       matrix:
         # Current go.mod version and latest stable go version
-        go: [1.16, 1.17]
+        go: [1.16, 1.24]
         include:
           - go: 1.16
             tag: current
-          - go: 1.17
+          - go: 1.24
             tag: latest
 
     name: integration-tests (go ${{ matrix.tag }} version)


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #653 

## What does this PR do?
- This PR change max version of golang to 1.24 for pipelines

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated integration test workflows to use Go versions 1.16 and 1.24 for testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->