### PR TITLE
Add enhanced DecodeInto for hit and hits

### DIFF
--- a/hit.go
+++ b/hit.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sync"
 )
 
 type (
@@ -12,7 +13,9 @@ type (
 	Hits []Hit                      // Hits is an alias for a slice of Hit.
 )
 
-// Decode decodes a single Hit into the provided struct.
+// Deprecated: Decode decodes a single Hit into the provided struct.
+//
+// Please use DecodeInto for better performance without intermediate marshaling.
 func (h Hit) Decode(vPtr interface{}) error {
 	if vPtr == nil || reflect.ValueOf(vPtr).Kind() != reflect.Ptr {
 		return errors.New("vPtr must be a non-nil pointer")
@@ -24,6 +27,44 @@ func (h Hit) Decode(vPtr interface{}) error {
 	}
 
 	return json.Unmarshal(raw, vPtr)
+}
+
+// DecodeInto decodes a single Hit into the provided struct without intermediate marshaling.
+func (h Hit) DecodeInto(out any) error {
+	if out == nil {
+		return errors.New("out must be a non-nil pointer")
+	}
+	rv := reflect.ValueOf(out)
+	if rv.Kind() != reflect.Ptr || rv.IsNil() {
+		return errors.New("out must be a non-nil pointer")
+	}
+	rv = rv.Elem()
+	if rv.Kind() != reflect.Struct {
+		return fmt.Errorf("out must point to a struct, got %T", out)
+	}
+
+	ti := getTypeInfo(rv.Type())
+
+	// iterate only present json keys in the hit
+	for key, raw := range h {
+		if len(raw) == 0 || isJSONNull(raw) {
+			continue
+		}
+		idx, ok := ti.byNameIndex[key]
+		if !ok {
+			// unknown field: ignore (or collect for a Strict mode)
+			continue
+		}
+		f := ti.fields[idx]
+		fv := rv.FieldByIndex(f.indexPath)
+		if !fv.CanAddr() {
+			continue
+		}
+		if err := json.Unmarshal(raw, fv.Addr().Interface()); err != nil {
+			return fmt.Errorf("decode field %q: %w", key, err)
+		}
+	}
+	return nil
 }
 
 // DecodeWith decodes a Hit into the provided struct using the provided marshal and unmarshal functions.
@@ -44,7 +85,9 @@ func (h Hits) Len() int {
 	return len(h)
 }
 
-// Decode decodes the Hits into the provided target slice.
+// Deprecated: Decode decodes the Hits into the provided target slice.
+//
+// Please use DecodeInto for better performance without intermediate marshaling.
 func (h Hits) Decode(vSlicePtr interface{}) error {
 	v := reflect.ValueOf(vSlicePtr)
 
@@ -76,4 +119,147 @@ func (h Hits) DecodeWith(vSlicePtr interface{}, marshal JSONMarshal, unmarshal J
 	}
 
 	return unmarshal(buf, vSlicePtr)
+}
+
+// DecodeInto decodes hs into the provided slice pointer without re-marshal.
+// vSlicePtr must be a non-nil pointer to a slice whose element type is a struct or *struct.
+// Example:
+//
+//	var out []exampleBookForTest
+//	if err := hits.DecodeInto(&out); err != nil { ... }
+//
+//	var outPtr []*exampleBookForTest
+//	if err := hits.DecodeInto(&outPtr); err != nil { ... }
+func (h Hits) DecodeInto(vSlicePtr interface{}) error {
+	if vSlicePtr == nil {
+		return fmt.Errorf("vSlicePtr must be a non-nil pointer to a slice")
+	}
+
+	rv := reflect.ValueOf(vSlicePtr)
+	if rv.Kind() != reflect.Ptr || rv.IsNil() {
+		return fmt.Errorf("vSlicePtr must be a non-nil pointer, got %T", vSlicePtr)
+	}
+
+	sv := rv.Elem()
+	if sv.Kind() != reflect.Slice {
+		return fmt.Errorf("vSlicePtr must point to a slice, got %s", sv.Kind())
+	}
+
+	elemType := sv.Type().Elem()
+	out := reflect.MakeSlice(sv.Type(), 0, len(h))
+
+	switch elemType.Kind() {
+	case reflect.Struct:
+		// Target is []S
+		for i := range h {
+			elemPtr := reflect.New(elemType) // *S
+			if err := h[i].DecodeInto(elemPtr.Interface()); err != nil {
+				return fmt.Errorf("decode hits[%d]: %w", i, err)
+			}
+			out = reflect.Append(out, elemPtr.Elem()) // S
+		}
+
+	case reflect.Ptr:
+		// Target is []*S
+		if elemType.Elem().Kind() != reflect.Struct {
+			return fmt.Errorf("slice element must be struct or *struct, got %s", elemType)
+		}
+		for i := range h {
+			elemPtr := reflect.New(elemType.Elem()) // *S
+			if err := h[i].DecodeInto(elemPtr.Interface()); err != nil {
+				return fmt.Errorf("decode hits[%d]: %w", i, err)
+			}
+			out = reflect.Append(out, elemPtr.Convert(elemType)) // *S
+		}
+
+	default:
+		return fmt.Errorf("slice element must be struct or *struct, got %s", elemType)
+	}
+
+	sv.Set(out)
+	return nil
+}
+
+type fieldMeta struct {
+	jsonName  string
+	indexPath []int
+}
+
+type typeInfo struct {
+	fields      []fieldMeta
+	byNameIndex map[string]int // json name -> index in fields
+}
+
+var (
+	typeInfoCache sync.Map // reflect.Type -> *typeInfo
+)
+
+func getTypeInfo(t reflect.Type) *typeInfo {
+	if v, ok := typeInfoCache.Load(t); ok {
+		return v.(*typeInfo)
+	}
+	f := collectFields(t, nil)
+	ti := &typeInfo{
+		fields:      f,
+		byNameIndex: make(map[string]int, len(f)),
+	}
+	for i := range f {
+		ti.byNameIndex[f[i].jsonName] = i
+	}
+	typeInfoCache.Store(t, ti)
+	return ti
+}
+
+func collectFields(t reflect.Type, prefix []int) []fieldMeta {
+	var out []fieldMeta
+
+	// Walk struct fields, including anonymous/embedded.
+	for i := 0; i < t.NumField(); i++ {
+		sf := t.Field(i)
+		// Skip unexported (PkgPath != "", except for embedded anonymous exported types)
+		if sf.PkgPath != "" && !sf.Anonymous {
+			continue
+		}
+		tag := sf.Tag.Get("json")
+		if tag == "-" {
+			continue
+		}
+		name := sf.Name
+		if tag != "" {
+			// take first token before comma
+			if c := indexByte(tag, ','); c >= 0 {
+				tag = tag[:c]
+			}
+			if tag != "" {
+				name = tag
+			}
+		}
+		idx := append(append([]int(nil), prefix...), i)
+
+		if sf.Anonymous && sf.Type.Kind() == reflect.Struct && name == sf.Name {
+			// inline embedded struct fields (respect tags if present)
+			out = append(out, collectFields(sf.Type, idx)...)
+			continue
+		}
+
+		out = append(out, fieldMeta{
+			jsonName:  name,
+			indexPath: idx,
+		})
+	}
+	return out
+}
+
+// small helper: faster than strings.IndexByte here, avoids import
+func indexByte(s string, c byte) int {
+	for i := 0; i < len(s); i++ {
+		if s[i] == c {
+			return i
+		}
+	}
+	return -1
+}
+
+func isJSONNull(b []byte) bool {
+	return len(b) == 4 && b[0] == 'n' && b[1] == 'u' && b[2] == 'l' && b[3] == 'l'
 }

--- a/hit.go
+++ b/hit.go
@@ -333,6 +333,11 @@ func fieldByIndexPathAlloc(rv reflect.Value, indexPath []int) (reflect.Value, bo
 		if cur.Kind() != reflect.Struct {
 			return reflect.Value{}, false
 		}
+
+		if idx < 0 || idx >= cur.NumField() {
+			return reflect.Value{}, false
+		}
+
 		cur = cur.Field(idx)
 	}
 	if cur.Kind() == reflect.Ptr && cur.IsNil() {

--- a/hit_bench_test.go
+++ b/hit_bench_test.go
@@ -1,0 +1,171 @@
+package meilisearch
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+type BookSmall struct {
+	ID    string `json:"id"`
+	Title string `json:"title"`
+	Price int    `json:"price"`
+}
+
+type BookLarge struct {
+	ID      string            `json:"id"`
+	Title   string            `json:"title"`
+	Author  string            `json:"author"`
+	Price   float64           `json:"price"`
+	InStock bool              `json:"in_stock"`
+	Tags    []string          `json:"tags"`
+	Ratings []float64         `json:"ratings"`
+	Attrs   map[string]string `json:"attrs"`
+	Nested  struct {
+		ISBN      string   `json:"isbn"`
+		PageCount int      `json:"page_count"`
+		Editions  []string `json:"editions"`
+	} `json:"nested"`
+}
+
+func makeHit(v any) Hit {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(b, &m); err != nil {
+		panic(err)
+	}
+	return Hit(m)
+}
+
+func makeHitsSmall(n int) Hits {
+	h := makeHit(BookSmall{ID: "bk_001", Title: "Intro to Go", Price: 42})
+	hs := make(Hits, n)
+	for i := range hs {
+		hs[i] = h
+	}
+	return hs
+}
+
+func sampleLarge() BookLarge {
+	return BookLarge{
+		ID:      "bk_999",
+		Title:   "The Complete Guide to High-Perf Go",
+		Author:  "Gopher",
+		Price:   129.99,
+		InStock: true,
+		Tags:    []string{"go", "performance", "concurrency", "json", "sdk"},
+		Ratings: []float64{4.8, 4.9, 5.0, 4.7, 4.95, 4.85, 4.9},
+		Attrs: map[string]string{
+			"lang":   "en",
+			"cover":  "hard",
+			"series": "pro",
+			"sku":    "GO-PERF-129",
+		},
+		Nested: struct {
+			ISBN      string   `json:"isbn"`
+			PageCount int      `json:"page_count"`
+			Editions  []string `json:"editions"`
+		}{
+			ISBN:      "978-1-23456-789-7",
+			PageCount: 864,
+			Editions:  []string{"first", "second", "revised"},
+		},
+	}
+}
+
+func makeHitsLarge(n int) Hits {
+	h := makeHit(sampleLarge())
+	hs := make(Hits, n)
+	for i := range hs {
+		hs[i] = h
+	}
+	return hs
+}
+
+func BenchmarkHitsDecode_Small_1(b *testing.B)    { benchHitsDecodeSmall(b, 1, false) }
+func BenchmarkHitsDecode_Small_100(b *testing.B)  { benchHitsDecodeSmall(b, 100, false) }
+func BenchmarkHitsDecode_Small_1000(b *testing.B) { benchHitsDecodeSmall(b, 1000, false) }
+
+func BenchmarkHitsDecodeInto_Small_1(b *testing.B)    { benchHitsDecodeSmall(b, 1, true) }
+func BenchmarkHitsDecodeInto_Small_100(b *testing.B)  { benchHitsDecodeSmall(b, 100, true) }
+func BenchmarkHitsDecodeInto_Small_1000(b *testing.B) { benchHitsDecodeSmall(b, 1000, true) }
+
+func benchHitsDecodeSmall(b *testing.B, n int, fast bool) {
+	hits := makeHitsSmall(n)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var out []BookSmall
+		if fast {
+			if err := hits.DecodeInto(&out); err != nil {
+				b.Fatal(err)
+			}
+		} else {
+			if err := hits.Decode(&out); err != nil {
+				b.Fatal(err)
+			}
+		}
+		_ = out
+	}
+	// per-element metric (ns/op per hit)
+	if n > 0 {
+		b.SetBytes(int64(n)) // treat 1 "byte" == 1 element; useful to get ns/element in -benchmem output viewers
+	}
+}
+
+func BenchmarkHitsDecode_Large_1(b *testing.B)    { benchHitsDecodeLarge(b, 1, false) }
+func BenchmarkHitsDecode_Large_100(b *testing.B)  { benchHitsDecodeLarge(b, 100, false) }
+func BenchmarkHitsDecode_Large_1000(b *testing.B) { benchHitsDecodeLarge(b, 1000, false) }
+
+func BenchmarkHitsDecodeInto_Large_1(b *testing.B)    { benchHitsDecodeLarge(b, 1, true) }
+func BenchmarkHitsDecodeInto_Large_100(b *testing.B)  { benchHitsDecodeLarge(b, 100, true) }
+func BenchmarkHitsDecodeInto_Large_1000(b *testing.B) { benchHitsDecodeLarge(b, 1000, true) }
+
+func benchHitsDecodeLarge(b *testing.B, n int, fast bool) {
+	hits := makeHitsLarge(n)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var out []BookLarge
+		if fast {
+			if err := hits.DecodeInto(&out); err != nil {
+				b.Fatal(err)
+			}
+		} else {
+			if err := hits.Decode(&out); err != nil {
+				b.Fatal(err)
+			}
+		}
+		_ = out
+	}
+	if n > 0 {
+		b.SetBytes(int64(n)) // see note above
+	}
+}
+
+func BenchmarkHitsDecodePtr_Small_1000(b *testing.B)     { benchHitsDecodePtrSmall(b, 1000, false) }
+func BenchmarkHitsDecodeIntoPtr_Small_1000(b *testing.B) { benchHitsDecodePtrSmall(b, 1000, true) }
+
+func benchHitsDecodePtrSmall(b *testing.B, n int, fast bool) {
+	hits := makeHitsSmall(n)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var out []*BookSmall
+		if fast {
+			if err := hits.DecodeInto(&out); err != nil {
+				b.Fatal(err)
+			}
+		} else {
+			if err := hits.Decode(&out); err != nil {
+				b.Fatal(err)
+			}
+		}
+		_ = out
+	}
+	if n > 0 {
+		b.SetBytes(int64(n))
+	}
+}

--- a/hit_test.go
+++ b/hit_test.go
@@ -3,6 +3,7 @@ package meilisearch
 import (
 	"encoding/json"
 	"errors"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -162,4 +163,439 @@ func TestHits_Len(t *testing.T) {
 		Hit{},
 	}
 	assert.Equal(t, 2, hits.Len())
+}
+
+type exampleEmbedded struct {
+	E string `json:"e"`
+}
+
+type exampleBookForTest struct {
+	ID              string            `json:"id"`
+	Title           string            `json:"title"`
+	Price           int               `json:"price"`
+	OptS            *string           `json:"opt_s,omitempty"`
+	Tags            []string          `json:"tags,omitempty"`
+	Attrs           map[string]string `json:"attrs,omitempty"`
+	exampleEmbedded                   // embedded, inlined
+	Renamed         string            `json:"renamed_field"`
+	unexp           string            // unexported: must remain zero
+}
+
+// --- Helpers ---
+
+func makeHitFromJSON(t *testing.T, s string) Hit {
+	t.Helper()
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(s), &m); err != nil {
+		t.Fatalf("bad test json: %v", err)
+	}
+	return Hit(m)
+}
+
+func makeHitFromStruct(t *testing.T, v any) Hit {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("unmarshal to map: %v", err)
+	}
+	return Hit(m)
+}
+
+func TestHitDecodeInto_Basic(t *testing.T) {
+	jsonStr := `{
+		"id":"bk_1",
+		"title":"Intro to Go",
+		"price":42,
+		"tags":["a","b"],
+		"attrs":{"lang":"en"},
+		"e":"emb",
+		"renamed_field":"X",
+		"unknown_ignored": true
+	}`
+	h := makeHitFromJSON(t, jsonStr)
+
+	var got exampleBookForTest
+	if err := h.DecodeInto(&got); err != nil {
+		t.Fatalf("DecodeInto error: %v", err)
+	}
+
+	if got.ID != "bk_1" || got.Title != "Intro to Go" || got.Price != 42 {
+		t.Fatalf("basic fields mismatch: %+v", got)
+	}
+	if got.exampleEmbedded.E != "emb" {
+		t.Fatalf("embedded field not set: %+v", got)
+	}
+	if got.Renamed != "X" {
+		t.Fatalf("renamed tag not respected: %+v", got)
+	}
+	if got.unexp != "" {
+		t.Fatalf("unexported field must remain zero, got %q", got.unexp)
+	}
+	if got.OptS != nil {
+		t.Fatalf("optional pointer should be nil when not present, got %v", *got.OptS)
+	}
+	if !reflect.DeepEqual(got.Tags, []string{"a", "b"}) {
+		t.Fatalf("tags mismatch: %+v", got.Tags)
+	}
+	if !reflect.DeepEqual(got.Attrs, map[string]string{"lang": "en"}) {
+		t.Fatalf("attrs mismatch: %+v", got.Attrs)
+	}
+}
+
+func TestHitDecodeInto_NullAndMissing(t *testing.T) {
+	jsonStr := `{
+		"id":"bk_2",
+		"title":null,
+		"price":null,
+		"opt_s":null,
+		"e":null,
+		"renamed_field":null
+	}`
+	h := makeHitFromJSON(t, jsonStr)
+
+	var got exampleBookForTest
+	if err := h.DecodeInto(&got); err != nil {
+		t.Fatalf("DecodeInto error: %v", err)
+	}
+
+	// nulls should zero the fields
+	if got.Title != "" || got.Price != 0 || got.OptS != nil || got.exampleEmbedded.E != "" || got.Renamed != "" {
+		t.Fatalf("nulls not treated as zero values: %+v", got)
+	}
+
+	// missing fields: zero values (ID is present above; test missing behavior too)
+	h2 := makeHitFromJSON(t, `{}`)
+	var got2 exampleBookForTest
+	if err := h2.DecodeInto(&got2); err != nil {
+		t.Fatalf("DecodeInto error: %v", err)
+	}
+	var zero exampleBookForTest
+	if !reflect.DeepEqual(got2, zero) {
+		t.Fatalf("missing fields should yield zero value struct: %+v", got2)
+	}
+}
+
+func TestHitDecodeInto_Errors(t *testing.T) {
+	h := makeHitFromJSON(t, `{"id":"x"}`)
+
+	// nil
+	if err := h.DecodeInto(nil); err == nil {
+		t.Fatalf("expected error for nil target")
+	}
+
+	// non-pointer
+	var notPtr exampleBookForTest
+	if err := h.DecodeInto(notPtr); err == nil {
+		t.Fatalf("expected error for non-pointer")
+	}
+
+	// pointer to non-struct
+	var x int
+	if err := h.DecodeInto(&x); err == nil {
+		t.Fatalf("expected error for pointer to non-struct")
+	}
+}
+
+func TestHitsDecodeInto_StructSlice(t *testing.T) {
+	h := makeHitFromStruct(t, exampleBookForTest{
+		ID:              "bk_3",
+		Title:           "T",
+		Price:           7,
+		exampleEmbedded: exampleEmbedded{E: "e"},
+		Renamed:         "R",
+	})
+	hs := Hits{h, h, h}
+
+	var out []exampleBookForTest
+	if err := hs.DecodeInto(&out); err != nil {
+		t.Fatalf("DecodeInto (slice) error: %v", err)
+	}
+
+	if len(out) != 3 {
+		t.Fatalf("len mismatch: %d", len(out))
+	}
+	for i, b := range out {
+		if b.ID != "bk_3" || b.Title != "T" || b.Price != 7 || b.exampleEmbedded.E != "e" || b.Renamed != "R" {
+			t.Fatalf("element %d mismatch: %+v", i, b)
+		}
+	}
+}
+
+func TestHitsDecodeInto_PtrSlice(t *testing.T) {
+	h := makeHitFromStruct(t, exampleBookForTest{ID: "bk_4", Title: "Ptr"})
+	hs := Hits{h, h}
+
+	var out []*exampleBookForTest
+	if err := hs.DecodeInto(&out); err != nil {
+		t.Fatalf("DecodeInto (ptr slice) error: %v", err)
+	}
+	if len(out) != 2 {
+		t.Fatalf("len mismatch: %d", len(out))
+	}
+	for i, p := range out {
+		if p == nil || p.ID != "bk_4" || p.Title != "Ptr" {
+			t.Fatalf("element %d mismatch: %+v", i, p)
+		}
+	}
+}
+
+func TestHitsDecodeInto_EmptyInput(t *testing.T) {
+	var hs Hits
+	var out []exampleBookForTest
+	if err := hs.DecodeInto(&out); err != nil {
+		t.Fatalf("DecodeInto error on empty input: %v", err)
+	}
+	if len(out) != 0 {
+		t.Fatalf("expected empty output slice, got %d", len(out))
+	}
+}
+
+func TestHitsDecodeInto_NullFields(t *testing.T) {
+	jsonStr := `{
+		"id":"bk_5",
+		"title":"ok",
+		"opt_s":null,
+		"tags":null,
+		"attrs":null,
+		"e":"E"
+	}`
+	h := makeHitFromJSON(t, jsonStr)
+	hs := Hits{h}
+
+	var out []exampleBookForTest
+	if err := hs.DecodeInto(&out); err != nil {
+		t.Fatalf("DecodeInto error: %v", err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("len mismatch: %d", len(out))
+	}
+	got := out[0]
+	if got.ID != "bk_5" || got.Title != "ok" || got.exampleEmbedded.E != "E" {
+		t.Fatalf("values mismatch: %+v", got)
+	}
+	// null → zero
+	if got.OptS != nil || got.Tags != nil || got.Attrs != nil {
+		t.Fatalf("null should zero pointer/map/slice fields: %+v", got)
+	}
+}
+
+func TestHitsDecodeInto_Errors(t *testing.T) {
+	h := makeHitFromJSON(t, `{"id":"bk_6"}`)
+	hs := Hits{h}
+
+	// nil
+	if err := hs.DecodeInto(nil); err == nil {
+		t.Fatalf("expected error for nil")
+	}
+
+	// non-pointer
+	var notPtr []exampleBookForTest
+	if err := hs.DecodeInto(notPtr); err == nil {
+		t.Fatalf("expected error for non-pointer")
+	}
+
+	// pointer to non-slice
+	var x int
+	if err := hs.DecodeInto(&x); err == nil {
+		t.Fatalf("expected error for pointer to non-slice")
+	}
+
+	// slice of non-struct element
+	var bad1 []int
+	if err := hs.DecodeInto(&bad1); err == nil {
+		t.Fatalf("expected error for slice element not struct/*struct")
+	}
+
+	// slice of pointer to non-struct
+	var bad2 []*int
+	if err := hs.DecodeInto(&bad2); err == nil {
+		t.Fatalf("expected error for slice element pointer to non-struct")
+	}
+
+	// ensure error text is informative (optional assert on substring)
+	var out []exampleBookForTest
+	err := hs.DecodeInto(&out)
+	if err != nil && !errors.Is(err, nil) {
+		// no-op: just compile-time reference to errors package to avoid lint noise
+	}
+}
+
+func TestHitDecodeInto_IgnoresUnknownFields(t *testing.T) {
+	h := makeHitFromJSON(t, `{"id":"bk_7","unknown":123}`)
+	var b exampleBookForTest
+	if err := h.DecodeInto(&b); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if b.ID != "bk_7" {
+		t.Fatalf("id mismatch: %+v", b)
+	}
+}
+
+type BookSmall struct {
+	ID    string `json:"id"`
+	Title string `json:"title"`
+	Price int    `json:"price"`
+}
+
+type BookLarge struct {
+	ID      string            `json:"id"`
+	Title   string            `json:"title"`
+	Author  string            `json:"author"`
+	Price   float64           `json:"price"`
+	InStock bool              `json:"in_stock"`
+	Tags    []string          `json:"tags"`
+	Ratings []float64         `json:"ratings"`
+	Attrs   map[string]string `json:"attrs"`
+	Nested  struct {
+		ISBN      string   `json:"isbn"`
+		PageCount int      `json:"page_count"`
+		Editions  []string `json:"editions"`
+	} `json:"nested"`
+}
+
+func makeHit(v any) Hit {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(b, &m); err != nil {
+		panic(err)
+	}
+	return Hit(m)
+}
+
+func makeHitsSmall(n int) Hits {
+	h := makeHit(BookSmall{ID: "bk_001", Title: "Intro to Go", Price: 42})
+	hs := make(Hits, n)
+	for i := range hs {
+		hs[i] = h
+	}
+	return hs
+}
+
+func sampleLarge() BookLarge {
+	return BookLarge{
+		ID:      "bk_999",
+		Title:   "The Complete Guide to High-Perf Go",
+		Author:  "Gopher",
+		Price:   129.99,
+		InStock: true,
+		Tags:    []string{"go", "performance", "concurrency", "json", "sdk"},
+		Ratings: []float64{4.8, 4.9, 5.0, 4.7, 4.95, 4.85, 4.9},
+		Attrs: map[string]string{
+			"lang":   "en",
+			"cover":  "hard",
+			"series": "pro",
+			"sku":    "GO-PERF-129",
+		},
+		Nested: struct {
+			ISBN      string   `json:"isbn"`
+			PageCount int      `json:"page_count"`
+			Editions  []string `json:"editions"`
+		}{
+			ISBN:      "978-1-23456-789-7",
+			PageCount: 864,
+			Editions:  []string{"first", "second", "revised"},
+		},
+	}
+}
+
+func makeHitsLarge(n int) Hits {
+	h := makeHit(sampleLarge())
+	hs := make(Hits, n)
+	for i := range hs {
+		hs[i] = h
+	}
+	return hs
+}
+
+func BenchmarkHitsDecode_Small_1(b *testing.B)    { benchHitsDecodeSmall(b, 1, false) }
+func BenchmarkHitsDecode_Small_100(b *testing.B)  { benchHitsDecodeSmall(b, 100, false) }
+func BenchmarkHitsDecode_Small_1000(b *testing.B) { benchHitsDecodeSmall(b, 1000, false) }
+
+func BenchmarkHitsDecodeInto_Small_1(b *testing.B)    { benchHitsDecodeSmall(b, 1, true) }
+func BenchmarkHitsDecodeInto_Small_100(b *testing.B)  { benchHitsDecodeSmall(b, 100, true) }
+func BenchmarkHitsDecodeInto_Small_1000(b *testing.B) { benchHitsDecodeSmall(b, 1000, true) }
+
+func benchHitsDecodeSmall(b *testing.B, n int, fast bool) {
+	hits := makeHitsSmall(n)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var out []BookSmall
+		if fast {
+			if err := hits.DecodeInto(&out); err != nil {
+				b.Fatal(err)
+			}
+		} else {
+			if err := hits.Decode(&out); err != nil {
+				b.Fatal(err)
+			}
+		}
+		_ = out
+	}
+	// per-element metric (ns/op per hit)
+	if n > 0 {
+		b.SetBytes(int64(n)) // treat 1 "byte" == 1 element; useful to get ns/element in -benchmem output viewers
+	}
+}
+
+func BenchmarkHitsDecode_Large_1(b *testing.B)    { benchHitsDecodeLarge(b, 1, false) }
+func BenchmarkHitsDecode_Large_100(b *testing.B)  { benchHitsDecodeLarge(b, 100, false) }
+func BenchmarkHitsDecode_Large_1000(b *testing.B) { benchHitsDecodeLarge(b, 1000, false) }
+
+func BenchmarkHitsDecodeInto_Large_1(b *testing.B)    { benchHitsDecodeLarge(b, 1, true) }
+func BenchmarkHitsDecodeInto_Large_100(b *testing.B)  { benchHitsDecodeLarge(b, 100, true) }
+func BenchmarkHitsDecodeInto_Large_1000(b *testing.B) { benchHitsDecodeLarge(b, 1000, true) }
+
+func benchHitsDecodeLarge(b *testing.B, n int, fast bool) {
+	hits := makeHitsLarge(n)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var out []BookLarge
+		if fast {
+			if err := hits.DecodeInto(&out); err != nil {
+				b.Fatal(err)
+			}
+		} else {
+			if err := hits.Decode(&out); err != nil {
+				b.Fatal(err)
+			}
+		}
+		_ = out
+	}
+	if n > 0 {
+		b.SetBytes(int64(n)) // see note above
+	}
+}
+
+func BenchmarkHitsDecodePtr_Small_1000(b *testing.B)     { benchHitsDecodePtrSmall(b, 1000, false) }
+func BenchmarkHitsDecodeIntoPtr_Small_1000(b *testing.B) { benchHitsDecodePtrSmall(b, 1000, true) }
+
+func benchHitsDecodePtrSmall(b *testing.B, n int, fast bool) {
+	hits := makeHitsSmall(n)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var out []*BookSmall
+		if fast {
+			if err := hits.DecodeInto(&out); err != nil {
+				b.Fatal(err)
+			}
+		} else {
+			if err := hits.Decode(&out); err != nil {
+				b.Fatal(err)
+			}
+		}
+		_ = out
+	}
+	if n > 0 {
+		b.SetBytes(int64(n))
+	}
 }

--- a/hit_test.go
+++ b/hit_test.go
@@ -479,9 +479,6 @@ type helperOuter struct {
 	Boxed embeddedA `json:"boxed"`
 	// Anonymous but renamed (NOT promoted) => nested under "renamed"
 	embeddedRenamed `json:"renamed"`
-
-	// Unexported skip
-	private string
 }
 
 func TestGetTypeInfoAndCollectFields(t *testing.T) {

--- a/hit_test.go
+++ b/hit_test.go
@@ -426,7 +426,7 @@ func TestHitDecodeInto_EmbeddedWithTag_AsNestedObject(t *testing.T) {
 	h := makeHitFromJSON(t, `{"embedded":{"e":"ok"}}`)
 	var p Parent
 	require.NoError(t, h.DecodeInto(&p))
-	assert.Equal(t, "ok", p.Embedded.E)
+	assert.Equal(t, "ok", p.E)
 }
 
 func TestHitsDecodeInto_NestedSliceBatch(t *testing.T) {

--- a/integration/index_search_test.go
+++ b/integration/index_search_test.go
@@ -3,8 +3,9 @@ package integration
 import (
 	"crypto/tls"
 	"encoding/json"
-	"github.com/meilisearch/meilisearch-go"
 	"testing"
+
+	"github.com/meilisearch/meilisearch-go"
 
 	"github.com/stretchr/testify/require"
 )
@@ -941,7 +942,7 @@ func TestIndex_SearchWithShowRankingScore(t *testing.T) {
 
 	// Convert to a structured format and verify _rankingScore presence
 	var result map[string]json.RawMessage
-	err = got.Hits[0].Decode(&result)
+	err = got.Hits[0].DecodeInto(&result)
 	require.NoError(t, err)
 	require.Contains(t, got.Hits[0], "_rankingScore")
 }
@@ -978,7 +979,7 @@ func TestIndex_SearchWithShowRankingScoreDetails(t *testing.T) {
 
 	// Convert first hit to structured format and check for _rankingScoreDetails
 	var result map[string]json.RawMessage
-	err = got.Hits[0].Decode(&result)
+	err = got.Hits[0].DecodeInto(&result)
 	require.NoError(t, err)
 	require.Contains(t, result, "_rankingScoreDetails", "expected _rankingScoreDetails to be present in the search result")
 }
@@ -1023,7 +1024,7 @@ func TestIndex_SearchWithVectorStore(t *testing.T) {
 
 			for _, hit := range got.Hits {
 				var hitMap map[string]json.RawMessage
-				err := hit.Decode(&hitMap)
+				err := hit.DecodeInto(&hitMap)
 				require.NoError(t, err)
 				require.Contains(t, hitMap, "_vectors", "expected _vectors field in search result")
 			}

--- a/integration/meilisearch_test.go
+++ b/integration/meilisearch_test.go
@@ -2330,10 +2330,10 @@ func TestClient_MultiSearch(t *testing.T) {
 						gots  map[string]interface{}
 					)
 
-					err := tt.want.Hits[i].Decode(&wants)
+					err := tt.want.Hits[i].DecodeInto(&wants)
 					require.NoError(t, err)
 
-					err = got.Hits[i].Decode(&gots)
+					err = got.Hits[i].DecodeInto(&gots)
 					require.NoError(t, err)
 
 					for k, v := range wants {


### PR DESCRIPTION
# Pull Request

## What does this PR do?

* Adds a **non-breaking fast decode path** for Meilisearch hits:

  * `Hit.DecodeInto(out any) error` (field-wise, no re-marshal)
  * `Hits.DecodeInto(vSlicePtr any) error` (supports `[]S` and `[]*S`)
* Introduces a **type-info cache** (json tag → field index) to reduce reflection overhead.
* Implements **null** and **missing-field** handling consistent with `encoding/json`.
* Provides comprehensive **unit tests** for `Hit.DecodeInto` and `Hits.DecodeInto` (tags, embedded fields, nulls, missing, unknown fields, error paths).
* Adds **benchmarks** comparing old `Decode` (re-marshal) vs new `DecodeInto` across small/large payloads and batch sizes.

### Performance (from benchmarks on my machine)

* **Small docs:** \~2.1× faster (≈2.9µs → ≈1.3µs), allocs: **18 → 10**
* **Large docs:** \~1.4× faster (≈15.3µs → ≈10.8µs), allocs: **68 → 59**
* Batches (1000 hits) show proportional wall-time reductions and fewer allocations.

### Backward compatibility

* No public type changes (`Hit` and `Hits` unchanged).
* Existing `Decode`/`DecodeWith` kept intact.
* New `DecodeInto` methods are opt-in for better performance.

```
BenchmarkHitsDecode_Small_1-22                    411990              2921 ns/op           0.34 MB/s         665 B/op         18 allocs/op
BenchmarkHitsDecode_Small_100-22                    5760            212606 ns/op           0.47 MB/s       44940 B/op        916 allocs/op
BenchmarkHitsDecode_Small_1000-22                    549           2060789 ns/op           0.49 MB/s      414354 B/op       9019 allocs/op
BenchmarkHitsDecodeInto_Small_1-22                793160              1386 ns/op           0.72 MB/s         624 B/op         10 allocs/op
BenchmarkHitsDecodeInto_Small_100-22                8941            122024 ns/op           0.82 MB/s       56944 B/op        703 allocs/op
BenchmarkHitsDecodeInto_Small_1000-22                987           1236779 ns/op           0.81 MB/s      569009 B/op       7003 allocs/op
BenchmarkHitsDecode_Large_1-22                     79682             15375 ns/op           0.07 MB/s        2741 B/op         68 allocs/op
BenchmarkHitsDecode_Large_100-22                     852           1400259 ns/op           0.07 MB/s      276186 B/op       5718 allocs/op
BenchmarkHitsDecode_Large_1000-22                     85          14510975 ns/op           0.07 MB/s     3048757 B/op      57033 allocs/op
BenchmarkHitsDecodeInto_Large_1-22                109417             10842 ns/op           0.09 MB/s        2924 B/op         59 allocs/op
BenchmarkHitsDecodeInto_Large_100-22                1063           1049555 ns/op           0.10 MB/s      288840 B/op       5603 allocs/op
BenchmarkHitsDecodeInto_Large_1000-22                100          10887349 ns/op           0.09 MB/s     2875726 B/op      56003 allocs/op
BenchmarkHitsDecodePtr_Small_1000-22                 583           2079971 ns/op           0.48 MB/s      392875 B/op      10020 allocs/op
BenchmarkHitsDecodeIntoPtr_Small_1000-22             948           1261812 ns/op           0.79 MB/s      536241 B/op       7003 allocs/op
```


## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added DecodeInto for single hits and collections to decode directly into structs, pointer slices, and maps; ignores unknown fields and validates targets.

- Refactor
  - Added cached type metadata and field-level decode paths for faster, lower-allocation decoding; Decode remains but is deprecated.

- Tests
  - Added extensive unit tests and benchmarks; updated integration tests to use DecodeInto.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->