### PR TITLE
Revert "chore(deps): bump release-drafter/release-drafter from 6 to 7"

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -9,7 +9,7 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v7
+      - uses: release-drafter/release-drafter@v6
         with:
           config-name: release-draft-template.yml
         env:


### PR DESCRIPTION
Reverts meilisearch/meilisearch-go#770 because issue with release drafter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->