### PR TITLE
feat: add human-formatted sizes and detailed DB sizes in stats

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -382,9 +382,9 @@ facet_search_2: |-
       }
   })
 get_index_stats_1: |-
-  client.Index("movies").GetStats()
+  client.Index("movies").GetStats(nil)
 get_indexes_stats_1: |-
-  client.GetStats()
+  client.GetStats(nil)
 get_health_1: |-
   client.Health()
 get_version_1: |-

--- a/index.go
+++ b/index.go
@@ -138,19 +138,26 @@ func (i *index) DeleteWithContext(ctx context.Context, uid string) (bool, error)
 	return true, nil
 }
 
-func (i *index) GetStats() (*StatsIndex, error) {
-	return i.GetStatsWithContext(context.Background())
+func (i *index) GetStats(param *StatsParams) (*StatsIndex, error) {
+	return i.GetStatsWithContext(context.Background(), param)
 }
 
-func (i *index) GetStatsWithContext(ctx context.Context) (*StatsIndex, error) {
+func (i *index) GetStatsWithContext(ctx context.Context, param *StatsParams) (*StatsIndex, error) {
 	resp := new(StatsIndex)
 	req := &internalRequest{
 		endpoint:            "/indexes/" + i.uid + "/stats",
 		method:              http.MethodGet,
 		withRequest:         nil,
+		withQueryParams:     map[string]string{},
 		withResponse:        resp,
 		acceptedStatusCodes: []int{http.StatusOK},
 		functionName:        "GetStats",
+	}
+	if param != nil && param.SizeFormat != "" {
+		req.withQueryParams["sizeFormat"] = param.SizeFormat
+	}
+	if param != nil && param.ShowInternalDatabaseSizes {
+		req.withQueryParams["showInternalDatabaseSizes"] = "true"
 	}
 	if err := i.client.executeRequest(ctx, req); err != nil {
 		return nil, err

--- a/index_interface.go
+++ b/index_interface.go
@@ -72,12 +72,12 @@ type IndexReader interface {
 	// GetStats retrieves statistical information about the index.
 	//
 	// docs: https://www.meilisearch.com/docs/reference/api/stats/get-stats-of-index
-	GetStats() (*StatsIndex, error)
+	GetStats(param *StatsParams) (*StatsIndex, error)
 
 	// GetStatsWithContext retrieves statistical information about the index using the provided context for cancellation.
 	//
 	// docs: https://www.meilisearch.com/docs/reference/api/stats/get-stats-of-index
-	GetStatsWithContext(ctx context.Context) (*StatsIndex, error)
+	GetStatsWithContext(ctx context.Context, param *StatsParams) (*StatsIndex, error)
 }
 
 type DocumentManager interface {

--- a/integration/index_test.go
+++ b/integration/index_test.go
@@ -110,9 +110,10 @@ func TestIndex_GetStats(t *testing.T) {
 		client meilisearch.ServiceManager
 	}
 	tests := []struct {
-		name     string
-		args     args
-		wantResp *meilisearch.StatsIndex
+		name       string
+		args       args
+		statsParam *meilisearch.StatsParams
+		wantResp   *meilisearch.StatsIndex
 	}{
 		{
 			name: "TestIndexBasicGetStats",
@@ -124,8 +125,8 @@ func TestIndex_GetStats(t *testing.T) {
 				NumberOfDocuments: 6,
 				IsIndexing:        false,
 				FieldDistribution: map[string]int64{"book_id": 6, "title": 6},
-				RawDocumentDbSize: 4096,
-				AvgDocumentSize:   674,
+				RawDocumentDbSize: float64(4096),
+				AvgDocumentSize:   float64(674),
 			},
 		},
 		{
@@ -138,8 +139,44 @@ func TestIndex_GetStats(t *testing.T) {
 				NumberOfDocuments: 6,
 				IsIndexing:        false,
 				FieldDistribution: map[string]int64{"book_id": 6, "title": 6},
-				RawDocumentDbSize: 4096,
-				AvgDocumentSize:   674,
+				RawDocumentDbSize: float64(4096),
+				AvgDocumentSize:   float64(674),
+			},
+		},
+		{
+			name: "TestIndexBasicGetStatsWithRawFormat",
+			args: args{
+				UID:    "TestIndexBasicGetStatsWithRawFormat",
+				client: sv,
+			},
+			statsParam: &meilisearch.StatsParams{
+				ShowInternalDatabaseSizes: true,
+				SizeFormat:                "raw",
+			},
+			wantResp: &meilisearch.StatsIndex{
+				NumberOfDocuments: 6,
+				IsIndexing:        false,
+				FieldDistribution: map[string]int64{"book_id": 6, "title": 6},
+				RawDocumentDbSize: float64(4096),
+				AvgDocumentSize:   float64(674),
+			},
+		},
+		{
+			name: "TestIndexBasicGetStatsWithHumanFormat",
+			args: args{
+				UID:    "TestIndexBasicGetStatsWithHumanFormat",
+				client: sv,
+			},
+			statsParam: &meilisearch.StatsParams{
+				ShowInternalDatabaseSizes: true,
+				SizeFormat:                "human",
+			},
+			wantResp: &meilisearch.StatsIndex{
+				NumberOfDocuments: 6,
+				IsIndexing:        false,
+				FieldDistribution: map[string]int64{"book_id": 6, "title": 6},
+				RawDocumentDbSize: "4 KiB",
+				AvgDocumentSize:   "674 B",
 			},
 		},
 	}
@@ -150,9 +187,16 @@ func TestIndex_GetStats(t *testing.T) {
 			i := c.Index(tt.args.UID)
 			t.Cleanup(cleanup(c))
 
-			gotResp, err := i.GetStats()
+			gotResp, err := i.GetStats(tt.statsParam)
 			require.NoError(t, err)
-			require.Equal(t, tt.wantResp, gotResp)
+			require.Equal(t, tt.wantResp.NumberOfDocuments, gotResp.NumberOfDocuments)
+			require.Equal(t, tt.wantResp.IsIndexing, gotResp.IsIndexing)
+			require.Equal(t, tt.wantResp.FieldDistribution, gotResp.FieldDistribution)
+			require.Equal(t, tt.wantResp.RawDocumentDbSize, gotResp.RawDocumentDbSize)
+			require.Equal(t, tt.wantResp.AvgDocumentSize, gotResp.AvgDocumentSize)
+			if tt.statsParam != nil && tt.statsParam.ShowInternalDatabaseSizes {
+				require.NotZero(t, gotResp.InternalDatabaseSizes)
+			}
 		})
 	}
 }

--- a/integration/meilisearch_test.go
+++ b/integration/meilisearch_test.go
@@ -79,21 +79,30 @@ func Test_GetStats(t *testing.T) {
 	}))
 
 	tests := []struct {
-		name   string
-		client meilisearch.ServiceManager
+		name       string
+		client     meilisearch.ServiceManager
+		statsParam *meilisearch.StatsParams
 	}{
 		{
 			name:   "TestGetStats",
 			client: sv,
+			statsParam: &meilisearch.StatsParams{
+				ShowInternalDatabaseSizes: true,
+				SizeFormat:                "human",
+			},
 		},
 		{
 			name:   "TestGetStatsWithCustomClient",
 			client: customSv,
+			statsParam: &meilisearch.StatsParams{
+				ShowInternalDatabaseSizes: false,
+				SizeFormat:                "raw",
+			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotResp, err := tt.client.GetStats()
+			gotResp, err := tt.client.GetStats(tt.statsParam)
 			require.NoError(t, err)
 			require.NotNil(t, gotResp, "GetStats() should not return nil value")
 		})
@@ -1167,7 +1176,7 @@ func Test_GetTasksUsingClientAllFailures(t *testing.T) {
 			_, err = c.GetTasks(tt.args.query)
 			require.Error(t, err)
 
-			_, err = c.GetStats()
+			_, err = c.GetStats(nil)
 			require.Error(t, err)
 
 			_, err = c.CreateKey(&meilisearch.Key{

--- a/meilisearch.go
+++ b/meilisearch.go
@@ -547,19 +547,26 @@ func (m *meilisearch) GenerateTenantToken(
 	return tokenString, err
 }
 
-func (m *meilisearch) GetStats() (*Stats, error) {
-	return m.GetStatsWithContext(context.Background())
+func (m *meilisearch) GetStats(param *StatsParams) (*Stats, error) {
+	return m.GetStatsWithContext(context.Background(), param)
 }
 
-func (m *meilisearch) GetStatsWithContext(ctx context.Context) (*Stats, error) {
+func (m *meilisearch) GetStatsWithContext(ctx context.Context, param *StatsParams) (*Stats, error) {
 	resp := new(Stats)
 	req := &internalRequest{
 		endpoint:            "/stats",
 		method:              http.MethodGet,
+		withQueryParams:     map[string]string{},
 		withRequest:         nil,
 		withResponse:        resp,
 		acceptedStatusCodes: []int{http.StatusOK},
 		functionName:        "GetStats",
+	}
+	if param != nil && param.SizeFormat != "" {
+		req.withQueryParams["sizeFormat"] = param.SizeFormat
+	}
+	if param != nil && param.ShowInternalDatabaseSizes {
+		req.withQueryParams["showInternalDatabaseSizes"] = "true"
 	}
 	if err := m.client.executeRequest(ctx, req); err != nil {
 		return nil, err

--- a/meilisearch_interface.go
+++ b/meilisearch_interface.go
@@ -175,12 +175,12 @@ type ServiceReader interface {
 	// GetStats fetches global stats.
 	//
 	// docs: https://www.meilisearch.com/docs/reference/api/stats/get-stats-of-all-indexes
-	GetStats() (*Stats, error)
+	GetStats(param *StatsParams) (*Stats, error)
 
 	// GetStatsWithContext fetches global stats with a context for cancellation.
 	//
 	// docs: https://www.meilisearch.com/docs/reference/api/stats/get-stats-of-all-indexes
-	GetStatsWithContext(ctx context.Context) (*Stats, error)
+	GetStatsWithContext(ctx context.Context, param *StatsParams) (*Stats, error)
 
 	// Version fetches the version of the Meilisearch server.
 	//

--- a/types.go
+++ b/types.go
@@ -401,21 +401,27 @@ type Version struct {
 	PkgVersion string `json:"pkgVersion"`
 }
 
+type StatsParams struct {
+	ShowInternalDatabaseSizes bool   `json:"showInternalDatabaseSizes,omitempty"`
+	SizeFormat                string `json:"sizeFormat,omitempty"` // human, raw
+}
+
 // StatsIndex is the type that represent the stats of an index in meilisearch
 type StatsIndex struct {
 	NumberOfDocuments         int64            `json:"numberOfDocuments"`
 	IsIndexing                bool             `json:"isIndexing"`
 	FieldDistribution         map[string]int64 `json:"fieldDistribution"`
-	RawDocumentDbSize         int64            `json:"rawDocumentDbSize"`
-	AvgDocumentSize           int64            `json:"avgDocumentSize"`
+	RawDocumentDbSize         any              `json:"rawDocumentDbSize"`
+	AvgDocumentSize           any              `json:"avgDocumentSize"`
 	NumberOfEmbeddedDocuments int64            `json:"numberOfEmbeddedDocuments"`
 	NumberOfEmbeddings        int64            `json:"numberOfEmbeddings"`
+	InternalDatabaseSizes     map[string]any   `json:"internalDatabaseSizes"`
 }
 
 // Stats is the type that represent all stats
 type Stats struct {
-	DatabaseSize     int64                 `json:"databaseSize"`
-	UsedDatabaseSize int64                 `json:"usedDatabaseSize"`
+	DatabaseSize     any                   `json:"databaseSize"`
+	UsedDatabaseSize any                   `json:"usedDatabaseSize"`
 	LastUpdate       time.Time             `json:"lastUpdate"`
 	Indexes          map[string]StatsIndex `json:"indexes"`
 }


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #784

## What does this PR do?
- added new stats params to index and service manager methods
- changed types of stats to cover both human-formatted and raw
- added new integration tests cases for stats endpoints

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR implements support for human-formatted sizes and detailed internal database sizes in stats endpoints for the Meilisearch Go SDK, addressing the requirements from issue `#784`.

## Changes Summary

### New Types and Parameters
- Added `StatsParams` type to support optional query parameters:
  - `ShowInternalDatabaseSizes` (boolean): When enabled, index stats include an `InternalDatabaseSizes` map with internal database names and their sizes
  - `SizeFormat` (string): Specifies size format as "human" (human-readable strings with units like MiB/GiB) or "raw" (numeric bytes)

### Type Updates
- Modified `StatsIndex` response type:
  - Changed `RawDocumentDbSize` and `AvgDocumentSize` from `int64` to `any` to support both numeric and string representations
  - Added `InternalDatabaseSizes map[string]any` field for internal database size details
  
- Modified top-level `Stats` response type:
  - Changed `DatabaseSize` and `UsedDatabaseSize` from `int64` to `any` to support both numeric and string representations

### API Signature Updates
- **Index-level stats**: Updated `index.GetStats()` and `index.GetStatsWithContext()` to accept `*StatsParams` parameter
- **Service-level stats**: Updated `meilisearch.GetStats()` and `meilisearch.GetStatsWithContext()` to accept `*StatsParams` parameter
- Updated corresponding interface definitions in `IndexReader` and `ServiceReader`

### Implementation Details
- Query parameters (`sizeFormat` and `showInternalDatabaseSizes`) are conditionally set based on provided `StatsParams`
- The implementation maintains backward compatibility in terms of endpoint behavior while introducing new parameter handling

### Testing
- Extended integration tests in `index_test.go` to cover:
  - Default behavior (no parameters)
  - Explicit "raw" format specification
  - "human" format specification with string size assertions
  - Internal database sizes when enabled
  
- Updated global stats tests in `meilisearch_test.go` to use the new `StatsParams` parameter

### Documentation
- Updated `.code-samples.meilisearch.yaml` to reflect the new API signatures (`GetStats(nil)` instead of `GetStats()`)

### Breaking Changes
- Method signatures for `GetStats()` and `GetStatsWithContext()` now require a `*StatsParams` argument (can be `nil` for default behavior)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meilisearch/meilisearch-go/pull/785?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->