### PR TITLE
Update Dynamic Search Rules for Meilisearch v1.50

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -766,25 +766,30 @@ update_network_1: |-
 compact_index_1: |-
   client.Index("INDEX_UID").Compact();
 list_dynamic_search_rules_1: |-
-  client.ListSearchRules(&meilisearch.SearchRulesParams{})
+  client.ListSearchRules(&meilisearch.SearchRulesParams{
+    Filter: &meilisearch.SearchRulesFilter{
+      Query: "black friday",
+    },
+  })
 get_dynamic_search_rule_1: |-
   client.GetSearchRule("black-friday")
 patch_dynamic_search_rule_1: |-
+  precedence := 10
   active := true
-  isEmpty := true
+  isEmpty := false
+  words := "black friday"
   startTime, _ := time.Parse(time.RFC3339, "2025-11-28T00:00:00Z")
   endTime, _ := time.Parse(time.RFC3339, "2025-11-28T23:59:59Z")
   client.UpdateSearchRule("black-friday", &meilisearch.SearchRulesRequest{
     Description: "Black Friday 2025 rules",
-    Priority: 10,
+    Precedence: &precedence,
     Active: &active,
-    Conditions: []meilisearch.Condition{
-      {
-        Scope:   "query",
+    Conditions: &meilisearch.SearchRuleConditions{
+      Query: &meilisearch.QueryCondition{
         IsEmpty: &isEmpty,
+        Words:   &words,
       },
-      {
-        Scope: "time",
+      Time: &meilisearch.TimeCondition{
         Start: &startTime,
         End:   &endTime,
       },

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -114,7 +114,7 @@ func cleanupChat(services ...meilisearch.ChatManager) func() {
 	}
 }
 
-func cleanupSearchRules(services ...meilisearch.SearchRulesManager) func() {
+func cleanupSearchRules(services ...meilisearch.ServiceManager) func() {
 	return func() {
 		for _, s := range services {
 			_, _ = deleteAllSearchRules(s)
@@ -193,18 +193,13 @@ func resetNetwork(sv meilisearch.ServiceManager) (ok bool, err error) {
 	return true, nil
 }
 
-func deleteAllSearchRules(searchRuleMgr meilisearch.SearchRulesManager) (ok bool, err error) {
-	rules, err := searchRuleMgr.ListSearchRules(&meilisearch.SearchRulesParams{
-		Offset: 0,
-		Limit:  1000,
-	})
+func deleteAllSearchRules(searchRuleMgr meilisearch.ServiceManager) (ok bool, err error) {
+	task, err := searchRuleMgr.DeleteAllSearchRules()
 	if err != nil {
 		return false, err
 	}
-	for _, rule := range rules.Results {
-		if err := searchRuleMgr.DeleteSearchRule(rule.Uid); err != nil {
-			return false, err
-		}
+	if _, err := searchRuleMgr.WaitForTask(task.TaskUID, 0); err != nil {
+		return false, err
 	}
 	return true, nil
 }

--- a/integration/search_rules_test.go
+++ b/integration/search_rules_test.go
@@ -10,6 +10,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func updateSearchRuleAndWait(
+	t *testing.T,
+	sv meilisearch.ServiceManager,
+	uid string,
+	request *meilisearch.SearchRulesRequest,
+) *meilisearch.TaskInfo {
+	t.Helper()
+
+	task, err := sv.UpdateSearchRule(uid, request)
+	require.NoError(t, err)
+	require.NotNil(t, task)
+	require.Equal(t, meilisearch.TaskStatusEnqueued, task.Status)
+	require.False(t, task.EnqueuedAt.IsZero())
+
+	_, err = sv.WaitForTask(task.TaskUID, 0)
+	require.NoError(t, err)
+	return task
+}
+
 func Test_ListSearchRule(t *testing.T) {
 	sv := setup(t, "")
 	t.Cleanup(cleanupSearchRules(sv))
@@ -21,20 +40,20 @@ func Test_ListSearchRule(t *testing.T) {
 
 	uids := []string{"black-friday", "christmas-sale", "summer-deals"}
 	start := time.Now().UTC().Truncate(time.Second)
-	end := start.Add(time.Hour * 24)
+	end := start.Add(24 * time.Hour)
 
 	for i, uid := range uids {
-		_, err := sv.UpdateSearchRule(uid, &meilisearch.SearchRulesRequest{
+		words := fmt.Sprintf("%s promotion", uid)
+		updateSearchRuleAndWait(t, sv, uid, &meilisearch.SearchRulesRequest{
 			Description: fmt.Sprintf("Rule %d for %s", i, uid),
-			Priority:    intPtr(i + 1),
+			Precedence:  intPtr(i + 1),
 			Active:      boolPtr(true),
-			Conditions: []meilisearch.Condition{
-				{
-					Scope:   "query",
-					IsEmpty: boolPtr(true),
+			Conditions: &meilisearch.SearchRuleConditions{
+				Query: &meilisearch.QueryCondition{
+					IsEmpty: boolPtr(false),
+					Words:   &words,
 				},
-				{
-					Scope: "time",
+				Time: &meilisearch.TimeCondition{
 					Start: &start,
 					End:   &end,
 				},
@@ -52,62 +71,66 @@ func Test_ListSearchRule(t *testing.T) {
 				},
 			},
 		})
-		require.NoError(t, err)
 	}
 
-	t.Run("list all rules with pagination", func(t *testing.T) {
+	t.Run("list all rules", func(t *testing.T) {
 		results, err := sv.ListSearchRules(&meilisearch.SearchRulesParams{
 			Offset: 0,
 			Limit:  20,
 		})
 		require.NoError(t, err)
-		assert.NotNil(t, results)
-
-		assert.Equal(t, results.Total, int64(len(uids)))
+		require.NotNil(t, results)
+		assert.Equal(t, int64(len(uids)), results.Total)
 		assert.Equal(t, int64(0), results.Offset)
 		assert.Equal(t, int64(20), results.Limit)
 		assert.Len(t, results.Results, len(uids))
 
-		// Verify results contain expected UIDs
 		foundUIDs := make(map[string]bool)
 		for _, rule := range results.Results {
 			foundUIDs[rule.Uid] = true
-			assert.NotEmpty(t, rule.Uid)
 			assert.NotEmpty(t, rule.Description)
 			assert.True(t, rule.Active)
-			assert.Greater(t, rule.Priority, 0)
-			assert.NotEmpty(t, rule.Conditions)
+			assert.Greater(t, rule.Precedence, 0)
+			require.NotNil(t, rule.Conditions.Query)
+			assert.NotNil(t, rule.Conditions.Query.Words)
+			assert.NotNil(t, rule.Conditions.Time)
 			assert.NotEmpty(t, rule.Actions)
 		}
 		for _, uid := range uids {
-			assert.True(t, foundUIDs[uid], "Expected to find rule with UID: %s", uid)
+			assert.True(t, foundUIDs[uid], "expected to find rule with UID: %s", uid)
 		}
 	})
 
-	t.Run("list rules with filter", func(t *testing.T) {
+	t.Run("paginate rules", func(t *testing.T) {
 		results, err := sv.ListSearchRules(&meilisearch.SearchRulesParams{
-			Offset: 0,
-			Limit:  20,
-			Filter: &meilisearch.SearchRulesFilter{
-				Active: boolPtr(false),
-			},
+			Offset: 1,
+			Limit:  1,
 		})
 		require.NoError(t, err)
-		assert.NotNil(t, results)
+		require.NotNil(t, results)
+		assert.Equal(t, int64(1), results.Offset)
+		assert.Equal(t, int64(1), results.Limit)
+		assert.Equal(t, int64(len(uids)), results.Total)
+		assert.Len(t, results.Results, 1)
+	})
+
+	t.Run("filter rules by active status", func(t *testing.T) {
+		results, err := sv.ListSearchRules(&meilisearch.SearchRulesParams{
+			Filter: &meilisearch.SearchRulesFilter{Active: boolPtr(false)},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, results)
 		assert.Zero(t, results.Total)
 	})
 
-	t.Run("list rules with attribute patterns filter", func(t *testing.T) {
+	t.Run("filter rules by query", func(t *testing.T) {
 		results, err := sv.ListSearchRules(&meilisearch.SearchRulesParams{
-			Offset: 0,
-			Limit:  20,
-			Filter: &meilisearch.SearchRulesFilter{
-				AttributePatterns: []string{"categories"},
-			},
+			Filter: &meilisearch.SearchRulesFilter{Query: "christmas"},
 		})
 		require.NoError(t, err)
-		assert.NotNil(t, results)
-		assert.Equal(t, len(results.Results), 0)
+		require.NotNil(t, results)
+		require.Len(t, results.Results, 1)
+		assert.Equal(t, "christmas-sale", results.Results[0].Uid)
 	})
 }
 
@@ -121,98 +144,73 @@ func Test_UpdateSearchRule(t *testing.T) {
 	require.True(t, resp.DynamicSearchRules)
 
 	uid := "promo-rule"
-	start := time.Now().Truncate(time.Second)
-	end := start.Add(time.Hour * 2)
+	start := time.Now().UTC().Truncate(time.Second)
+	end := start.Add(2 * time.Hour)
+	createWords := "special offer"
 
-	t.Run("create new rule", func(t *testing.T) {
-		rule, err := sv.UpdateSearchRule(uid, &meilisearch.SearchRulesRequest{
-			Description: "Promotional campaign rules",
-			Priority:    intPtr(10),
-			Active:      boolPtr(true),
-			Conditions: []meilisearch.Condition{
-				{
-					Scope:   "query",
-					IsEmpty: boolPtr(true),
-				},
-				{
-					Scope: "time",
-					Start: &start,
-					End:   &end,
-				},
+	createTask := updateSearchRuleAndWait(t, sv, uid, &meilisearch.SearchRulesRequest{
+		Description: "Promotional campaign rules",
+		Precedence:  intPtr(10),
+		Active:      boolPtr(true),
+		Conditions: &meilisearch.SearchRuleConditions{
+			Query: &meilisearch.QueryCondition{
+				IsEmpty: boolPtr(false),
+				Words:   &createWords,
 			},
-			Actions: []meilisearch.Action{
-				{
-					Selector: meilisearch.Selector{
-						IndexUid: "products",
-						ID:       "456",
-					},
-					Action: meilisearch.ActionDef{
-						Type:     "pin",
-						Position: 1,
-					},
-				},
+			Time: &meilisearch.TimeCondition{Start: &start, End: &end},
+		},
+		Actions: []meilisearch.Action{
+			{
+				Selector: meilisearch.Selector{IndexUid: "products", ID: "456"},
+				Action:   meilisearch.ActionDef{Type: "pin", Position: 1},
 			},
-		})
-		require.NoError(t, err)
-		require.NotNil(t, rule)
-		assert.Equal(t, uid, rule.Uid)
-		assert.Equal(t, "Promotional campaign rules", rule.Description)
-		assert.Equal(t, 10, rule.Priority)
-		assert.True(t, rule.Active)
-		assert.Len(t, rule.Conditions, 2)
-		assert.Len(t, rule.Actions, 1)
+		},
 	})
+	assert.Equal(t, meilisearch.TaskStatusEnqueued, createTask.Status)
 
-	t.Run("update existing rule", func(t *testing.T) {
-		updatedRule, err := sv.UpdateSearchRule(uid, &meilisearch.SearchRulesRequest{
-			Description: "Updated promotional campaign rules",
-			Priority:    intPtr(8),
-			Active:      boolPtr(false),
-			Conditions: []meilisearch.Condition{
-				{
-					Scope:   "query",
-					IsEmpty: boolPtr(false),
-				},
-			},
-			Actions: []meilisearch.Action{
-				{
-					Selector: meilisearch.Selector{
-						IndexUid: "products",
-						ID:       "789",
-					},
-					Action: meilisearch.ActionDef{
-						Type:     "pin",
-						Position: 2,
-					},
-				},
-				{
-					Selector: meilisearch.Selector{
-						IndexUid: "categories",
-						ID:       "001",
-					},
-					Action: meilisearch.ActionDef{
-						Type:     "pin",
-						Position: 1,
-					},
-				},
-			},
-		})
-		require.NoError(t, err)
-		require.NotNil(t, updatedRule)
-		assert.Equal(t, uid, updatedRule.Uid)
-		assert.Equal(t, "Updated promotional campaign rules", updatedRule.Description)
-		assert.Equal(t, 8, updatedRule.Priority)
-		assert.False(t, updatedRule.Active)
-		assert.Len(t, updatedRule.Conditions, 1)
-		assert.Len(t, updatedRule.Actions, 2)
+	createdRule, err := sv.GetSearchRule(uid)
+	require.NoError(t, err)
+	require.NotNil(t, createdRule)
+	assert.Equal(t, "Promotional campaign rules", createdRule.Description)
+	assert.Equal(t, 10, createdRule.Precedence)
+	assert.True(t, createdRule.Active)
+	require.NotNil(t, createdRule.Conditions.Query)
+	assert.Equal(t, createWords, *createdRule.Conditions.Query.Words)
+	assert.Len(t, createdRule.Actions, 1)
 
-		// Verify update persisted
-		fetchedRule, err := sv.GetSearchRule(uid)
-		require.NoError(t, err)
-		assert.Equal(t, updatedRule.Description, fetchedRule.Description)
-		assert.Equal(t, updatedRule.Priority, fetchedRule.Priority)
-		assert.Equal(t, updatedRule.Active, fetchedRule.Active)
+	updateWords := "updated promotion"
+	updateTask := updateSearchRuleAndWait(t, sv, uid, &meilisearch.SearchRulesRequest{
+		Description: "Updated promotional campaign rules",
+		Precedence:  intPtr(8),
+		Active:      boolPtr(false),
+		Conditions: &meilisearch.SearchRuleConditions{
+			Query: &meilisearch.QueryCondition{
+				IsEmpty: boolPtr(false),
+				Words:   &updateWords,
+			},
+		},
+		Actions: []meilisearch.Action{
+			{
+				Selector: meilisearch.Selector{IndexUid: "products", ID: "789"},
+				Action:   meilisearch.ActionDef{Type: "pin", Position: 2},
+			},
+			{
+				Selector: meilisearch.Selector{IndexUid: "categories", ID: "001"},
+				Action:   meilisearch.ActionDef{Type: "pin", Position: 1},
+			},
+		},
 	})
+	assert.Equal(t, meilisearch.TaskStatusEnqueued, updateTask.Status)
+
+	updatedRule, err := sv.GetSearchRule(uid)
+	require.NoError(t, err)
+	require.NotNil(t, updatedRule)
+	assert.Equal(t, "Updated promotional campaign rules", updatedRule.Description)
+	assert.Equal(t, 8, updatedRule.Precedence)
+	assert.False(t, updatedRule.Active)
+	require.NotNil(t, updatedRule.Conditions.Query)
+	assert.Equal(t, updateWords, *updatedRule.Conditions.Query.Words)
+	assert.Len(t, updatedRule.Actions, 2)
 }
 
 func Test_GetSearchRule(t *testing.T) {
@@ -225,42 +223,29 @@ func Test_GetSearchRule(t *testing.T) {
 	require.True(t, resp.DynamicSearchRules)
 
 	uid := "black-friday"
-	start := time.Now()
-	end := start.Add(time.Hour * 1)
-
-	want, err := sv.UpdateSearchRule(uid, &meilisearch.SearchRulesRequest{
+	updateSearchRuleAndWait(t, sv, uid, &meilisearch.SearchRulesRequest{
 		Description: "Black Friday 2025 rules",
-		Priority:    intPtr(5),
+		Precedence:  intPtr(5),
 		Active:      boolPtr(true),
-		Conditions: []meilisearch.Condition{
-			{
-				Scope:   "query",
-				IsEmpty: boolPtr(true),
-			},
-			{
-				Scope: "time",
-				Start: &start,
-				End:   &end,
-			},
+		Conditions: &meilisearch.SearchRuleConditions{
+			Query: &meilisearch.QueryCondition{IsEmpty: boolPtr(true)},
 		},
 		Actions: []meilisearch.Action{
 			{
-				Selector: meilisearch.Selector{
-					IndexUid: "products",
-					ID:       "123",
-				},
-				Action: meilisearch.ActionDef{
-					Type:     "pin",
-					Position: 1,
-				},
+				Selector: meilisearch.Selector{IndexUid: "products", ID: "123"},
+				Action:   meilisearch.ActionDef{Type: "pin", Position: 1},
 			},
 		},
 	})
-	require.NoError(t, err)
 
 	got, err := sv.GetSearchRule(uid)
 	require.NoError(t, err)
-	assert.Equal(t, want, got)
+	require.NotNil(t, got)
+	assert.Equal(t, uid, got.Uid)
+	assert.Equal(t, "Black Friday 2025 rules", got.Description)
+	assert.Equal(t, 5, got.Precedence)
+	require.NotNil(t, got.Conditions.Query)
+	assert.Equal(t, true, *got.Conditions.Query.IsEmpty)
 }
 
 func Test_DeleteSearchRule(t *testing.T) {
@@ -273,42 +258,65 @@ func Test_DeleteSearchRule(t *testing.T) {
 	require.True(t, resp.DynamicSearchRules)
 
 	uid := "black-friday"
-	start := time.Now()
-	end := start.Add(time.Hour * 1)
-	_, err = sv.UpdateSearchRule(uid, &meilisearch.SearchRulesRequest{
-		Description: "Black Friday 2025 rules",
-		Priority:    intPtr(5),
-		Active:      boolPtr(true),
-		Conditions: []meilisearch.Condition{
-			{
-				Scope:   "query",
-				IsEmpty: boolPtr(true),
-			},
-			{
-				Scope: "time",
-				Start: &start,
-				End:   &end,
-			},
+	updateSearchRuleAndWait(t, sv, uid, &meilisearch.SearchRulesRequest{
+		Conditions: &meilisearch.SearchRuleConditions{
+			Query: &meilisearch.QueryCondition{IsEmpty: boolPtr(true)},
 		},
 		Actions: []meilisearch.Action{
 			{
-				Selector: meilisearch.Selector{
-					IndexUid: "products",
-					ID:       "123",
-				},
-				Action: meilisearch.ActionDef{
-					Type:     "pin",
-					Position: 1,
-				},
+				Selector: meilisearch.Selector{IndexUid: "products", ID: "123"},
+				Action:   meilisearch.ActionDef{Type: "pin", Position: 1},
 			},
 		},
 	})
-	require.NoError(t, err)
 
-	err = sv.DeleteSearchRule(uid)
+	deleteTask, err := sv.DeleteSearchRule(uid)
+	require.NoError(t, err)
+	require.NotNil(t, deleteTask)
+	assert.Equal(t, meilisearch.TaskStatusEnqueued, deleteTask.Status)
+	_, err = sv.WaitForTask(deleteTask.TaskUID, 0)
 	require.NoError(t, err)
 
 	got, err := sv.GetSearchRule(uid)
 	require.Error(t, err)
 	assert.Nil(t, got)
+
+	missingTask, err := sv.DeleteSearchRule("missing-rule")
+	require.NoError(t, err)
+	require.NotNil(t, missingTask)
+	_, err = sv.WaitForTask(missingTask.TaskUID, 0)
+	require.NoError(t, err)
+}
+
+func Test_DeleteAllSearchRules(t *testing.T) {
+	sv := setup(t, "")
+	t.Cleanup(cleanupSearchRules(sv))
+
+	resp, err := sv.ExperimentalFeatures().SetDynamicSearchRules(true).Update()
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.True(t, resp.DynamicSearchRules)
+
+	for _, uid := range []string{"rule-one", "rule-two"} {
+		updateSearchRuleAndWait(t, sv, uid, &meilisearch.SearchRulesRequest{
+			Actions: []meilisearch.Action{
+				{
+					Selector: meilisearch.Selector{ID: uid},
+					Action:   meilisearch.ActionDef{Type: "pin", Position: 1},
+				},
+			},
+		})
+	}
+
+	deleteTask, err := sv.DeleteAllSearchRules()
+	require.NoError(t, err)
+	require.NotNil(t, deleteTask)
+	assert.Equal(t, meilisearch.TaskStatusEnqueued, deleteTask.Status)
+	_, err = sv.WaitForTask(deleteTask.TaskUID, 0)
+	require.NoError(t, err)
+
+	results, err := sv.ListSearchRules(&meilisearch.SearchRulesParams{})
+	require.NoError(t, err)
+	require.NotNil(t, results)
+	assert.Zero(t, results.Total)
 }

--- a/mocks/meilisearch_search_rules_manager_mock.go
+++ b/mocks/meilisearch_search_rules_manager_mock.go
@@ -38,21 +38,149 @@ func (_m *MockmeilisearchSearchRulesManager) EXPECT() *MockmeilisearchSearchRule
 	return &MockmeilisearchSearchRulesManager_Expecter{mock: &_m.Mock}
 }
 
+// DeleteAllSearchRules provides a mock function for the type MockmeilisearchSearchRulesManager
+func (_mock *MockmeilisearchSearchRulesManager) DeleteAllSearchRules() (*meilisearch.TaskInfo, error) {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteAllSearchRules")
+	}
+
+	var r0 *meilisearch.TaskInfo
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func() (*meilisearch.TaskInfo, error)); ok {
+		return returnFunc()
+	}
+	if returnFunc, ok := ret.Get(0).(func() *meilisearch.TaskInfo); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*meilisearch.TaskInfo)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func() error); ok {
+		r1 = returnFunc()
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockmeilisearchSearchRulesManager_DeleteAllSearchRules_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteAllSearchRules'
+type MockmeilisearchSearchRulesManager_DeleteAllSearchRules_Call struct {
+	*mock.Call
+}
+
+// DeleteAllSearchRules is a helper method to define mock.On call
+func (_e *MockmeilisearchSearchRulesManager_Expecter) DeleteAllSearchRules() *MockmeilisearchSearchRulesManager_DeleteAllSearchRules_Call {
+	return &MockmeilisearchSearchRulesManager_DeleteAllSearchRules_Call{Call: _e.mock.On("DeleteAllSearchRules")}
+}
+
+func (_c *MockmeilisearchSearchRulesManager_DeleteAllSearchRules_Call) Run(run func()) *MockmeilisearchSearchRulesManager_DeleteAllSearchRules_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockmeilisearchSearchRulesManager_DeleteAllSearchRules_Call) Return(taskInfo *meilisearch.TaskInfo, err error) *MockmeilisearchSearchRulesManager_DeleteAllSearchRules_Call {
+	_c.Call.Return(taskInfo, err)
+	return _c
+}
+
+func (_c *MockmeilisearchSearchRulesManager_DeleteAllSearchRules_Call) RunAndReturn(run func() (*meilisearch.TaskInfo, error)) *MockmeilisearchSearchRulesManager_DeleteAllSearchRules_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// DeleteAllSearchRulesWithContext provides a mock function for the type MockmeilisearchSearchRulesManager
+func (_mock *MockmeilisearchSearchRulesManager) DeleteAllSearchRulesWithContext(ctx context.Context) (*meilisearch.TaskInfo, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteAllSearchRulesWithContext")
+	}
+
+	var r0 *meilisearch.TaskInfo
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (*meilisearch.TaskInfo, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) *meilisearch.TaskInfo); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*meilisearch.TaskInfo)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockmeilisearchSearchRulesManager_DeleteAllSearchRulesWithContext_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteAllSearchRulesWithContext'
+type MockmeilisearchSearchRulesManager_DeleteAllSearchRulesWithContext_Call struct {
+	*mock.Call
+}
+
+// DeleteAllSearchRulesWithContext is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *MockmeilisearchSearchRulesManager_Expecter) DeleteAllSearchRulesWithContext(ctx interface{}) *MockmeilisearchSearchRulesManager_DeleteAllSearchRulesWithContext_Call {
+	return &MockmeilisearchSearchRulesManager_DeleteAllSearchRulesWithContext_Call{Call: _e.mock.On("DeleteAllSearchRulesWithContext", ctx)}
+}
+
+func (_c *MockmeilisearchSearchRulesManager_DeleteAllSearchRulesWithContext_Call) Run(run func(ctx context.Context)) *MockmeilisearchSearchRulesManager_DeleteAllSearchRulesWithContext_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockmeilisearchSearchRulesManager_DeleteAllSearchRulesWithContext_Call) Return(taskInfo *meilisearch.TaskInfo, err error) *MockmeilisearchSearchRulesManager_DeleteAllSearchRulesWithContext_Call {
+	_c.Call.Return(taskInfo, err)
+	return _c
+}
+
+func (_c *MockmeilisearchSearchRulesManager_DeleteAllSearchRulesWithContext_Call) RunAndReturn(run func(ctx context.Context) (*meilisearch.TaskInfo, error)) *MockmeilisearchSearchRulesManager_DeleteAllSearchRulesWithContext_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // DeleteSearchRule provides a mock function for the type MockmeilisearchSearchRulesManager
-func (_mock *MockmeilisearchSearchRulesManager) DeleteSearchRule(uid string) error {
+func (_mock *MockmeilisearchSearchRulesManager) DeleteSearchRule(uid string) (*meilisearch.TaskInfo, error) {
 	ret := _mock.Called(uid)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteSearchRule")
 	}
 
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
+	var r0 *meilisearch.TaskInfo
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string) (*meilisearch.TaskInfo, error)); ok {
+		return returnFunc(uid)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string) *meilisearch.TaskInfo); ok {
 		r0 = returnFunc(uid)
 	} else {
-		r0 = ret.Error(0)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*meilisearch.TaskInfo)
+		}
 	}
-	return r0
+	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
+		r1 = returnFunc(uid)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
 }
 
 // MockmeilisearchSearchRulesManager_DeleteSearchRule_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteSearchRule'
@@ -79,31 +207,42 @@ func (_c *MockmeilisearchSearchRulesManager_DeleteSearchRule_Call) Run(run func(
 	return _c
 }
 
-func (_c *MockmeilisearchSearchRulesManager_DeleteSearchRule_Call) Return(err error) *MockmeilisearchSearchRulesManager_DeleteSearchRule_Call {
-	_c.Call.Return(err)
+func (_c *MockmeilisearchSearchRulesManager_DeleteSearchRule_Call) Return(taskInfo *meilisearch.TaskInfo, err error) *MockmeilisearchSearchRulesManager_DeleteSearchRule_Call {
+	_c.Call.Return(taskInfo, err)
 	return _c
 }
 
-func (_c *MockmeilisearchSearchRulesManager_DeleteSearchRule_Call) RunAndReturn(run func(uid string) error) *MockmeilisearchSearchRulesManager_DeleteSearchRule_Call {
+func (_c *MockmeilisearchSearchRulesManager_DeleteSearchRule_Call) RunAndReturn(run func(uid string) (*meilisearch.TaskInfo, error)) *MockmeilisearchSearchRulesManager_DeleteSearchRule_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // DeleteSearchRuleWithContext provides a mock function for the type MockmeilisearchSearchRulesManager
-func (_mock *MockmeilisearchSearchRulesManager) DeleteSearchRuleWithContext(ctx context.Context, uid string) error {
+func (_mock *MockmeilisearchSearchRulesManager) DeleteSearchRuleWithContext(ctx context.Context, uid string) (*meilisearch.TaskInfo, error) {
 	ret := _mock.Called(ctx, uid)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteSearchRuleWithContext")
 	}
 
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) error); ok {
+	var r0 *meilisearch.TaskInfo
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*meilisearch.TaskInfo, error)); ok {
+		return returnFunc(ctx, uid)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *meilisearch.TaskInfo); ok {
 		r0 = returnFunc(ctx, uid)
 	} else {
-		r0 = ret.Error(0)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*meilisearch.TaskInfo)
+		}
 	}
-	return r0
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, uid)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
 }
 
 // MockmeilisearchSearchRulesManager_DeleteSearchRuleWithContext_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteSearchRuleWithContext'
@@ -136,12 +275,12 @@ func (_c *MockmeilisearchSearchRulesManager_DeleteSearchRuleWithContext_Call) Ru
 	return _c
 }
 
-func (_c *MockmeilisearchSearchRulesManager_DeleteSearchRuleWithContext_Call) Return(err error) *MockmeilisearchSearchRulesManager_DeleteSearchRuleWithContext_Call {
-	_c.Call.Return(err)
+func (_c *MockmeilisearchSearchRulesManager_DeleteSearchRuleWithContext_Call) Return(taskInfo *meilisearch.TaskInfo, err error) *MockmeilisearchSearchRulesManager_DeleteSearchRuleWithContext_Call {
+	_c.Call.Return(taskInfo, err)
 	return _c
 }
 
-func (_c *MockmeilisearchSearchRulesManager_DeleteSearchRuleWithContext_Call) RunAndReturn(run func(ctx context.Context, uid string) error) *MockmeilisearchSearchRulesManager_DeleteSearchRuleWithContext_Call {
+func (_c *MockmeilisearchSearchRulesManager_DeleteSearchRuleWithContext_Call) RunAndReturn(run func(ctx context.Context, uid string) (*meilisearch.TaskInfo, error)) *MockmeilisearchSearchRulesManager_DeleteSearchRuleWithContext_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -407,23 +546,23 @@ func (_c *MockmeilisearchSearchRulesManager_ListSearchRulesWithContext_Call) Run
 }
 
 // UpdateSearchRule provides a mock function for the type MockmeilisearchSearchRulesManager
-func (_mock *MockmeilisearchSearchRulesManager) UpdateSearchRule(uid string, params *meilisearch.SearchRulesRequest) (*meilisearch.SearchRule, error) {
+func (_mock *MockmeilisearchSearchRulesManager) UpdateSearchRule(uid string, params *meilisearch.SearchRulesRequest) (*meilisearch.TaskInfo, error) {
 	ret := _mock.Called(uid, params)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateSearchRule")
 	}
 
-	var r0 *meilisearch.SearchRule
+	var r0 *meilisearch.TaskInfo
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, *meilisearch.SearchRulesRequest) (*meilisearch.SearchRule, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(string, *meilisearch.SearchRulesRequest) (*meilisearch.TaskInfo, error)); ok {
 		return returnFunc(uid, params)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, *meilisearch.SearchRulesRequest) *meilisearch.SearchRule); ok {
+	if returnFunc, ok := ret.Get(0).(func(string, *meilisearch.SearchRulesRequest) *meilisearch.TaskInfo); ok {
 		r0 = returnFunc(uid, params)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*meilisearch.SearchRule)
+			r0 = ret.Get(0).(*meilisearch.TaskInfo)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(string, *meilisearch.SearchRulesRequest) error); ok {
@@ -464,34 +603,34 @@ func (_c *MockmeilisearchSearchRulesManager_UpdateSearchRule_Call) Run(run func(
 	return _c
 }
 
-func (_c *MockmeilisearchSearchRulesManager_UpdateSearchRule_Call) Return(searchRule *meilisearch.SearchRule, err error) *MockmeilisearchSearchRulesManager_UpdateSearchRule_Call {
-	_c.Call.Return(searchRule, err)
+func (_c *MockmeilisearchSearchRulesManager_UpdateSearchRule_Call) Return(taskInfo *meilisearch.TaskInfo, err error) *MockmeilisearchSearchRulesManager_UpdateSearchRule_Call {
+	_c.Call.Return(taskInfo, err)
 	return _c
 }
 
-func (_c *MockmeilisearchSearchRulesManager_UpdateSearchRule_Call) RunAndReturn(run func(uid string, params *meilisearch.SearchRulesRequest) (*meilisearch.SearchRule, error)) *MockmeilisearchSearchRulesManager_UpdateSearchRule_Call {
+func (_c *MockmeilisearchSearchRulesManager_UpdateSearchRule_Call) RunAndReturn(run func(uid string, params *meilisearch.SearchRulesRequest) (*meilisearch.TaskInfo, error)) *MockmeilisearchSearchRulesManager_UpdateSearchRule_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // UpdateSearchRuleWithContext provides a mock function for the type MockmeilisearchSearchRulesManager
-func (_mock *MockmeilisearchSearchRulesManager) UpdateSearchRuleWithContext(ctx context.Context, uid string, params *meilisearch.SearchRulesRequest) (*meilisearch.SearchRule, error) {
+func (_mock *MockmeilisearchSearchRulesManager) UpdateSearchRuleWithContext(ctx context.Context, uid string, params *meilisearch.SearchRulesRequest) (*meilisearch.TaskInfo, error) {
 	ret := _mock.Called(ctx, uid, params)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateSearchRuleWithContext")
 	}
 
-	var r0 *meilisearch.SearchRule
+	var r0 *meilisearch.TaskInfo
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *meilisearch.SearchRulesRequest) (*meilisearch.SearchRule, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *meilisearch.SearchRulesRequest) (*meilisearch.TaskInfo, error)); ok {
 		return returnFunc(ctx, uid, params)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *meilisearch.SearchRulesRequest) *meilisearch.SearchRule); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *meilisearch.SearchRulesRequest) *meilisearch.TaskInfo); ok {
 		r0 = returnFunc(ctx, uid, params)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*meilisearch.SearchRule)
+			r0 = ret.Get(0).(*meilisearch.TaskInfo)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(context.Context, string, *meilisearch.SearchRulesRequest) error); ok {
@@ -538,12 +677,12 @@ func (_c *MockmeilisearchSearchRulesManager_UpdateSearchRuleWithContext_Call) Ru
 	return _c
 }
 
-func (_c *MockmeilisearchSearchRulesManager_UpdateSearchRuleWithContext_Call) Return(searchRule *meilisearch.SearchRule, err error) *MockmeilisearchSearchRulesManager_UpdateSearchRuleWithContext_Call {
-	_c.Call.Return(searchRule, err)
+func (_c *MockmeilisearchSearchRulesManager_UpdateSearchRuleWithContext_Call) Return(taskInfo *meilisearch.TaskInfo, err error) *MockmeilisearchSearchRulesManager_UpdateSearchRuleWithContext_Call {
+	_c.Call.Return(taskInfo, err)
 	return _c
 }
 
-func (_c *MockmeilisearchSearchRulesManager_UpdateSearchRuleWithContext_Call) RunAndReturn(run func(ctx context.Context, uid string, params *meilisearch.SearchRulesRequest) (*meilisearch.SearchRule, error)) *MockmeilisearchSearchRulesManager_UpdateSearchRuleWithContext_Call {
+func (_c *MockmeilisearchSearchRulesManager_UpdateSearchRuleWithContext_Call) RunAndReturn(run func(ctx context.Context, uid string, params *meilisearch.SearchRulesRequest) (*meilisearch.TaskInfo, error)) *MockmeilisearchSearchRulesManager_UpdateSearchRuleWithContext_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/mocks/meilisearch_service_manager_mock.go
+++ b/mocks/meilisearch_service_manager_mock.go
@@ -1060,6 +1060,123 @@ func (_c *MockmeilisearchServiceManager_CreateSnapshotWithContext_Call) RunAndRe
 	return _c
 }
 
+// DeleteAllSearchRules provides a mock function for the type MockmeilisearchServiceManager
+func (_mock *MockmeilisearchServiceManager) DeleteAllSearchRules() (*meilisearch.TaskInfo, error) {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteAllSearchRules")
+	}
+
+	var r0 *meilisearch.TaskInfo
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func() (*meilisearch.TaskInfo, error)); ok {
+		return returnFunc()
+	}
+	if returnFunc, ok := ret.Get(0).(func() *meilisearch.TaskInfo); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*meilisearch.TaskInfo)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func() error); ok {
+		r1 = returnFunc()
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockmeilisearchServiceManager_DeleteAllSearchRules_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteAllSearchRules'
+type MockmeilisearchServiceManager_DeleteAllSearchRules_Call struct {
+	*mock.Call
+}
+
+// DeleteAllSearchRules is a helper method to define mock.On call
+func (_e *MockmeilisearchServiceManager_Expecter) DeleteAllSearchRules() *MockmeilisearchServiceManager_DeleteAllSearchRules_Call {
+	return &MockmeilisearchServiceManager_DeleteAllSearchRules_Call{Call: _e.mock.On("DeleteAllSearchRules")}
+}
+
+func (_c *MockmeilisearchServiceManager_DeleteAllSearchRules_Call) Run(run func()) *MockmeilisearchServiceManager_DeleteAllSearchRules_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockmeilisearchServiceManager_DeleteAllSearchRules_Call) Return(taskInfo *meilisearch.TaskInfo, err error) *MockmeilisearchServiceManager_DeleteAllSearchRules_Call {
+	_c.Call.Return(taskInfo, err)
+	return _c
+}
+
+func (_c *MockmeilisearchServiceManager_DeleteAllSearchRules_Call) RunAndReturn(run func() (*meilisearch.TaskInfo, error)) *MockmeilisearchServiceManager_DeleteAllSearchRules_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// DeleteAllSearchRulesWithContext provides a mock function for the type MockmeilisearchServiceManager
+func (_mock *MockmeilisearchServiceManager) DeleteAllSearchRulesWithContext(ctx context.Context) (*meilisearch.TaskInfo, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteAllSearchRulesWithContext")
+	}
+
+	var r0 *meilisearch.TaskInfo
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (*meilisearch.TaskInfo, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) *meilisearch.TaskInfo); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*meilisearch.TaskInfo)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockmeilisearchServiceManager_DeleteAllSearchRulesWithContext_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteAllSearchRulesWithContext'
+type MockmeilisearchServiceManager_DeleteAllSearchRulesWithContext_Call struct {
+	*mock.Call
+}
+
+// DeleteAllSearchRulesWithContext is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *MockmeilisearchServiceManager_Expecter) DeleteAllSearchRulesWithContext(ctx interface{}) *MockmeilisearchServiceManager_DeleteAllSearchRulesWithContext_Call {
+	return &MockmeilisearchServiceManager_DeleteAllSearchRulesWithContext_Call{Call: _e.mock.On("DeleteAllSearchRulesWithContext", ctx)}
+}
+
+func (_c *MockmeilisearchServiceManager_DeleteAllSearchRulesWithContext_Call) Run(run func(ctx context.Context)) *MockmeilisearchServiceManager_DeleteAllSearchRulesWithContext_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockmeilisearchServiceManager_DeleteAllSearchRulesWithContext_Call) Return(taskInfo *meilisearch.TaskInfo, err error) *MockmeilisearchServiceManager_DeleteAllSearchRulesWithContext_Call {
+	_c.Call.Return(taskInfo, err)
+	return _c
+}
+
+func (_c *MockmeilisearchServiceManager_DeleteAllSearchRulesWithContext_Call) RunAndReturn(run func(ctx context.Context) (*meilisearch.TaskInfo, error)) *MockmeilisearchServiceManager_DeleteAllSearchRulesWithContext_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // DeleteIndex provides a mock function for the type MockmeilisearchServiceManager
 func (_mock *MockmeilisearchServiceManager) DeleteIndex(uid string) (*meilisearch.TaskInfo, error) {
 	ret := _mock.Called(uid)
@@ -1317,20 +1434,31 @@ func (_c *MockmeilisearchServiceManager_DeleteKeyWithContext_Call) RunAndReturn(
 }
 
 // DeleteSearchRule provides a mock function for the type MockmeilisearchServiceManager
-func (_mock *MockmeilisearchServiceManager) DeleteSearchRule(uid string) error {
+func (_mock *MockmeilisearchServiceManager) DeleteSearchRule(uid string) (*meilisearch.TaskInfo, error) {
 	ret := _mock.Called(uid)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteSearchRule")
 	}
 
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
+	var r0 *meilisearch.TaskInfo
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string) (*meilisearch.TaskInfo, error)); ok {
+		return returnFunc(uid)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string) *meilisearch.TaskInfo); ok {
 		r0 = returnFunc(uid)
 	} else {
-		r0 = ret.Error(0)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*meilisearch.TaskInfo)
+		}
 	}
-	return r0
+	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
+		r1 = returnFunc(uid)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
 }
 
 // MockmeilisearchServiceManager_DeleteSearchRule_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteSearchRule'
@@ -1357,31 +1485,42 @@ func (_c *MockmeilisearchServiceManager_DeleteSearchRule_Call) Run(run func(uid 
 	return _c
 }
 
-func (_c *MockmeilisearchServiceManager_DeleteSearchRule_Call) Return(err error) *MockmeilisearchServiceManager_DeleteSearchRule_Call {
-	_c.Call.Return(err)
+func (_c *MockmeilisearchServiceManager_DeleteSearchRule_Call) Return(taskInfo *meilisearch.TaskInfo, err error) *MockmeilisearchServiceManager_DeleteSearchRule_Call {
+	_c.Call.Return(taskInfo, err)
 	return _c
 }
 
-func (_c *MockmeilisearchServiceManager_DeleteSearchRule_Call) RunAndReturn(run func(uid string) error) *MockmeilisearchServiceManager_DeleteSearchRule_Call {
+func (_c *MockmeilisearchServiceManager_DeleteSearchRule_Call) RunAndReturn(run func(uid string) (*meilisearch.TaskInfo, error)) *MockmeilisearchServiceManager_DeleteSearchRule_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // DeleteSearchRuleWithContext provides a mock function for the type MockmeilisearchServiceManager
-func (_mock *MockmeilisearchServiceManager) DeleteSearchRuleWithContext(ctx context.Context, uid string) error {
+func (_mock *MockmeilisearchServiceManager) DeleteSearchRuleWithContext(ctx context.Context, uid string) (*meilisearch.TaskInfo, error) {
 	ret := _mock.Called(ctx, uid)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteSearchRuleWithContext")
 	}
 
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) error); ok {
+	var r0 *meilisearch.TaskInfo
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*meilisearch.TaskInfo, error)); ok {
+		return returnFunc(ctx, uid)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *meilisearch.TaskInfo); ok {
 		r0 = returnFunc(ctx, uid)
 	} else {
-		r0 = ret.Error(0)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*meilisearch.TaskInfo)
+		}
 	}
-	return r0
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, uid)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
 }
 
 // MockmeilisearchServiceManager_DeleteSearchRuleWithContext_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteSearchRuleWithContext'
@@ -1414,12 +1553,12 @@ func (_c *MockmeilisearchServiceManager_DeleteSearchRuleWithContext_Call) Run(ru
 	return _c
 }
 
-func (_c *MockmeilisearchServiceManager_DeleteSearchRuleWithContext_Call) Return(err error) *MockmeilisearchServiceManager_DeleteSearchRuleWithContext_Call {
-	_c.Call.Return(err)
+func (_c *MockmeilisearchServiceManager_DeleteSearchRuleWithContext_Call) Return(taskInfo *meilisearch.TaskInfo, err error) *MockmeilisearchServiceManager_DeleteSearchRuleWithContext_Call {
+	_c.Call.Return(taskInfo, err)
 	return _c
 }
 
-func (_c *MockmeilisearchServiceManager_DeleteSearchRuleWithContext_Call) RunAndReturn(run func(ctx context.Context, uid string) error) *MockmeilisearchServiceManager_DeleteSearchRuleWithContext_Call {
+func (_c *MockmeilisearchServiceManager_DeleteSearchRuleWithContext_Call) RunAndReturn(run func(ctx context.Context, uid string) (*meilisearch.TaskInfo, error)) *MockmeilisearchServiceManager_DeleteSearchRuleWithContext_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -5802,23 +5941,23 @@ func (_c *MockmeilisearchServiceManager_UpdateNetworkWithContext_Call) RunAndRet
 }
 
 // UpdateSearchRule provides a mock function for the type MockmeilisearchServiceManager
-func (_mock *MockmeilisearchServiceManager) UpdateSearchRule(uid string, params *meilisearch.SearchRulesRequest) (*meilisearch.SearchRule, error) {
+func (_mock *MockmeilisearchServiceManager) UpdateSearchRule(uid string, params *meilisearch.SearchRulesRequest) (*meilisearch.TaskInfo, error) {
 	ret := _mock.Called(uid, params)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateSearchRule")
 	}
 
-	var r0 *meilisearch.SearchRule
+	var r0 *meilisearch.TaskInfo
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, *meilisearch.SearchRulesRequest) (*meilisearch.SearchRule, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(string, *meilisearch.SearchRulesRequest) (*meilisearch.TaskInfo, error)); ok {
 		return returnFunc(uid, params)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, *meilisearch.SearchRulesRequest) *meilisearch.SearchRule); ok {
+	if returnFunc, ok := ret.Get(0).(func(string, *meilisearch.SearchRulesRequest) *meilisearch.TaskInfo); ok {
 		r0 = returnFunc(uid, params)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*meilisearch.SearchRule)
+			r0 = ret.Get(0).(*meilisearch.TaskInfo)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(string, *meilisearch.SearchRulesRequest) error); ok {
@@ -5859,34 +5998,34 @@ func (_c *MockmeilisearchServiceManager_UpdateSearchRule_Call) Run(run func(uid 
 	return _c
 }
 
-func (_c *MockmeilisearchServiceManager_UpdateSearchRule_Call) Return(searchRule *meilisearch.SearchRule, err error) *MockmeilisearchServiceManager_UpdateSearchRule_Call {
-	_c.Call.Return(searchRule, err)
+func (_c *MockmeilisearchServiceManager_UpdateSearchRule_Call) Return(taskInfo *meilisearch.TaskInfo, err error) *MockmeilisearchServiceManager_UpdateSearchRule_Call {
+	_c.Call.Return(taskInfo, err)
 	return _c
 }
 
-func (_c *MockmeilisearchServiceManager_UpdateSearchRule_Call) RunAndReturn(run func(uid string, params *meilisearch.SearchRulesRequest) (*meilisearch.SearchRule, error)) *MockmeilisearchServiceManager_UpdateSearchRule_Call {
+func (_c *MockmeilisearchServiceManager_UpdateSearchRule_Call) RunAndReturn(run func(uid string, params *meilisearch.SearchRulesRequest) (*meilisearch.TaskInfo, error)) *MockmeilisearchServiceManager_UpdateSearchRule_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // UpdateSearchRuleWithContext provides a mock function for the type MockmeilisearchServiceManager
-func (_mock *MockmeilisearchServiceManager) UpdateSearchRuleWithContext(ctx context.Context, uid string, params *meilisearch.SearchRulesRequest) (*meilisearch.SearchRule, error) {
+func (_mock *MockmeilisearchServiceManager) UpdateSearchRuleWithContext(ctx context.Context, uid string, params *meilisearch.SearchRulesRequest) (*meilisearch.TaskInfo, error) {
 	ret := _mock.Called(ctx, uid, params)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateSearchRuleWithContext")
 	}
 
-	var r0 *meilisearch.SearchRule
+	var r0 *meilisearch.TaskInfo
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *meilisearch.SearchRulesRequest) (*meilisearch.SearchRule, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *meilisearch.SearchRulesRequest) (*meilisearch.TaskInfo, error)); ok {
 		return returnFunc(ctx, uid, params)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *meilisearch.SearchRulesRequest) *meilisearch.SearchRule); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *meilisearch.SearchRulesRequest) *meilisearch.TaskInfo); ok {
 		r0 = returnFunc(ctx, uid, params)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*meilisearch.SearchRule)
+			r0 = ret.Get(0).(*meilisearch.TaskInfo)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(context.Context, string, *meilisearch.SearchRulesRequest) error); ok {
@@ -5933,12 +6072,12 @@ func (_c *MockmeilisearchServiceManager_UpdateSearchRuleWithContext_Call) Run(ru
 	return _c
 }
 
-func (_c *MockmeilisearchServiceManager_UpdateSearchRuleWithContext_Call) Return(searchRule *meilisearch.SearchRule, err error) *MockmeilisearchServiceManager_UpdateSearchRuleWithContext_Call {
-	_c.Call.Return(searchRule, err)
+func (_c *MockmeilisearchServiceManager_UpdateSearchRuleWithContext_Call) Return(taskInfo *meilisearch.TaskInfo, err error) *MockmeilisearchServiceManager_UpdateSearchRuleWithContext_Call {
+	_c.Call.Return(taskInfo, err)
 	return _c
 }
 
-func (_c *MockmeilisearchServiceManager_UpdateSearchRuleWithContext_Call) RunAndReturn(run func(ctx context.Context, uid string, params *meilisearch.SearchRulesRequest) (*meilisearch.SearchRule, error)) *MockmeilisearchServiceManager_UpdateSearchRuleWithContext_Call {
+func (_c *MockmeilisearchServiceManager_UpdateSearchRuleWithContext_Call) RunAndReturn(run func(ctx context.Context, uid string, params *meilisearch.SearchRulesRequest) (*meilisearch.TaskInfo, error)) *MockmeilisearchServiceManager_UpdateSearchRuleWithContext_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/models_search.go
+++ b/models_search.go
@@ -6,11 +6,11 @@ import (
 )
 
 type SearchRulesRequest struct {
-	Description string      `json:"description,omitempty"`
-	Priority    *int        `json:"priority,omitempty"`
-	Active      *bool       `json:"active,omitempty"`
-	Conditions  []Condition `json:"conditions,omitempty"`
-	Actions     []Action    `json:"actions,omitempty"`
+	Description string                `json:"description,omitempty"`
+	Precedence  *int                  `json:"precedence,omitempty"`
+	Active      *bool                 `json:"active,omitempty"`
+	Conditions  *SearchRuleConditions `json:"conditions,omitempty"`
+	Actions     []Action              `json:"actions,omitempty"`
 }
 
 type SearchRulesResults struct {
@@ -21,30 +21,38 @@ type SearchRulesResults struct {
 }
 
 type SearchRulesParams struct {
-	Offset int64              `json:"offset"`
-	Limit  int64              `json:"limit"`
+	Offset int64              `json:"offset,omitempty"`
+	Limit  int64              `json:"limit,omitempty"`
 	Filter *SearchRulesFilter `json:"filter,omitempty"`
 }
 
 type SearchRulesFilter struct {
-	AttributePatterns []string `json:"attributePatterns,omitempty"`
-	Active            *bool    `json:"active,omitempty"`
+	Query  string `json:"query,omitempty"`
+	Active *bool  `json:"active,omitempty"`
 }
 
 type SearchRule struct {
-	Uid         string      `json:"uid"`
-	Description string      `json:"description"`
-	Priority    int         `json:"priority"`
-	Active      bool        `json:"active"`
-	Conditions  []Condition `json:"conditions"`
-	Actions     []Action    `json:"actions"`
+	Uid         string               `json:"uid"`
+	Description string               `json:"description"`
+	Precedence  int                  `json:"precedence"`
+	Active      bool                 `json:"active"`
+	Conditions  SearchRuleConditions `json:"conditions"`
+	Actions     []Action             `json:"actions"`
 }
 
-type Condition struct {
-	Scope   string     `json:"scope"`
-	IsEmpty *bool      `json:"isEmpty,omitempty"`
-	Start   *time.Time `json:"start,omitempty"`
-	End     *time.Time `json:"end,omitempty"`
+type SearchRuleConditions struct {
+	Query *QueryCondition `json:"query,omitempty"`
+	Time  *TimeCondition  `json:"time,omitempty"`
+}
+
+type QueryCondition struct {
+	IsEmpty *bool   `json:"isEmpty,omitempty"`
+	Words   *string `json:"words,omitempty"`
+}
+
+type TimeCondition struct {
+	Start *time.Time `json:"start,omitempty"`
+	End   *time.Time `json:"end,omitempty"`
 }
 
 type Action struct {
@@ -53,8 +61,8 @@ type Action struct {
 }
 
 type Selector struct {
-	IndexUid string `json:"indexUid"`
-	ID       string `json:"id,omitempty"`
+	IndexUid string `json:"indexUid,omitempty"`
+	ID       string `json:"id"`
 }
 
 type ActionDef struct {

--- a/search_rules.go
+++ b/search_rules.go
@@ -6,12 +6,12 @@ import (
 	"net/http"
 )
 
-func (m *meilisearch) UpdateSearchRule(uid string, params *SearchRulesRequest) (*SearchRule, error) {
+func (m *meilisearch) UpdateSearchRule(uid string, params *SearchRulesRequest) (*TaskInfo, error) {
 	return m.UpdateSearchRuleWithContext(context.Background(), uid, params)
 }
 
-func (m *meilisearch) UpdateSearchRuleWithContext(ctx context.Context, uid string, params *SearchRulesRequest) (*SearchRule, error) {
-	resp := new(SearchRule)
+func (m *meilisearch) UpdateSearchRuleWithContext(ctx context.Context, uid string, params *SearchRulesRequest) (*TaskInfo, error) {
+	resp := new(TaskInfo)
 
 	req := &internalRequest{
 		endpoint:            fmt.Sprintf("/dynamic-search-rules/%s", uid),
@@ -19,7 +19,7 @@ func (m *meilisearch) UpdateSearchRuleWithContext(ctx context.Context, uid strin
 		contentType:         contentTypeJSON,
 		withRequest:         params,
 		withResponse:        resp,
-		acceptedStatusCodes: []int{http.StatusCreated, http.StatusOK},
+		acceptedStatusCodes: []int{http.StatusAccepted},
 		functionName:        "UpdateSearchRule",
 	}
 
@@ -77,18 +77,42 @@ func (m *meilisearch) GetSearchRuleWithContext(ctx context.Context, uid string) 
 	return resp, nil
 }
 
-func (m *meilisearch) DeleteSearchRule(uid string) error {
+func (m *meilisearch) DeleteSearchRule(uid string) (*TaskInfo, error) {
 	return m.DeleteSearchRuleWithContext(context.Background(), uid)
 }
 
-func (m *meilisearch) DeleteSearchRuleWithContext(ctx context.Context, uid string) error {
+func (m *meilisearch) DeleteSearchRuleWithContext(ctx context.Context, uid string) (*TaskInfo, error) {
+	resp := new(TaskInfo)
 	req := &internalRequest{
 		endpoint:            fmt.Sprintf("/dynamic-search-rules/%s", uid),
 		method:              http.MethodDelete,
 		withRequest:         nil,
-		withResponse:        nil,
-		acceptedStatusCodes: []int{http.StatusNoContent},
+		withResponse:        resp,
+		acceptedStatusCodes: []int{http.StatusAccepted},
 		functionName:        "DeleteSearchRule",
 	}
-	return m.client.executeRequest(ctx, req)
+	if err := m.client.executeRequest(ctx, req); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (m *meilisearch) DeleteAllSearchRules() (*TaskInfo, error) {
+	return m.DeleteAllSearchRulesWithContext(context.Background())
+}
+
+func (m *meilisearch) DeleteAllSearchRulesWithContext(ctx context.Context) (*TaskInfo, error) {
+	resp := new(TaskInfo)
+	req := &internalRequest{
+		endpoint:            "/dynamic-search-rules",
+		method:              http.MethodDelete,
+		withRequest:         nil,
+		withResponse:        resp,
+		acceptedStatusCodes: []int{http.StatusAccepted},
+		functionName:        "DeleteAllSearchRules",
+	}
+	if err := m.client.executeRequest(ctx, req); err != nil {
+		return nil, err
+	}
+	return resp, nil
 }

--- a/search_rules_interface.go
+++ b/search_rules_interface.go
@@ -6,23 +6,33 @@ type SearchRulesManager interface {
 	SearchRulesReader
 	// UpdateSearchRule update a dynamic search rule or create a new one if it doesn't exist.
 	//
-	// docs: https://www.meilisearch.com/docs/reference/api/dynamic-search-rules/update-a-dynamic-search-rule-or-create-a-new-one-if-it-doesnt-exist#body-priority-one-of-0
-	UpdateSearchRule(uid string, params *SearchRulesRequest) (*SearchRule, error)
+	// docs: https://www.meilisearch.com/docs/reference/api/dynamic-search-rules/update-a-dynamic-search-rule-or-create-a-new-one-if-it-doesnt-exist
+	UpdateSearchRule(uid string, params *SearchRulesRequest) (*TaskInfo, error)
 
 	// UpdateSearchRuleWithContext update a dynamic search rule or create a new one if it doesn't exist with a context.
 	//
-	// docs: https://www.meilisearch.com/docs/reference/api/dynamic-search-rules/update-a-dynamic-search-rule-or-create-a-new-one-if-it-doesnt-exist#body-priority-one-of-0
-	UpdateSearchRuleWithContext(ctx context.Context, uid string, params *SearchRulesRequest) (*SearchRule, error)
+	// docs: https://www.meilisearch.com/docs/reference/api/dynamic-search-rules/update-a-dynamic-search-rule-or-create-a-new-one-if-it-doesnt-exist
+	UpdateSearchRuleWithContext(ctx context.Context, uid string, params *SearchRulesRequest) (*TaskInfo, error)
 
 	// DeleteSearchRule deletes a dynamic search rule by its unique identifier.
 	//
 	// docs: https://www.meilisearch.com/docs/reference/api/dynamic-search-rules/delete-a-dynamic-search-rule
-	DeleteSearchRule(uid string) error
+	DeleteSearchRule(uid string) (*TaskInfo, error)
 
 	// DeleteSearchRuleWithContext deletes a dynamic search rule by its unique identifier with a context.
 	//
 	// docs: https://www.meilisearch.com/docs/reference/api/dynamic-search-rules/delete-a-dynamic-search-rule
-	DeleteSearchRuleWithContext(ctx context.Context, uid string) error
+	DeleteSearchRuleWithContext(ctx context.Context, uid string) (*TaskInfo, error)
+
+	// DeleteAllSearchRules deletes all dynamic search rules.
+	//
+	// docs: https://www.meilisearch.com/docs/reference/api/dynamic-search-rules/delete-all-dynamic-search-rules
+	DeleteAllSearchRules() (*TaskInfo, error)
+
+	// DeleteAllSearchRulesWithContext deletes all dynamic search rules with a context.
+	//
+	// docs: https://www.meilisearch.com/docs/reference/api/dynamic-search-rules/delete-all-dynamic-search-rules
+	DeleteAllSearchRulesWithContext(ctx context.Context) (*TaskInfo, error)
 }
 
 type SearchRulesReader interface {


### PR DESCRIPTION
## Summary

- replace the v1.49 Dynamic Search Rules models with the v1.50 `precedence`, structured conditions, selector, and list-filter contract
- return asynchronous tasks from update and delete operations, and add bulk deletion
- regenerate the affected mocks and update integration coverage and documentation samples
- omit zero-valued list pagination fields so Meilisearch applies its documented defaults

## Schema note

`QueryCondition.Words` is a string in this implementation. Although #802 describes a string array, the tagged v1.50 Rust type, the v1.50 release behavior, and [the pending documentation update](https://github.com/meilisearch/documentation/pull/3633) use a string. A live v1.50.0 request rejects an array and accepts `"super hero"`.

## Testing

- `go test $(go list ./... | rg -v "/integration$")`
- `MEILISEARCH_URL=http://127.0.0.1:<port> go test -race -gcflags=-l ./integration -run "SearchRule" -count=1` against `getmeili/meilisearch-enterprise:v1.50.0`
- `go vet ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.3.0 run`
- `uvx --from yamllint yamllint -c .yamllint.yml .code-samples.meilisearch.yaml`

The full v1.50 integration suite also reached unrelated failures in `TestIndex_SearchFacets` (the server now rejects a wildcard facet when only `tag` is filterable) and `Test_GetTasksUsingClient` (an empty date-filter result is indexed). The Dynamic Search Rules suite passes with race detection.

## AI assistance

OpenAI Codex assisted with the model and method changes, test updates, mock regeneration, and live-server validation. The commit includes a co-author trailer and the AI-assisted scope is limited to this PR.

Fixes #802