### PR TITLE
Bump version from 0.36.2 to 0.36.3

### DIFF
--- a/version.go
+++ b/version.go
@@ -2,7 +2,7 @@ package meilisearch
 
 import "fmt"
 
-const VERSION = "0.36.2"
+const VERSION = "0.36.3"
 
 func GetQualifiedVersion() (qualifiedVersion string) {
 	return getQualifiedVersion(VERSION)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This pull request bumps the package version from 0.36.2 to 0.36.3 by updating the `VERSION` constant in `version.go`. This change affects the version string returned by `GetQualifiedVersion()` and `getQualifiedVersion()` functions.

**Changes:**
- Updated `const VERSION = "0.36.2"` to `const VERSION = "0.36.3"` in `version.go`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->