### PR TITLE
chore: bump golang-jwt to v5 and, consequently, the minimum go version to 1.21

### DIFF
--- a/.github/workflows/pre-release-tests.yml
+++ b/.github/workflows/pre-release-tests.yml
@@ -14,11 +14,11 @@ jobs:
     strategy:
       matrix:
         # Current go.mod version and latest stable go version
-        go: ["1.20", "1.24"]
+        go: ["1.21", "1.25"]
         include:
-          - go: "1.20"
+          - go: "1.21"
             tag: current
-          - go: "1.24"
+          - go: "1.25"
             tag: latest
 
     name: integration-tests-against-rc (go ${{ matrix.tag }} version)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v6
         with:
-          go-version: 1.24
+          go-version: 1.25
       - uses: actions/checkout@v6
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
@@ -35,11 +35,11 @@ jobs:
     strategy:
       matrix:
         # Current go.mod version and latest stable go version
-        go: ["1.20", "1.24"]
+        go: ["1.21", "1.25"]
         include:
-          - go: "1.20"
+          - go: "1.21"
             tag: current
-          - go: "1.24"
+          - go: "1.25"
             tag: latest
 
     name: integration-tests (go ${{ matrix.tag }} version)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
-FROM golang:1.20-buster
+FROM golang:1.21-bookworm
 
 WORKDIR /home/package
+
+RUN git config --global --add safe.directory /home/package
 
 COPY go.mod .
 COPY go.sum .

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 
 - [Table of Contents](#table-of-contents)
 - [📖 Documentation](#-documentation)
-- [🔧 Installation (\>= 1.20)](#-installation--120)
+- [🔧 Installation (\>= 1.21)](#-installation--121)
 - [🚀 Getting started](#-getting-started)
     - [Add documents](#add-documents)
     - [Basic Search](#basic-search)
@@ -52,7 +52,7 @@ This readme contains all the documentation you need to start using this Meilisea
 For general information on how to use Meilisearch—such as our API reference, tutorials, guides, and in-depth articles—refer to our [main documentation website](https://www.meilisearch.com/docs/).
 
 
-## 🔧 Installation (>= 1.20)
+## 🔧 Installation (>= 1.21)
 
 With `go get` in command line:
 ```bash

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/meilisearch/meilisearch-go
 
-go 1.20
+go 1.21
 
 require (
 	github.com/andybalholm/brotli v1.1.1
-	github.com/golang-jwt/jwt/v4 v4.5.2
+	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/andybalholm/brotli v1.1.1 h1:PR2pgnyFznKEugtsUo0xLdDop5SKXd5Qf5ysW+7X
 github.com/andybalholm/brotli v1.1.1/go.mod h1:05ib4cKhjx3OQYUY22hTVd34Bc8upXjOLL2rKwwZBoA=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
-github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9vvo=
+github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=

--- a/meilisearch.go
+++ b/meilisearch.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 )
 
 type meilisearch struct {

--- a/types.go
+++ b/types.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 )
 
 const (


### PR DESCRIPTION
In a project using this module it was noticed that it was the (only) reason to still also include jwt/v4.

JWT usage in this module seems rather limited, so regressions seem unlikely.

## What does this PR do?

Updates https://github.com/golang-jwt/jwt from v4 to v5
Bumps the minimum go version from 1.20 to 1.21

## PR checklist

- No AI was used
- Changes have been listen
- I have read the guidelines
- Yes, I hope that the title is accurate and descriptive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated minimum Go requirement from 1.20 to 1.21 across build and CI
  * Upgraded JWT authentication library to v5
  * Adjusted CI toolchain matrix entries to align with new Go versions
  * Updated base build image and added build-time repository safety configuration

* **Documentation**
  * Updated installation/version reference to reflect Go >= 1.21

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->