### PR TITLE
Bump minimum go version into 1.20

### DIFF
--- a/.github/workflows/pre-release-tests.yml
+++ b/.github/workflows/pre-release-tests.yml
@@ -14,9 +14,9 @@ jobs:
     strategy:
       matrix:
         # Current go.mod version and latest stable go version
-        go: [1.16, 1.24]
+        go: [1.20, 1.24]
         include:
-          - go: 1.16
+          - go: 1.20
             tag: current
           - go: 1.24
             tag: latest

--- a/.github/workflows/pre-release-tests.yml
+++ b/.github/workflows/pre-release-tests.yml
@@ -14,11 +14,11 @@ jobs:
     strategy:
       matrix:
         # Current go.mod version and latest stable go version
-        go: [1.20, 1.24]
+        go: ["1.20", "1.24"]
         include:
-          - go: 1.20
+          - go: "1.20"
             tag: current
-          - go: 1.24
+          - go: "1.24"
             tag: latest
 
     name: integration-tests-against-rc (go ${{ matrix.tag }} version)

--- a/.github/workflows/pre-release-tests.yml
+++ b/.github/workflows/pre-release-tests.yml
@@ -27,13 +27,18 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
+
       - name: Get dependencies
-        run: go mod download -x
+        run: go mod download
+
       - name: Get the latest Meilisearch RC
         run: echo "MEILISEARCH_VERSION=$(curl https://raw.githubusercontent.com/meilisearch/integration-guides/main/scripts/get-latest-meilisearch-rc.sh | bash)" >> $GITHUB_ENV
+
       - name: Meilisearch (${{ env.MEILISEARCH_VERSION }}) setup with Docker
         run: docker run -d -p 7700:7700 getmeili/meilisearch:${{ env.MEILISEARCH_VERSION }} meilisearch --master-key=masterKey --no-analytics
+
       - name: Run integration tests
         run: go test -v ./...

--- a/.github/workflows/pre-release-tests.yml
+++ b/.github/workflows/pre-release-tests.yml
@@ -30,13 +30,7 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
       - name: Get dependencies
-        run: |
-          if [ -f go.mod ]; then
-            go mod download -x
-          elif [ -f Gopkg.toml ]; then
-            curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-            dep ensure
-          fi
+        run: go mod download -x
       - name: Get the latest Meilisearch RC
         run: echo "MEILISEARCH_VERSION=$(curl https://raw.githubusercontent.com/meilisearch/integration-guides/main/scripts/get-latest-meilisearch-rc.sh | bash)" >> $GITHUB_ENV
       - name: Meilisearch (${{ env.MEILISEARCH_VERSION }}) setup with Docker

--- a/.github/workflows/pre-release-tests.yml
+++ b/.github/workflows/pre-release-tests.yml
@@ -31,8 +31,9 @@ jobs:
         uses: actions/checkout@v4
       - name: Get dependencies
         run: |
-          go get -v -t -d ./...
-          if [ -f Gopkg.toml ]; then
+          if [ -f go.mod ]; then
+            go mod download -x
+          elif [ -f Gopkg.toml ]; then
             curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
             dep ensure
           fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,11 +37,11 @@ jobs:
     strategy:
       matrix:
         # Current go.mod version and latest stable go version
-        go: [1.20, 1.24]
+        go: ["1.20", "1.24"]
         include:
-          - go: 1.20
+          - go: "1.20"
             tag: current
-          - go: 1.24
+          - go: "1.24"
             tag: latest
 
     name: integration-tests (go ${{ matrix.tag }} version)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,8 +54,9 @@ jobs:
         uses: actions/checkout@v4
       - name: Get dependencies
         run: |
-          go get -v -t -d ./...
-          if [ -f Gopkg.toml ]; then
+          if [ -f go.mod ]; then
+            go mod download -x
+          elif [ -f Gopkg.toml ]; then
             curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
             dep ensure
           fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,13 +53,7 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
       - name: Get dependencies
-        run: |
-          if [ -f go.mod ]; then
-            go mod download -x
-          elif [ -f Gopkg.toml ]; then
-            curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-            dep ensure
-          fi
+        run: go mod download -x
       - name: Meilisearch setup (latest version) with Docker
         run: docker run -d -p 7700:7700 getmeili/meilisearch:latest meilisearch --master-key=masterKey --no-analytics
       - name: Run unit tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,12 +16,12 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.17
+          go-version: 1.24
       - uses: actions/checkout@v4
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.45.2
+          version: v2.3.0
       - name: Run go vet
         run: go vet
       - name: Yaml linter

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,9 +37,9 @@ jobs:
     strategy:
       matrix:
         # Current go.mod version and latest stable go version
-        go: [1.16, 1.24]
+        go: [1.20, 1.24]
         include:
-          - go: 1.16
+          - go: 1.20
             tag: current
           - go: 1.24
             tag: latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,22 +50,29 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
+
       - name: Get dependencies
-        run: go mod download -x
+        run: go mod download
+
       - name: Meilisearch setup (latest version) with Docker
         run: docker run -d -p 7700:7700 getmeili/meilisearch:latest meilisearch --master-key=masterKey --no-analytics
+
       - name: Run unit tests
         run: |
           go test --race -v -gcflags=-l -coverprofile=unit_coverage.txt -covermode=atomic $(go list ./... | grep -v /integration)
+
       - name: Run integration tests
         run: |
           go test --race -v -gcflags=-l -coverprofile=integration_coverage.txt -covermode=atomic -coverpkg=./... ./integration
+
       - name: Merge coverage reports
         run: |
           go install github.com/ja7ad/gocovmerge/cmd/gocovmerge@v0.2.0
           gocovmerge unit_coverage.txt integration_coverage.txt > coverage.txt
+
       - name: Upload coverage report
         uses: codecov/codecov-action@v5
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
           go-version: 1.24
       - uses: actions/checkout@v4
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
           version: v2.3.0
       - name: Run go vet

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.17.11-buster
+FROM golang:1.20-buster
 
 WORKDIR /home/package
 
 COPY go.mod .
 COPY go.sum .
 
-COPY --from=golangci/golangci-lint:v1.42.0 /usr/bin/golangci-lint /usr/local/bin/golangci-lint
+COPY --from=golangci/golangci-lint:v2.3.0 /usr/bin/golangci-lint /usr/local/bin/golangci-lint
 
 RUN go mod download
 RUN go mod verify

--- a/client.go
+++ b/client.go
@@ -218,7 +218,7 @@ func (c *client) do(req *http.Request, internalError *Error) (resp *http.Respons
 			retriesCount++
 
 			// Close response body to prevent memory leaks
-			resp.Body.Close()
+			_ = resp.Body.Close()
 
 			// Handle backoff with context cancellation support
 			backoff := c.retryBackoff(retriesCount)

--- a/client_bench_test.go
+++ b/client_bench_test.go
@@ -72,7 +72,9 @@ func Benchmark_ExecuteRequestWithEncoding(b *testing.B) {
 				if err != nil {
 					b.Fatal(err)
 				}
-				defer res.Close()
+				defer func() {
+					_ = res.Close()
+				}()
 
 				compressedData, err := io.ReadAll(res)
 				if err != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -58,7 +58,9 @@ func TestExecuteRequest(t *testing.T) {
 				res, err := enc.Encode(bytes.NewReader(b))
 				require.NoError(t, err)
 
-				defer res.Close()
+				defer func() {
+					_ = res.Close()
+				}()
 
 				compressedData, err := io.ReadAll(res)
 				require.NoError(t, err)
@@ -90,7 +92,9 @@ func TestExecuteRequest(t *testing.T) {
 				require.NoError(t, err)
 				res, err := respEnc.Encode(bytes.NewReader(d))
 				require.NoError(t, err)
-				defer res.Close()
+				defer func() {
+					_ = res.Close()
+				}()
 
 				compressedData, err := io.ReadAll(res)
 				require.NoError(t, err)
@@ -117,7 +121,9 @@ func TestExecuteRequest(t *testing.T) {
 				e := newEncoding(ContentEncoding(enc), DefaultCompression)
 				res, err := e.Encode(bytes.NewReader(msg))
 				require.NoError(t, err)
-				defer res.Close()
+				defer func() {
+					_ = res.Close()
+				}()
 
 				compressedData, err := io.ReadAll(res)
 				require.NoError(t, err)

--- a/encoding.go
+++ b/encoding.go
@@ -67,7 +67,9 @@ func (g *gzipEncoder) Encode(rc io.Reader) (io.ReadCloser, error) {
 	if w.err != nil {
 		return nil, w.err
 	}
-	defer w.writer.Close()
+	defer func() {
+		_ = w.writer.Close()
+	}()
 
 	buf := g.bufferPool.Get().(*bytes.Buffer)
 	buf.Reset()
@@ -86,7 +88,9 @@ func (g *gzipEncoder) Decode(data []byte, vPtr interface{}) error {
 	if err != nil {
 		return err
 	}
-	defer r.Close()
+	defer func() {
+		_ = r.Close()
+	}()
 	return json.NewDecoder(r).Decode(vPtr)
 }
 
@@ -106,7 +110,9 @@ func (f *flateEncoder) Encode(rc io.Reader) (io.ReadCloser, error) {
 	if w.err != nil {
 		return nil, w.err
 	}
-	defer w.writer.Close()
+	defer func() {
+		_ = w.writer.Close()
+	}()
 
 	buf := f.bufferPool.Get().(*bytes.Buffer)
 	buf.Reset()
@@ -125,7 +131,9 @@ func (f *flateEncoder) Decode(data []byte, vPtr interface{}) error {
 	if err != nil {
 		return err
 	}
-	defer r.Close()
+	defer func() {
+		_ = r.Close()
+	}()
 	return json.NewDecoder(r).Decode(vPtr)
 }
 
@@ -136,7 +144,9 @@ type brotliEncoder struct {
 
 func (b *brotliEncoder) Encode(rc io.Reader) (io.ReadCloser, error) {
 	w := b.brWriterPool.Get().(*brotli.Writer)
-	defer w.Close()
+	defer func() {
+		_ = w.Close()
+	}()
 	defer b.brWriterPool.Put(w)
 
 	buf := b.bufferPool.Get().(*bytes.Buffer)

--- a/encoding_bench_test.go
+++ b/encoding_bench_test.go
@@ -70,7 +70,9 @@ func BenchmarkGzipDecoder(b *testing.B) {
 	jsonData, _ := json.Marshal(sampleMapData())
 
 	encoded, _ := encoder.Encode(bytes.NewReader(jsonData))
-	defer encoded.Close()
+	defer func() {
+		_ = encoded.Close()
+	}()
 	payload, _ := io.ReadAll(encoded)
 
 	b.ResetTimer()
@@ -89,7 +91,9 @@ func BenchmarkFlateDecoder(b *testing.B) {
 	jsonData, _ := json.Marshal(sampleMapData())
 
 	encoded, _ := encoder.Encode(bytes.NewReader(jsonData))
-	defer encoded.Close()
+	defer func() {
+		_ = encoded.Close()
+	}()
 	payload, _ := io.ReadAll(encoded)
 
 	b.ResetTimer()
@@ -108,7 +112,9 @@ func BenchmarkBrotliDecoder(b *testing.B) {
 	jsonData, _ := json.Marshal(sampleMapData())
 
 	encoded, _ := encoder.Encode(bytes.NewReader(jsonData))
-	defer encoded.Close()
+	defer func() {
+		_ = encoded.Close()
+	}()
 	payload, _ := io.ReadAll(encoded)
 
 	b.ResetTimer()

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -111,7 +111,9 @@ func testEncoder(t *testing.T, enc encoder, original *mockData) {
 	readCloser := io.NopCloser(bytes.NewReader(originalJSON))
 	encodedReader, err := enc.Encode(readCloser)
 	assert.NoError(t, err)
-	defer encodedReader.Close()
+	defer func() {
+		_ = encodedReader.Close()
+	}()
 
 	encodedData, err := io.ReadAll(encodedReader)
 	assert.NoError(t, err)

--- a/error.go
+++ b/error.go
@@ -146,7 +146,7 @@ func (e *Error) ErrorBody(body []byte) {
 	msg := meilisearchApiError{}
 
 	if e.encoder != nil {
-		err := e.encoder.Decode(body, &msg)
+		err := e.Decode(body, &msg)
 		if err == nil {
 			e.MeilisearchApiError.Message = msg.Message
 			e.MeilisearchApiError.Code = msg.Code

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,15 @@
 module github.com/meilisearch/meilisearch-go
 
-go 1.16
+go 1.20
 
 require (
 	github.com/andybalholm/brotli v1.1.1
 	github.com/golang-jwt/jwt/v4 v4.5.1
 	github.com/stretchr/testify v1.8.2
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/index_document.go
+++ b/index_document.go
@@ -621,7 +621,7 @@ func (i *index) updateDocumentsNdjsonFromReaderInBatches(ctx context.Context, do
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("Could not read NDJSON: %w", err)
+		return nil, fmt.Errorf("could not read NDJSON: %w", err)
 	}
 
 	// Send remaining records as the last batch if there is any

--- a/integration/index_document_test.go
+++ b/integration/index_document_test.go
@@ -1541,7 +1541,7 @@ func TestIndex_DeleteDocumentsByFilter(t *testing.T) {
 
 			testWaitForTask(t, i, gotAddResp)
 
-			if tt.args.filterToApply != nil && len(tt.args.filterToApply) != 0 {
+			if len(tt.args.filterToApply) != 0 {
 				gotTask, err := i.UpdateFilterableAttributes(&tt.args.filterToApply)
 				require.NoError(t, err)
 				testWaitForTask(t, i, gotTask)

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -218,7 +218,9 @@ func setupMovieIndex(t *testing.T, client meilisearch.ServiceManager, uid string
 
 	testdata, err := os.Open("./testdata/movies.json")
 	require.NoError(t, err)
-	defer testdata.Close()
+	defer func() {
+		_ = testdata.Close()
+	}()
 
 	tests := make([]map[string]interface{}, 0)
 
@@ -242,7 +244,9 @@ func setupComicIndex(t *testing.T, client meilisearch.ServiceManager, uid string
 
 	testdata, err := os.Open("./testdata/comics.json")
 	require.NoError(t, err)
-	defer testdata.Close()
+	defer func() {
+		_ = testdata.Close()
+	}()
 
 	tests := make([]map[string]interface{}, 0)
 

--- a/pool.go
+++ b/pool.go
@@ -15,7 +15,7 @@ func (pb *pooledBuffer) Read(p []byte) (int, error) {
 }
 
 func (pb *pooledBuffer) Close() error {
-	pb.Buffer.Reset()
+	pb.Reset()
 	pb.pool.Put(pb.Buffer)
 	return nil
 }


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #588 

## What does this PR do?
- This PR bump minimum go version of meilisearch sdk into 1.20 for stability, performance and support generics.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Go version and linter tool to newer releases in the development workflow and Docker environment.
  * Upgraded Go module version and added new indirect dependencies for improved compatibility.
  * Simplified dependency installation steps in workflows for faster setup.
  * Improved resource cleanup by explicitly handling close operations to prevent errors during execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->