### PR TITLE
fix(search): allow explicit zero hitsPerPage

### DIFF
--- a/integration/index_search_test.go
+++ b/integration/index_search_test.go
@@ -807,7 +807,7 @@ func TestIndex_SearchWithPagination(t *testing.T) {
 				client: sv,
 				query:  "and",
 				request: &meilisearch.SearchRequest{
-					HitsPerPage: 10,
+					HitsPerPage: int64Ptr(10),
 				},
 			},
 			want: &meilisearch.SearchResponse{
@@ -855,7 +855,7 @@ func TestIndex_SearchWithPagination(t *testing.T) {
 				client: sv,
 				query:  "and",
 				request: &meilisearch.SearchRequest{
-					HitsPerPage: 10,
+					HitsPerPage: int64Ptr(10),
 					Page:        1,
 				},
 			},
@@ -870,6 +870,52 @@ func TestIndex_SearchWithPagination(t *testing.T) {
 				Page:        1,
 				TotalHits:   4,
 				TotalPages:  1,
+			},
+			wantErr: false,
+		},
+		{
+			name: "TestIndexBasicSearchWithHitsPerPageZero",
+			args: args{
+				UID:    "indexUID",
+				client: sv,
+				query:  "and",
+				request: &meilisearch.SearchRequest{
+					HitsPerPage: int64Ptr(0),
+				},
+			},
+			want: &meilisearch.SearchResponse{
+				Hits:        meilisearch.Hits{},
+				HitsPerPage: 0,
+				Page:        1,
+				TotalHits:   4,
+				TotalPages:  0,
+			},
+			wantErr: false,
+		},
+		{
+			name: "TestIndexBasicSearchWithHitsPerPageNull",
+			args: args{
+				UID:    "indexUID",
+				client: sv,
+				query:  "and",
+				request: &meilisearch.SearchRequest{
+					HitsPerPage: nil,
+				},
+			},
+			want: &meilisearch.SearchResponse{
+				Hits: meilisearch.Hits{
+					{"book_id": toRawMessage(123), "title": toRawMessage("Pride and Prejudice")},
+					{"book_id": toRawMessage(730), "title": toRawMessage("War and Peace")},
+					{"book_id": toRawMessage(1032), "title": toRawMessage("Crime and Punishment")},
+					{"book_id": toRawMessage(4), "title": toRawMessage("Harry Potter and the Half-Blood Prince")},
+				},
+				HitsPerPage:        0,
+				Limit:              20,
+				Offset:             0,
+				EstimatedTotalHits: 4,
+				Page:               0,
+				TotalHits:          0,
+				TotalPages:         0,
 			},
 			wantErr: false,
 		},
@@ -905,6 +951,9 @@ func TestIndex_SearchWithPagination(t *testing.T) {
 			require.Equal(t, tt.want.Page, got.Page)
 			require.Equal(t, tt.want.TotalHits, got.TotalHits)
 			require.Equal(t, tt.want.TotalPages, got.TotalPages)
+			require.Equal(t, tt.want.Limit, got.Limit)
+			require.Equal(t, tt.want.EstimatedTotalHits, got.EstimatedTotalHits)
+			require.Equal(t, tt.want.Offset, got.Offset)
 		})
 	}
 }

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -580,3 +580,12 @@ func toRawMessage(vPtr interface{}) json.RawMessage {
 	}
 	return data
 }
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func int64Ptr(i int) *int64 {
+	v := int64(i)
+	return &v
+}

--- a/integration/search_rules_test.go
+++ b/integration/search_rules_test.go
@@ -312,7 +312,3 @@ func Test_DeleteSearchRule(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, got)
 }
-
-func intPtr(i int) *int {
-	return &i
-}

--- a/types.go
+++ b/types.go
@@ -643,7 +643,7 @@ type SearchRequest struct {
 	Facets                  []string                 `json:"facets,omitempty"`
 	Sort                    []string                 `json:"sort,omitempty"`
 	Vector                  []float32                `json:"vector,omitempty"`
-	HitsPerPage             int64                    `json:"hitsPerPage,omitempty"`
+	HitsPerPage             *int64                   `json:"hitsPerPage,omitempty"`
 	Page                    int64                    `json:"page,omitempty"`
 	IndexUID                string                   `json:"indexUid,omitempty"`
 	Query                   string                   `json:"q"`


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #777

## What does this PR do?
- allow explicit zero hitsPerPage.
- Add new integration test cases for new changes.

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `SearchRequest.HitsPerPage` is now optional, allowing explicit differentiation between unspecified and zero values in pagination requests.

* **Tests**
  * Enhanced pagination tests to validate behavior when `HitsPerPage` is zero or omitted, ensuring proper handling of edge cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meilisearch/meilisearch-go/pull/783)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->