### PR TITLE
Add personalized search support (v1.47.0)

### DIFF
--- a/integration/index_search_test.go
+++ b/integration/index_search_test.go
@@ -1085,6 +1085,8 @@ func TestIndex_SearchWithVectorStore(t *testing.T) {
 func TestIndex_SearchWithPersonalize(t *testing.T) {
 	sv := setup(t, "")
 
+	getEnvOrSkip(t, "VOYAGE_API_KEY")
+
 	tests := []struct {
 		name    string
 		UID     string

--- a/integration/index_search_test.go
+++ b/integration/index_search_test.go
@@ -1082,6 +1082,44 @@ func TestIndex_SearchWithVectorStore(t *testing.T) {
 	}
 }
 
+func TestIndex_SearchWithPersonalize(t *testing.T) {
+	sv := setup(t, "")
+
+	tests := []struct {
+		name    string
+		UID     string
+		client  meilisearch.ServiceManager
+		query   string
+		request meilisearch.SearchRequest
+	}{
+		{
+			name:   "personalized search with user context",
+			UID:    "indexUID",
+			client: sv,
+			query:  "Pride",
+			request: meilisearch.SearchRequest{
+				Personalize: &meilisearch.SearchRequestPersonalize{
+					UserContext: "Prefers classic romance novels",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setUpBasicIndex(tt.client, tt.UID)
+			c := tt.client
+			t.Cleanup(cleanup(c))
+			i := c.Index(tt.UID)
+
+			got, err := i.Search(tt.query, &tt.request)
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			require.Greater(t, len(got.Hits), 0, "expected at least one hit")
+		})
+	}
+}
+
 func TestIndex_SearchWithDistinct(t *testing.T) {
 	sv := setup(t, "")
 

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -267,6 +267,17 @@ func getenv(key, fallback string) string {
 	return value
 }
 
+func getEnvOrSkip(t *testing.T, key string) string {
+	t.Helper()
+
+	value := os.Getenv(key)
+	if value == "" {
+		t.Skipf("env %q not set, skipping test", key)
+	}
+
+	return value
+}
+
 func testWaitForIndexTask(t *testing.T, i meilisearch.IndexManager, u *meilisearch.TaskInfo) {
 	t.Helper()
 	r, err := i.WaitForTask(u.TaskUID, 0)

--- a/types.go
+++ b/types.go
@@ -675,36 +675,37 @@ type CreateIndexRequest struct {
 //
 // Documentation: https://www.meilisearch.com/docs/reference/api/search#search-parameters
 type SearchRequest struct {
-	Offset                  int64                    `json:"offset,omitempty"`
-	Limit                   int64                    `json:"limit,omitempty"`
-	AttributesToRetrieve    []string                 `json:"attributesToRetrieve,omitempty"`
-	AttributesToSearchOn    []string                 `json:"attributesToSearchOn,omitempty"`
-	AttributesToCrop        []string                 `json:"attributesToCrop,omitempty"`
-	CropLength              int64                    `json:"cropLength,omitempty"`
-	CropMarker              string                   `json:"cropMarker,omitempty"`
-	AttributesToHighlight   []string                 `json:"attributesToHighlight,omitempty"`
-	HighlightPreTag         string                   `json:"highlightPreTag,omitempty"`
-	HighlightPostTag        string                   `json:"highlightPostTag,omitempty"`
-	MatchingStrategy        MatchingStrategy         `json:"matchingStrategy,omitempty"`
-	Filter                  interface{}              `json:"filter,omitempty"`
-	ShowMatchesPosition     bool                     `json:"showMatchesPosition,omitempty"`
-	ShowRankingScore        bool                     `json:"showRankingScore,omitempty"`
-	ShowRankingScoreDetails bool                     `json:"showRankingScoreDetails,omitempty"`
-	ShowPerformanceDetails  bool                     `json:"showPerformanceDetails,omitempty"`
-	Facets                  []string                 `json:"facets,omitempty"`
-	Sort                    []string                 `json:"sort,omitempty"`
-	Vector                  []float32                `json:"vector,omitempty"`
-	HitsPerPage             *int64                   `json:"hitsPerPage,omitempty"`
-	Page                    int64                    `json:"page,omitempty"`
-	IndexUID                string                   `json:"indexUid,omitempty"`
-	Query                   string                   `json:"q"`
-	Distinct                string                   `json:"distinct,omitempty"`
-	Hybrid                  *SearchRequestHybrid     `json:"hybrid"`
-	RetrieveVectors         bool                     `json:"retrieveVectors,omitempty"`
-	RankingScoreThreshold   float64                  `json:"rankingScoreThreshold,omitempty"`
-	FederationOptions       *SearchFederationOptions `json:"federationOptions,omitempty"`
-	Locales                 []string                 `json:"locales,omitempty"`
-	Media                   map[string]any           `json:"media,omitempty"`
+	Offset                  int64                     `json:"offset,omitempty"`
+	Limit                   int64                     `json:"limit,omitempty"`
+	AttributesToRetrieve    []string                  `json:"attributesToRetrieve,omitempty"`
+	AttributesToSearchOn    []string                  `json:"attributesToSearchOn,omitempty"`
+	AttributesToCrop        []string                  `json:"attributesToCrop,omitempty"`
+	CropLength              int64                     `json:"cropLength,omitempty"`
+	CropMarker              string                    `json:"cropMarker,omitempty"`
+	AttributesToHighlight   []string                  `json:"attributesToHighlight,omitempty"`
+	HighlightPreTag         string                    `json:"highlightPreTag,omitempty"`
+	HighlightPostTag        string                    `json:"highlightPostTag,omitempty"`
+	MatchingStrategy        MatchingStrategy          `json:"matchingStrategy,omitempty"`
+	Filter                  interface{}               `json:"filter,omitempty"`
+	ShowMatchesPosition     bool                      `json:"showMatchesPosition,omitempty"`
+	ShowRankingScore        bool                      `json:"showRankingScore,omitempty"`
+	ShowRankingScoreDetails bool                      `json:"showRankingScoreDetails,omitempty"`
+	ShowPerformanceDetails  bool                      `json:"showPerformanceDetails,omitempty"`
+	Facets                  []string                  `json:"facets,omitempty"`
+	Sort                    []string                  `json:"sort,omitempty"`
+	Vector                  []float32                 `json:"vector,omitempty"`
+	HitsPerPage             *int64                    `json:"hitsPerPage,omitempty"`
+	Page                    int64                     `json:"page,omitempty"`
+	IndexUID                string                    `json:"indexUid,omitempty"`
+	Query                   string                    `json:"q"`
+	Distinct                string                    `json:"distinct,omitempty"`
+	Hybrid                  *SearchRequestHybrid      `json:"hybrid"`
+	RetrieveVectors         bool                      `json:"retrieveVectors,omitempty"`
+	RankingScoreThreshold   float64                   `json:"rankingScoreThreshold,omitempty"`
+	FederationOptions       *SearchFederationOptions  `json:"federationOptions,omitempty"`
+	Locales                 []string                  `json:"locales,omitempty"`
+	Media                   map[string]any            `json:"media,omitempty"`
+	Personalize             *SearchRequestPersonalize `json:"personalize,omitempty"`
 }
 
 type SearchFederationOptions struct {
@@ -715,6 +716,15 @@ type SearchFederationOptions struct {
 type SearchRequestHybrid struct {
 	SemanticRatio float64 `json:"semanticRatio,omitempty"`
 	Embedder      string  `json:"embedder"`
+}
+
+// SearchRequestPersonalize configures personalized search.
+// When set, Meilisearch re-ranks results based on the user profile described in UserContext.
+//
+// Requires the experimental search personalization feature to be enabled on the server.
+// Documentation: https://www.meilisearch.com/docs/capabilities/personalization/getting_started/personalized_search
+type SearchRequestPersonalize struct {
+	UserContext string `json:"userContext"`
 }
 
 type MultiSearchRequest struct {

--- a/types.go
+++ b/types.go
@@ -724,6 +724,10 @@ type SearchRequestHybrid struct {
 // Requires the experimental search personalization feature to be enabled on the server.
 // Documentation: https://www.meilisearch.com/docs/capabilities/personalization/getting_started/personalized_search
 type SearchRequestPersonalize struct {
+	// UserContext is a free-text, natural-language description of the user's
+	// preferences, behavior, or intent (e.g. "Prefers compact mechanical keyboards
+	// from Keychron, mid-range budget"). The re-ranking model only processes
+	// positive signals, so state preferences affirmatively.
 	UserContext string `json:"userContext"`
 }
 

--- a/types_test.go
+++ b/types_test.go
@@ -114,6 +114,39 @@ func TestSearchRequest_Personalize(t *testing.T) {
 		require.NoError(t, json.Unmarshal(got["personalize"], &p))
 		require.Equal(t, "Prefers compact mechanical keyboards", p["userContext"])
 	})
+
+	t.Run("Personalize with empty UserContext still serializes the field", func(t *testing.T) {
+		sr := &SearchRequest{
+			Query:       "test",
+			Personalize: &SearchRequestPersonalize{UserContext: ""},
+		}
+		data, err := json.Marshal(sr)
+		require.NoError(t, err)
+
+		var got map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(data, &got))
+		require.Contains(t, got, "personalize", "personalize object must be present even when UserContext is empty")
+
+		var p map[string]string
+		require.NoError(t, json.Unmarshal(got["personalize"], &p))
+		require.Equal(t, "", p["userContext"], "userContext must be present with empty value")
+	})
+
+	t.Run("Personalize round-trips through JSON unmarshal", func(t *testing.T) {
+		original := &SearchRequest{
+			Query: "roundtrip",
+			Personalize: &SearchRequestPersonalize{
+				UserContext: "Prefers lightweight trail running shoes",
+			},
+		}
+		data, err := json.Marshal(original)
+		require.NoError(t, err)
+
+		var decoded SearchRequest
+		require.NoError(t, json.Unmarshal(data, &decoded))
+		require.NotNil(t, decoded.Personalize, "Personalize must populate after unmarshal")
+		require.Equal(t, "Prefers lightweight trail running shoes", decoded.Personalize.UserContext)
+	})
 }
 
 func TestTimestampz_String(t *testing.T) {

--- a/types_test.go
+++ b/types_test.go
@@ -85,6 +85,37 @@ func TestSearchRequest_validate(t *testing.T) {
 	})
 }
 
+func TestSearchRequest_Personalize(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Personalize is nil by default", func(t *testing.T) {
+		sr := &SearchRequest{Query: "test"}
+		data, err := json.Marshal(sr)
+		require.NoError(t, err)
+		require.NotContains(t, string(data), "personalize",
+			"personalize should be omitted when nil")
+	})
+
+	t.Run("Personalize serializes to expected JSON shape", func(t *testing.T) {
+		sr := &SearchRequest{
+			Query: "keyboard",
+			Personalize: &SearchRequestPersonalize{
+				UserContext: "Prefers compact mechanical keyboards",
+			},
+		}
+		data, err := json.Marshal(sr)
+		require.NoError(t, err)
+
+		var got map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(data, &got))
+		require.Contains(t, got, "personalize", "personalize field must be present in JSON")
+
+		var p map[string]string
+		require.NoError(t, json.Unmarshal(got["personalize"], &p))
+		require.Equal(t, "Prefers compact mechanical keyboards", p["userContext"])
+	})
+}
+
 func TestTimestampz_String(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Adds support for the `personalize` search request parameter introduced in [Meilisearch v1.47.0](https://github.com/meilisearch/meilisearch/releases/tag/v1.47.0), enabling personalized (AI-re-ranked) search results.

Closes #787

## What changed

### New type
- **`SearchRequestPersonalize`** struct with a single field `UserContext string` (`json:"userContext"`), mirroring the existing `SearchRequestHybrid` pattern.

### New field on `SearchRequest`
- **`Personalize *SearchRequestPersonalize`** (`json:"personalize,omitempty"`) — optional pointer; omitted from JSON when nil.

This automatically enables support on `MultiSearch` as well, since `MultiSearchRequest` embeds `[]*SearchRequest`.

### Example usage
```go
resp, err := client.Index("products").Search("keyboard", &meilisearch.SearchRequest{
    Personalize: &meilisearch.SearchRequestPersonalize{
        UserContext: "Prefers compact mechanical keyboards from Keychron, mid-range budget",
    },
})
```

## How to test

**Unit tests (no server required):**
```sh
go test -run TestSearchRequest_Personalize -v ./...
```
Covers: nil-omission, JSON serialization shape, empty `UserContext` round-trip, and marshal/unmarshal symmetry.

**Integration test (requires Meilisearch v1.47+ with personalization enabled via CLI flag):**
```sh
go test -run TestIndex_SearchWithPersonalize ./integration/...
```

## Notes for reviewers

- **No transport/method changes**: the existing `Search()` method already POSTs the full `SearchRequest` body, so the new field flows through automatically.
- **No mock regeneration needed**: mocks reference `*SearchRequest` by pointer; adding a field doesn't change method signatures.
- **No `validate()` changes**: the server validates `userContext` (returns `invalid_search_personalize_user_context` on empty); the SDK intentionally defers validation to the server, consistent with `SearchRequestHybrid`.
- **Integration test CI dependency**: personalization is an experimental feature activated via CLI flag (`--experimental-*`), not via the `/experimental-features` API route. The integration test assumes CI's Meilisearch instance has personalization enabled. If CI uses the enterprise Docker image (`docker-compose.yml`), it should be available.

## Checklist

- [x] Type added matching the [OpenAPI contract](https://www.meilisearch.com/docs/reference/api/search/search-with-post)
- [x] Unit tests added (4 subtests: nil-omission, serialization, empty-context, round-trip)
- [x] Integration test added
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `gofmt` clean on modified files
- [x] `golangci-lint` clean on modified files
- [x] No breaking changes (new optional field)

## AI usage disclosure

This contribution was prepared with AI assistance (Claude via opencode). The type design, tests, and verification commands were generated and reviewed by the contributor. Scope is limited to the data-model change described in issue #787.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search requests can now include optional personalization details to tailor results using a user context.

* **Tests**
  * Added coverage for personalization request serialization and end-to-end search behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->